### PR TITLE
feat: add component Blockquote, update tokens (#3)

### DIFF
--- a/packages/core/src/tokens.css
+++ b/packages/core/src/tokens.css
@@ -157,6 +157,10 @@
   --gnome-radius-xl: 15px;    /* windows */
   --gnome-radius-pill: 9999px; /* pill buttons, circular buttons */
 
+  /* ─── Component tokens ──────────────────────────────────────── */
+
+  --gnome-blockquote-border-width: 3px;
+
   /* ─── Shadows ────────────────────────────────────────────────── */
 
   --gnome-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.12);

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -68,6 +68,7 @@ export default function App() {
 | [`Icon`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-icon--docs) | React adapter for `@gnome-ui/icons` — inline SVG, inherits `currentColor` |
 | [`Avatar`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-avatar--docs) | Circular user image with deterministic-color initials fallback |
 | [`Badge`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-badge--docs) | Counter or status dot, optionally anchored over another element |
+| [`Blockquote`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-blockquote--docs) | Styled pull-quote with left-border accent; default, info, warning, error, success variants; optional icon and attribution |
 | [`Spinner`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-spinner--docs) | Indeterminate loading indicator; sm/md/lg sizes |
 | [`ProgressBar`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-progressbar--docs) | Determinate (0–1) and indeterminate progress indicator |
 | [`StatusPage`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-statuspage--docs) | Empty-state page with icon, title, description, and optional actions; `compact` prop for sidebars/popovers |
@@ -75,6 +76,7 @@ export default function App() {
 | [`Chip`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-chip--docs) | Compact pill-shaped label for tags, filters, and multi-select; static, removable, and selectable modes |
 | [`ShortcutLabel`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-shortcutlabel--docs) | Renders keyboard shortcut tokens (e.g. `Ctrl+S`) as individual key cap pills |
 | [`WindowTitle`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-windowtitle--docs) | Two-line title + subtitle widget for use inside a `HeaderBar` |
+| [`Timeline`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-timeline--docs) | Ordered sequence of events connected by a visual connector line; vertical (activity feed) and horizontal (stepper) orientations; solid, dotted, and none variants |
 
 ### Layout & containers
 

--- a/packages/react/src/components/Blockquote/Blockquote.module.css
+++ b/packages/react/src/components/Blockquote/Blockquote.module.css
@@ -1,0 +1,86 @@
+/* ─── Base ────────────────────────────────────────────────────────────────── */
+
+.blockquote {
+  margin: 0;
+  padding: var(--gnome-space-2, 12px) var(--gnome-space-3, 18px);
+  border-left: var(--gnome-blockquote-border-width, 3px) solid;
+  border-radius: 0 var(--gnome-radius-sm, 4px) var(--gnome-radius-sm, 4px) 0;
+  font-family: var(--gnome-font-family);
+  font-size: var(--gnome-font-size-body, 1rem);
+  line-height: var(--gnome-line-height-body, 1.5);
+}
+
+/* ─── Body (icon + text) ──────────────────────────────────────────────────── */
+
+.body {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--gnome-space-2, 12px);
+}
+
+.icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-top: 2px; /* optical alignment with first text baseline */
+}
+
+.content {
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+}
+
+/* ─── Attribution ─────────────────────────────────────────────────────────── */
+
+.footer {
+  margin-top: var(--gnome-space-1, 6px);
+  font-size: var(--gnome-font-size-caption, 0.75rem);
+  opacity: var(--gnome-opacity-dim, 0.55);
+}
+
+.cite {
+  font-style: normal;
+}
+
+/* ─── Variants ────────────────────────────────────────────────────────────── */
+
+.default {
+  border-color: var(--gnome-border-subtle, rgba(0, 0, 0, 0.15));
+}
+
+.info {
+  border-color: var(--gnome-accent-bg-color, #3584e4);
+  background-color: color-mix(
+    in srgb,
+    var(--gnome-accent-bg-color, #3584e4) 8%,
+    transparent
+  );
+}
+
+.warning {
+  border-color: var(--gnome-warning-bg-color, #f6d32d);
+  background-color: color-mix(
+    in srgb,
+    var(--gnome-warning-bg-color, #f6d32d) 14%,
+    transparent
+  );
+}
+
+.error {
+  border-color: var(--gnome-error-bg-color, #e01b24);
+  background-color: color-mix(
+    in srgb,
+    var(--gnome-error-bg-color, #e01b24) 8%,
+    transparent
+  );
+}
+
+.success {
+  border-color: var(--gnome-success-bg-color, #2ec27e);
+  background-color: color-mix(
+    in srgb,
+    var(--gnome-success-bg-color, #2ec27e) 8%,
+    transparent
+  );
+}

--- a/packages/react/src/components/Blockquote/Blockquote.stories.tsx
+++ b/packages/react/src/components/Blockquote/Blockquote.stories.tsx
@@ -1,0 +1,175 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Blockquote } from "./Blockquote";
+
+const meta: Meta<typeof Blockquote> = {
+  title: "Components/Blockquote",
+  component: Blockquote,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+Styled pull-quote with semantic \`<blockquote>\` markup.
+
+Use it to highlight quoted text, callouts, or editorial notes inline within
+content. Five visual variants map to the same severity scale used by
+\`Banner\` and \`Badge\`.
+
+### Guidelines
+- Keep the quoted text short — one to three sentences.
+- Provide a \`cite\` whenever the source is known.
+- Use \`variant="default"\` for neutral quotations; reserve coloured variants
+  for callouts that match a clear intent (tip, caution, error, confirmation).
+- Supply an \`icon\` only when it meaningfully reinforces the variant intent.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "info", "warning", "error", "success"],
+    },
+    cite: { control: "text" },
+    children: { control: "text" },
+  },
+  args: {
+    variant: "default",
+    children:
+      "The best way to predict the future is to invent it.",
+    cite: "Alan Kay",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 560 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Blockquote>;
+
+// ─── Default ──────────────────────────────────────────────────────────────────
+
+export const Default: Story = {};
+
+// ─── All variants ─────────────────────────────────────────────────────────────
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12, maxWidth: 560 }}>
+      <Blockquote variant="default" cite="Alan Kay">
+        The best way to predict the future is to invent it.
+      </Blockquote>
+      <Blockquote variant="info" cite="GNOME HIG">
+        Prefer progressive disclosure: show only what the user needs right now.
+      </Blockquote>
+      <Blockquote variant="warning">
+        This behaviour changes in the next major release. Update your code before upgrading.
+      </Blockquote>
+      <Blockquote variant="error">
+        This API is deprecated and will be removed in v3. Use the new endpoint instead.
+      </Blockquote>
+      <Blockquote variant="success" cite="Release notes">
+        Migration complete. All data has been verified and is ready to use.
+      </Blockquote>
+    </div>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+// ─── With icon ────────────────────────────────────────────────────────────────
+
+export const WithIcon: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12, maxWidth: 560 }}>
+      <Blockquote
+        variant="info"
+        icon={
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 3a1 1 0 1 1 0 2 1 1 0 0 1 0-2Zm1 8H7V7h2v5Z" />
+          </svg>
+        }
+        cite="GNOME HIG"
+      >
+        Use icons only when they meaningfully reinforce the message, not for decoration.
+      </Blockquote>
+      <Blockquote
+        variant="warning"
+        icon={
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.888 0 1.438-.99.98-1.767L8.982 1.566ZM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5Zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z" />
+          </svg>
+        }
+      >
+        Saving while offline will queue changes locally. Sync when reconnected.
+      </Blockquote>
+    </div>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+// ─── No cite ──────────────────────────────────────────────────────────────────
+
+export const NoCite: Story = {
+  args: {
+    cite: undefined,
+    children: "Simplicity is the ultimate sophistication.",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Omit `cite` when the source is unknown or attribution is not needed.",
+      },
+    },
+  },
+};
+
+// ─── Long quote ───────────────────────────────────────────────────────────────
+
+export const LongQuote: Story = {
+  args: {
+    variant: "info",
+    cite: "Donald Knuth, The Art of Computer Programming",
+    children:
+      "Programs are meant to be read by humans and only incidentally for computers to execute. " +
+      "We should write programs that read well, with meaningful names and clean structure, " +
+      "as if they were prose addressed to another programmer.",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "The component wraps naturally; no fixed height or truncation is applied.",
+      },
+    },
+  },
+};
+
+// ─── ReactNode cite ───────────────────────────────────────────────────────────
+
+export const RichCite: Story = {
+  render: () => (
+    <Blockquote
+      variant="default"
+      cite={
+        <span>
+          Ada Lovelace,{" "}
+          <em>Notes on the Analytical Engine</em>, 1842
+        </span>
+      }
+    >
+      The Analytical Engine has no pretensions whatever to originate anything.
+      It can only do what we know how to order it to perform.
+    </Blockquote>
+  ),
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: "`cite` accepts any `ReactNode`, so you can include inline formatting like `<em>`.",
+      },
+    },
+  },
+};

--- a/packages/react/src/components/Blockquote/Blockquote.test.tsx
+++ b/packages/react/src/components/Blockquote/Blockquote.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Blockquote } from "./Blockquote";
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("Blockquote", () => {
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  describe("rendering", () => {
+    it("renders a <blockquote> element", () => {
+      const { container } = render(<Blockquote>Text</Blockquote>);
+      expect(container.querySelector("blockquote")).toBeInTheDocument();
+    });
+
+    it("renders the quoted content", () => {
+      render(<Blockquote>The quick brown fox</Blockquote>);
+      expect(screen.getByText("The quick brown fox")).toBeInTheDocument();
+    });
+
+    it("renders cite inside a <footer><cite> when provided", () => {
+      const { container } = render(
+        <Blockquote cite="Ada Lovelace">Some quote</Blockquote>,
+      );
+      const footer = container.querySelector("footer");
+      const cite = container.querySelector("cite");
+      expect(footer).toBeInTheDocument();
+      expect(cite).toBeInTheDocument();
+      expect(cite).toHaveTextContent("Ada Lovelace");
+    });
+
+    it("does not render a footer when cite is omitted", () => {
+      const { container } = render(<Blockquote>No cite</Blockquote>);
+      expect(container.querySelector("footer")).not.toBeInTheDocument();
+    });
+
+    it("renders icon when provided", () => {
+      render(
+        <Blockquote icon={<span data-testid="icon">★</span>}>Text</Blockquote>,
+      );
+      expect(screen.getByTestId("icon")).toBeInTheDocument();
+    });
+
+    it("does not render icon wrapper when icon is omitted", () => {
+      const { container } = render(<Blockquote>No icon</Blockquote>);
+      expect(container.querySelector("[aria-hidden='true']")).not.toBeInTheDocument();
+    });
+
+    it("renders children wrapped in a <p>", () => {
+      const { container } = render(<Blockquote>Paragraph</Blockquote>);
+      expect(container.querySelector("p")).toHaveTextContent("Paragraph");
+    });
+  });
+
+  // ── Variants ───────────────────────────────────────────────────────────────
+
+  describe("variants", () => {
+    it("applies default variant class by default", () => {
+      const { container } = render(<Blockquote>Text</Blockquote>);
+      expect(container.querySelector("blockquote")).toHaveClass(/default/);
+    });
+
+    it.each(["info", "warning", "error", "success"] as const)(
+      "applies %s variant class",
+      (variant) => {
+        const { container } = render(
+          <Blockquote variant={variant}>Text</Blockquote>,
+        );
+        expect(container.querySelector("blockquote")).toHaveClass(
+          new RegExp(variant),
+        );
+      },
+    );
+  });
+
+  // ── HTML attribute forwarding ───────────────────────────────────────────────
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the root element", () => {
+      const { container } = render(
+        <Blockquote className="my-quote">Text</Blockquote>,
+      );
+      expect(container.querySelector("blockquote")).toHaveClass("my-quote");
+    });
+
+    it("forwards inline style to the root element", () => {
+      const { container } = render(
+        <Blockquote style={{ maxWidth: "400px" }}>Text</Blockquote>,
+      );
+      expect(
+        (container.querySelector("blockquote") as HTMLElement).style.maxWidth,
+      ).toBe("400px");
+    });
+
+    it("forwards arbitrary HTML attributes to the root element", () => {
+      const { container } = render(
+        <Blockquote data-testid="bq" aria-label="Quote">Text</Blockquote>,
+      );
+      const bq = container.querySelector("blockquote") as HTMLElement;
+      expect(bq).toHaveAttribute("data-testid", "bq");
+      expect(bq).toHaveAttribute("aria-label", "Quote");
+    });
+  });
+});

--- a/packages/react/src/components/Blockquote/Blockquote.tsx
+++ b/packages/react/src/components/Blockquote/Blockquote.tsx
@@ -1,0 +1,80 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import styles from "./Blockquote.module.css";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type BlockquoteVariant = "default" | "info" | "warning" | "error" | "success";
+
+export interface BlockquoteProps extends HTMLAttributes<HTMLQuoteElement> {
+  /**
+   * Visual emphasis style.
+   * - `"default"` — neutral left border; use for general quotations.
+   * - `"info"`    — accent blue; use for tips and noteworthy passages.
+   * - `"warning"` — yellow; use for cautionary content.
+   * - `"error"`   — red; use for critical or deprecated content.
+   * - `"success"` — green; use for positive or approved content.
+   */
+  variant?: BlockquoteVariant;
+  /**
+   * Optional icon displayed to the left of the quoted text.
+   * Typically a 16 px `<Icon>` component.
+   */
+  icon?: ReactNode;
+  /**
+   * Attribution rendered below the quote — author name, source title, etc.
+   * Rendered inside a `<footer><cite>` for semantic correctness.
+   */
+  cite?: ReactNode;
+  /** The quoted content. */
+  children: ReactNode;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Styled pull-quote with semantic `<blockquote>` markup.
+ *
+ * Supports five visual variants and optional icon + attribution.
+ *
+ * ```tsx
+ * <Blockquote variant="info" cite="Ada Lovelace, 1842">
+ *   The Analytical Engine has no pretensions to originate anything.
+ * </Blockquote>
+ *
+ * <Blockquote variant="warning" icon={<Icon icon={Warning} size={16} />}>
+ *   This API is deprecated and will be removed in v3.
+ * </Blockquote>
+ * ```
+ */
+export function Blockquote({
+  variant = "default",
+  icon,
+  cite,
+  children,
+  className,
+  ...props
+}: BlockquoteProps) {
+  return (
+    <blockquote
+      className={[styles.blockquote, styles[variant], className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
+      <div className={styles.body}>
+        {icon && (
+          <span className={styles.icon} aria-hidden="true">
+            {icon}
+          </span>
+        )}
+        <p className={styles.content}>{children}</p>
+      </div>
+
+      {cite !== undefined && (
+        <footer className={styles.footer}>
+          <cite className={styles.cite}>{cite}</cite>
+        </footer>
+      )}
+    </blockquote>
+  );
+}

--- a/packages/react/src/components/Blockquote/index.ts
+++ b/packages/react/src/components/Blockquote/index.ts
@@ -1,0 +1,2 @@
+export { Blockquote } from "./Blockquote";
+export type { BlockquoteProps, BlockquoteVariant } from "./Blockquote";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,6 +3,9 @@
 import "@gnome-ui/core/styles";
 
 // Components
+export { Blockquote } from "./components/Blockquote";
+export type { BlockquoteProps, BlockquoteVariant } from "./components/Blockquote";
+
 export { Button } from "./components/Button";
 export type { ButtonProps, ButtonVariant, ButtonSize, ButtonShape } from "./components/Button";
 


### PR DESCRIPTION
## What
Blockquote component.

<img width="611" height="450" alt="image" src="https://github.com/user-attachments/assets/da9e56c2-f65a-4946-b6d8-d591b5667a72" />


## Why
I need to enable text quotes in the views.

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
