### PR TITLE
feat: add component PathBar #16 #17 Layout/FileManager story

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,7 @@ Legend: ✅ Done · 🚧 In progress · ⬜ Pending
 | ✅ | **View Switcher** | Segmented control for switching between views |
 | ✅ | **Sidebar** | Lateral navigation panel |
 | ✅ | **Search Bar** | Collapsible search bar |
+| ✅ | **PathBar** | Breadcrumb path bar for hierarchical navigation; ancestor segments are interactive buttons, current segment is bold non-interactive label; optional per-segment icons — issue [#17](https://github.com/ElJijuna/gnome-ui/issues/17) |
 
 ---
 
@@ -192,6 +193,8 @@ Legend: ✅ Done · 🚧 In progress · ⬜ Pending
 | Status | Story | Description |
 |--------|-------|-------------|
 | ✅ | **`Layout/Dashboard`** | Full-page app layout: `Toolbar` with logo + inline `SearchBar` + action buttons + avatar `Popover`, collapsible sidebar with `SidebarItem` + `Badge`, content area with `Card`, `BoxedList`, `ExpanderRow`, `InlineViewSwitcher`, `StatusPage`, and footer `Toolbar` |
+| ✅ | **`Layout/FileManager`** | GNOME Files (Nautilus)–style file browser: `PathBar` breadcrumb navigation in toolbar, collapsible `Sidebar` with Places + Network sections, `InlineViewSwitcher` for grid/list toggle, folder drill-down, and mobile overlay sidebar — issue [#16](https://github.com/ElJijuna/gnome-ui/issues/16) |
+| ✅ | **`Layout/Settings`** | GNOME Settings–style preferences app: dual-headerbar pattern, 14-category sidebar with per-category icons, sub-page drill-down (Accessibility → Seeing), `SwitchRow` toggle rows, `ActionRow` for value navigation, `PreferencesGroup` sections |
 
 ---
 
@@ -268,6 +271,23 @@ Legend: ✅ Done · 🚧 In progress · ⬜ Pending
 | ✅ | **`WindowTitle`** | Two-line title + subtitle widget centred in a `HeaderBar` — mirrors `AdwWindowTitle` |
 | ✅ | **`ShortcutLabel`** | Read-only display of a keyboard shortcut (e.g. `Ctrl+S`) with proper key-cap styling — mirrors `GtkShortcutLabel` |
 | ✅ | **`ButtonContent`** | Icon + label layout helper for buttons with both an icon and text — mirrors `AdwButtonContent` |
+
+---
+
+## `@gnome-ui/icons` — Icon Library
+
+> Framework-agnostic Adwaita symbolic icon definitions. Each icon is a plain `IconDefinition` object (SVG path data) consumed by the `<Icon>` component in `@gnome-ui/react`.
+
+| Status | Category | Icons |
+|--------|----------|-------|
+| ✅ | **Navigation** | `GoPrevious`, `GoNext`, `GoHome`, `GoUp`, `PanDown`, `PanUp`, `PanStart`, `PanEnd` |
+| ✅ | **Actions** | `Add`, `Remove`, `Delete`, `Edit`, `Copy`, `Paste`, `Cut`, `Undo`, `Redo`, `Save`, `DocumentOpen`, `Close`, `Search`, `Refresh`, `Share`, `Attachment` |
+| ✅ | **UI** | `OpenMenu`, `ViewMore`, `ViewSidebar`, `ViewReveal`, `ViewConceal`, `Settings` |
+| ✅ | **Status** | `Information`, `Warning`, `Error`, `Check` |
+| ✅ | **People & Identity** | `Person`, `Accessibility` |
+| ✅ | **System & Hardware** | `Applications`, `Notifications`, `InputMouse`, `InputKeyboard`, `InputTablet`, `ColorManagement`, `Printer`, `Lock` |
+| ✅ | **Misc** | `Star`, `StarOutline`, `Heart` |
+| ✅ | **Media** | `MediaPlay`, `MediaPause`, `MediaSkipForward`, `MediaSkipBackward` |
 
 ---
 

--- a/packages/charts/.storybook/main.ts
+++ b/packages/charts/.storybook/main.ts
@@ -9,7 +9,7 @@ const config: StorybookConfig = {
   },
   docs: {},
   refs: {
-    charts: {
+    react: {
       title: "@gnome-ui/react",
       url: "https://gnome-ui.org/react",
       expanded: false,

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -66,46 +66,96 @@ interface IconDefinition {
 
 All icons are Adwaita symbolic icons — monochrome, `currentColor`-based, 16 × 16 viewBox.
 
-| Export | Description |
-|--------|-------------|
-| `Add` | Plus / add |
-| `Attachment` | Paperclip |
-| `Check` | Checkmark |
-| `Close` | × close / dismiss |
-| `Copy` | Copy to clipboard |
-| `Cut` | Cut |
-| `Delete` | Trash / delete |
-| `DocumentOpen` | Open document |
-| `Edit` | Pencil / edit |
-| `Error` | Error badge |
-| `GoHome` | Home |
-| `GoNext` | Right chevron |
-| `GoPrevious` | Left chevron |
-| `GoUp` | Up chevron |
-| `Information` | Info badge |
-| `MediaPause` | Pause |
-| `MediaPlay` | Play |
-| `MediaSkipBackward` | Skip backward |
-| `MediaSkipForward` | Skip forward |
-| `OpenMenu` | Hamburger menu |
-| `PanDown` | Pan / caret down |
-| `PanEnd` | Pan / caret right |
-| `PanStart` | Pan / caret left |
-| `PanUp` | Pan / caret up |
-| `Paste` | Paste |
-| `Redo` | Redo |
-| `Refresh` | Refresh / reload |
-| `Remove` | Minus / remove |
-| `Save` | Save / floppy disk |
-| `Search` | Magnifying glass |
-| `Settings` | Gear / settings |
-| `Share` | Share / export |
-| `Star` | Star (filled) |
-| `StarOutline` | Star (outline) |
-| `Undo` | Undo |
-| `ViewMore` | Three dots / overflow |
-| `ViewSidebar` | Sidebar toggle |
-| `Warning` | Warning triangle |
+### Navigation
+
+| Export | Symbolic name |
+|--------|--------------|
+| `GoPrevious` | `go-previous-symbolic` |
+| `GoNext` | `go-next-symbolic` |
+| `GoHome` | `go-home-symbolic` |
+| `GoUp` | `go-up-symbolic` |
+| `PanDown` | `pan-down-symbolic` |
+| `PanUp` | `pan-up-symbolic` |
+| `PanStart` | `pan-start-symbolic` |
+| `PanEnd` | `pan-end-symbolic` |
+
+### Actions
+
+| Export | Symbolic name |
+|--------|--------------|
+| `Add` | `list-add-symbolic` |
+| `Remove` | `list-remove-symbolic` |
+| `Delete` | `edit-delete-symbolic` |
+| `Edit` | `document-edit-symbolic` |
+| `Copy` | `edit-copy-symbolic` |
+| `Paste` | `edit-paste-symbolic` |
+| `Cut` | `edit-cut-symbolic` |
+| `Undo` | `edit-undo-symbolic` |
+| `Redo` | `edit-redo-symbolic` |
+| `Save` | `document-save-symbolic` |
+| `DocumentOpen` | `document-open-symbolic` |
+| `Close` | `window-close-symbolic` |
+| `Search` | `system-search-symbolic` |
+| `Refresh` | `view-refresh-symbolic` |
+| `Share` | `emblem-shared-symbolic` |
+| `Attachment` | `mail-attachment-symbolic` |
+
+### UI
+
+| Export | Symbolic name |
+|--------|--------------|
+| `OpenMenu` | `open-menu-symbolic` |
+| `ViewMore` | `view-more-symbolic` |
+| `ViewSidebar` | `sidebar-show-symbolic` |
+| `ViewReveal` | `view-reveal-symbolic` |
+| `ViewConceal` | `view-conceal-symbolic` |
+| `Settings` | `preferences-system-symbolic` |
+
+### Status
+
+| Export | Symbolic name |
+|--------|--------------|
+| `Information` | `dialog-information-symbolic` |
+| `Warning` | `dialog-warning-symbolic` |
+| `Error` | `dialog-error-symbolic` |
+| `Check` | `object-select-symbolic` |
+
+### People & Identity
+
+| Export | Symbolic name |
+|--------|--------------|
+| `Person` | `system-users-symbolic` |
+| `Accessibility` | `preferences-desktop-accessibility-symbolic` |
+
+### System & Hardware
+
+| Export | Symbolic name |
+|--------|--------------|
+| `Applications` | `view-app-grid-symbolic` |
+| `Notifications` | `notifications-symbolic` |
+| `InputMouse` | `input-mouse-symbolic` |
+| `InputKeyboard` | `input-keyboard-symbolic` |
+| `InputTablet` | `input-tablet-symbolic` |
+| `ColorManagement` | `preferences-color-symbolic` |
+| `Printer` | `printer-symbolic` |
+| `Lock` | `changes-prevent-symbolic` |
+
+### Misc
+
+| Export | Symbolic name |
+|--------|--------------|
+| `Star` | `starred-symbolic` |
+| `StarOutline` | `non-starred-symbolic` |
+| `Heart` | `emblem-favorite-symbolic` |
+
+### Media
+
+| Export | Symbolic name |
+|--------|--------------|
+| `MediaPlay` | `media-playback-start-symbolic` |
+| `MediaPause` | `media-playback-pause-symbolic` |
+| `MediaSkipForward` | `media-skip-forward-symbolic` |
+| `MediaSkipBackward` | `media-skip-backward-symbolic` |
 
 ## License
 

--- a/packages/icons/src/icons/Accessibility.ts
+++ b/packages/icons/src/icons/Accessibility.ts
@@ -1,0 +1,10 @@
+import type { IconDefinition } from "../types.ts";
+
+/** preferences-desktop-accessibility-symbolic */
+export const Accessibility: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [
+    { d: "M8 1a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3zM3.5 5.5C5 6.2 6.5 6.5 8 6.5s3-.3 4.5-1l-.5 1.5-4 .5-4-.5z" },
+    { d: "M5.5 7.5 4 13l2.5-1.5L8 14l1.5-2.5L12 13l-1.5-5.5" },
+  ],
+};

--- a/packages/icons/src/icons/Applications.ts
+++ b/packages/icons/src/icons/Applications.ts
@@ -1,0 +1,7 @@
+import type { IconDefinition } from "../types.ts";
+
+/** view-app-grid-symbolic */
+export const Applications: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [{ d: "M1 1h6v6H1zm8 0h6v6H9zM1 9h6v6H1zm8 0h6v6H9z" }],
+};

--- a/packages/icons/src/icons/ColorManagement.ts
+++ b/packages/icons/src/icons/ColorManagement.ts
@@ -1,0 +1,7 @@
+import type { IconDefinition } from "../types.ts";
+
+/** preferences-color-symbolic */
+export const ColorManagement: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [{ d: "M8 2a6 6 0 1 0 0 12A6 6 0 0 0 8 2zM4 7a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0zm5.5-1.5a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3zM6.5 10a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0z" }],
+};

--- a/packages/icons/src/icons/Heart.ts
+++ b/packages/icons/src/icons/Heart.ts
@@ -1,0 +1,7 @@
+import type { IconDefinition } from "../types.ts";
+
+/** emblem-favorite-symbolic / heart */
+export const Heart: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [{ d: "M8 13.5S2 9.5 2 5.5a3.5 3.5 0 0 1 6-2.45A3.5 3.5 0 0 1 14 5.5c0 4-6 8-6 8z" }],
+};

--- a/packages/icons/src/icons/InputKeyboard.ts
+++ b/packages/icons/src/icons/InputKeyboard.ts
@@ -1,0 +1,7 @@
+import type { IconDefinition } from "../types.ts";
+
+/** input-keyboard-symbolic */
+export const InputKeyboard: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [{ d: "M1 4.5A1.5 1.5 0 0 1 2.5 3h11A1.5 1.5 0 0 1 15 4.5v7A1.5 1.5 0 0 1 13.5 13h-11A1.5 1.5 0 0 1 1 11.5v-7zM3 6h2v2H3zm3.5 0h2v2h-2zm3.5 0h2v2h-2zM5 9h6v2H5z" }],
+};

--- a/packages/icons/src/icons/InputMouse.ts
+++ b/packages/icons/src/icons/InputMouse.ts
@@ -1,0 +1,7 @@
+import type { IconDefinition } from "../types.ts";
+
+/** input-mouse-symbolic */
+export const InputMouse: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [{ d: "M8 1a5 5 0 0 0-5 5v4a5 5 0 0 0 10 0V6a5 5 0 0 0-5-5zm-1 1.1V7H4.05A4 4 0 0 1 7 2.1zM9 2.1A4 4 0 0 1 11.95 7H9V2.1z" }],
+};

--- a/packages/icons/src/icons/InputTablet.ts
+++ b/packages/icons/src/icons/InputTablet.ts
@@ -1,0 +1,7 @@
+import type { IconDefinition } from "../types.ts";
+
+/** input-tablet-symbolic */
+export const InputTablet: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [{ d: "M3 1.5A1.5 1.5 0 0 1 4.5 0h7A1.5 1.5 0 0 1 13 1.5v13a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 14.5zm5 11.5a1 1 0 1 0 0 2 1 1 0 0 0 0-2z" }],
+};

--- a/packages/icons/src/icons/Lock.ts
+++ b/packages/icons/src/icons/Lock.ts
@@ -1,0 +1,7 @@
+import type { IconDefinition } from "../types.ts";
+
+/** changes-prevent-symbolic / lock */
+export const Lock: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [{ d: "M8 1a3 3 0 0 0-3 3v2H3.5A1.5 1.5 0 0 0 2 7.5v7A1.5 1.5 0 0 0 3.5 16h9a1.5 1.5 0 0 0 1.5-1.5v-7A1.5 1.5 0 0 0 12.5 6H11V4a3 3 0 0 0-3-3zm0 9a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z" }],
+};

--- a/packages/icons/src/icons/Notifications.ts
+++ b/packages/icons/src/icons/Notifications.ts
@@ -1,0 +1,7 @@
+import type { IconDefinition } from "../types.ts";
+
+/** notifications-symbolic */
+export const Notifications: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [{ d: "M8 1a5 5 0 0 0-5 5v3L1.5 11.5h13L13 9V6a5 5 0 0 0-5-5zm-1.5 12a1.5 1.5 0 0 0 3 0z" }],
+};

--- a/packages/icons/src/icons/Person.ts
+++ b/packages/icons/src/icons/Person.ts
@@ -1,0 +1,7 @@
+import type { IconDefinition } from "../types.ts";
+
+/** system-users-symbolic */
+export const Person: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [{ d: "M8 2a3 3 0 1 0 0 6 3 3 0 0 0 0-6zM2 14c0-3.314 2.686-5 6-5s6 1.686 6 5z", fillRule: "evenodd" }],
+};

--- a/packages/icons/src/icons/Printer.ts
+++ b/packages/icons/src/icons/Printer.ts
@@ -1,0 +1,7 @@
+import type { IconDefinition } from "../types.ts";
+
+/** printer-symbolic */
+export const Printer: IconDefinition = {
+  viewBox: "0 0 16 16",
+  paths: [{ d: "M4 1h8v4H4zM2 6.5A1.5 1.5 0 0 1 3.5 5h9A1.5 1.5 0 0 1 14 6.5v4a1.5 1.5 0 0 1-1.5 1.5H12v-2H4v2H2.5A1.5 1.5 0 0 1 2 10.5zM4 11h8v4H4z" }],
+};

--- a/packages/icons/src/icons/index.ts
+++ b/packages/icons/src/icons/index.ts
@@ -40,9 +40,24 @@ export { Warning } from "./Warning.ts";
 export { Error } from "./Error.ts";
 export { Check } from "./Check.ts";
 
+// ─── People & Identity ────────────────────────────────────────────────────────
+export { Person } from "./Person.ts";
+export { Accessibility } from "./Accessibility.ts";
+
+// ─── System & Hardware ────────────────────────────────────────────────────────
+export { Applications } from "./Applications.ts";
+export { Notifications } from "./Notifications.ts";
+export { InputMouse } from "./InputMouse.ts";
+export { InputKeyboard } from "./InputKeyboard.ts";
+export { InputTablet } from "./InputTablet.ts";
+export { ColorManagement } from "./ColorManagement.ts";
+export { Printer } from "./Printer.ts";
+export { Lock } from "./Lock.ts";
+
 // ─── Misc ─────────────────────────────────────────────────────────────────────
 export { Star } from "./Star.ts";
 export { StarOutline } from "./StarOutline.ts";
+export { Heart } from "./Heart.ts";
 
 // ─── Media ────────────────────────────────────────────────────────────────────
 export { MediaPlay } from "./MediaPlay.ts";

--- a/packages/layout/.storybook/main.ts
+++ b/packages/layout/.storybook/main.ts
@@ -27,12 +27,12 @@ const config: StorybookConfig = {
     return config;
   },
   refs: {
-    charts: {
+    react: {
       title: "@gnome-ui/react",
       url: "https://gnome-ui.org/react",
       expanded: false,
     },
-    layout: {
+    charts: {
       title: "@gnome-ui/charts",
       url: "https://gnome-ui.org/charts",
       expanded: false,

--- a/packages/layout/src/components/FileManager/FileManager.stories.tsx
+++ b/packages/layout/src/components/FileManager/FileManager.stories.tsx
@@ -1,0 +1,620 @@
+/**
+ * FileManager — Layout/FileManager
+ *
+ * GNOME Files (Nautilus)–style file browser.
+ *
+ * Key structural pattern: the top bar is split into two header bars that sit
+ * side-by-side — one aligned with the sidebar (left) and one with the content
+ * area (right). This mirrors AdwOverlaySplitView's dual-headerbar layout.
+ *
+ * Closes issue #16.
+ */
+
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { GoHome, Star, GoUp, Refresh, ViewMore, ViewSidebar, Settings, Share, Search, GoPrevious, GoNext } from "@gnome-ui/icons";
+import {
+  Button,
+  Spacer,
+  Toolbar,
+  Sidebar,
+  SidebarSection,
+  SidebarItem,
+  InlineViewSwitcher,
+  InlineViewSwitcherItem,
+  Text,
+  Avatar,
+  Popover,
+  PathBar,
+  Badge,
+  Separator,
+  Icon,
+} from "@gnome-ui/react";
+import type { PathBarSegment } from "@gnome-ui/react";
+import { Layout } from "../Layout/Layout";
+import { UserCard } from "../UserCard";
+
+// ─── Constants ─────────────────────────────────────────────────────────────────
+
+const SIDEBAR_WIDTH = 240;
+const SIDEBAR_COLLAPSED_WIDTH = 56;
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+interface FileEntry {
+  name: string;
+  type: "folder" | "document" | "image" | "archive";
+  size?: string;
+  modified?: string;
+}
+
+// ─── File data ─────────────────────────────────────────────────────────────────
+
+const FOLDER_MAP: Record<string, { label: string; files: FileEntry[] }> = {
+  "/home": {
+    label: "Home",
+    files: [
+      { name: "Documents", type: "folder" },
+      { name: "Downloads", type: "folder" },
+      { name: "Pictures",  type: "folder" },
+      { name: "Music",     type: "folder" },
+      { name: "Videos",    type: "folder" },
+      { name: "Projects",  type: "folder" },
+    ],
+  },
+  "/home/documents": {
+    label: "Documents",
+    files: [
+      { name: "Project Proposal.odt", type: "document", size: "142 KB",  modified: "2 hours ago" },
+      { name: "Budget 2026.ods",       type: "document", size: "38 KB",   modified: "Yesterday"   },
+      { name: "Presentation.odp",      type: "document", size: "2.4 MB",  modified: "3 days ago"  },
+      { name: "Notes",                 type: "folder"                                             },
+      { name: "Archive.zip",           type: "archive",  size: "8.2 MB",  modified: "Last week"   },
+    ],
+  },
+  "/home/pictures": {
+    label: "Pictures",
+    files: [
+      { name: "GNOME Conference", type: "folder"                                          },
+      { name: "Wallpapers",       type: "folder"                                          },
+      { name: "screenshot-1.png", type: "image",    size: "312 KB", modified: "Today"     },
+      { name: "screenshot-2.png", type: "image",    size: "295 KB", modified: "Today"     },
+      { name: "logo.svg",         type: "image",    size: "48 KB",  modified: "Last week" },
+    ],
+  },
+  "/home/projects": {
+    label: "Projects",
+    files: [
+      { name: "gnome-ui",       type: "folder" },
+      { name: "adwaita-rs",     type: "folder" },
+      { name: "libadwaita-web", type: "folder" },
+    ],
+  },
+};
+
+function segmentsForPath(path: string): PathBarSegment[] {
+  const parts = path.split("/").filter(Boolean);
+  const segs: PathBarSegment[] = [];
+  let cumulative = "";
+  for (const part of parts) {
+    cumulative = `${cumulative}/${part}`;
+    const label = FOLDER_MAP[cumulative]?.label ?? (part.charAt(0).toUpperCase() + part.slice(1));
+    segs.push({ label, path: cumulative });
+  }
+  return segs;
+}
+
+// ─── Inline file icons ─────────────────────────────────────────────────────────
+
+function FolderIcon() {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden>
+      <path d="M4 10a4 4 0 0 1 4-4h8l4 5h12a4 4 0 0 1 4 4v17a4 4 0 0 1-4 4H8a4 4 0 0 1-4-4V10Z"
+        fill="var(--gnome-accent-bg-color, #3584e4)" />
+    </svg>
+  );
+}
+
+function DocumentIcon() {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden>
+      <rect x="8" y="4" width="24" height="32" rx="3"
+        fill="var(--gnome-card-bg-color, #fff)"
+        stroke="var(--gnome-headerbar-border-color, rgba(0,0,0,.15))" strokeWidth="1.5" />
+      <path d="M14 14h12M14 19h12M14 24h8"
+        stroke="var(--gnome-window-fg-color, rgba(0,0,0,.4))"
+        strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ImageIcon() {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden>
+      <rect x="6" y="6" width="28" height="28" rx="4" fill="#c084fc" />
+      <circle cx="15" cy="15" r="3" fill="white" opacity="0.7" />
+      <path d="M6 28l8-8 5 5 5-6 10 9" stroke="white" strokeWidth="2"
+        strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ArchiveIcon() {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden>
+      <rect x="8" y="8" width="24" height="24" rx="3"
+        fill="var(--gnome-warning-bg-color, #e5a50a)" />
+      <path d="M17 8v24M23 8v24" stroke="white" strokeWidth="2" opacity="0.4" />
+      <rect x="14" y="18" width="12" height="7" rx="1.5" fill="white" opacity="0.8" />
+    </svg>
+  );
+}
+
+function FileIcon({ type }: { type: FileEntry["type"] }) {
+  switch (type) {
+    case "folder":   return <FolderIcon />;
+    case "document": return <DocumentIcon />;
+    case "image":    return <ImageIcon />;
+    case "archive":  return <ArchiveIcon />;
+  }
+}
+
+// ─── Dual header bar ───────────────────────────────────────────────────────────
+//
+// GNOME Files splits the header into two bars:
+//   LEFT  — sidebar header (fixed width = sidebar): search · title · menu
+//   RIGHT — content header (flex:1): back/forward · PathBar · actions
+//
+// A border-right on the left section visually joins it to the sidebar below.
+
+const userActions = [
+  { label: "View Profile",     onClick: () => {} },
+  { label: "Account Settings", onClick: () => {} },
+  { label: "Sign Out",         onClick: () => {}, variant: "destructive" as const },
+];
+
+function DualHeaderBar({
+  sidebarCollapsed,
+  onToggleSidebar,
+  segments,
+  onNavigate,
+  canGoBack,
+  canGoForward,
+  onBack,
+  onForward,
+}: {
+  sidebarCollapsed: boolean;
+  onToggleSidebar: () => void;
+  segments: PathBarSegment[];
+  onNavigate: (path: string) => void;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  onBack: () => void;
+  onForward: () => void;
+}) {
+  const sidebarW = sidebarCollapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH;
+
+  return (
+    <div style={{ display: "flex", height: "100%" }}>
+
+      {/* ── Sidebar header ─────────────────────────────────────────────────── */}
+      <div style={{
+        width: sidebarW,
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        gap: 4,
+        padding: "0 8px",
+        background: "var(--gnome-sidebar-bg-color, #ebebeb)",
+        borderRight: "1px solid var(--gnome-headerbar-border-color, rgba(0,0,0,.12))",
+        transition: "width 200ms ease",
+        overflow: "hidden",
+        position: "relative" as const,
+        marginBottom: -1,
+        paddingBottom: 1,
+        zIndex: 1,
+      }}>
+        {/* Search */}
+        <Button variant="flat" style={{ minWidth: "unset", flexShrink: 0 }} aria-label="Search">
+          <Icon icon={Search} width={16} height={16} />
+        </Button>
+
+        {/* App title (hidden when collapsed) */}
+        {!sidebarCollapsed && (
+          <Text variant="heading" style={{ flex: 1, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+            Files
+          </Text>
+        )}
+
+        <Spacer />
+
+        {/* Toggle sidebar */}
+        <Button
+          variant="flat"
+          style={{ minWidth: "unset", flexShrink: 0 }}
+          aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+          onClick={onToggleSidebar}
+        >
+          <Icon icon={ViewSidebar} width={16} height={16} />
+        </Button>
+      </div>
+
+      {/* ── Content header ─────────────────────────────────────────────────── */}
+      <Toolbar style={{ flex: 1, minHeight: "unset", height: "100%", padding: "0 8px", gap: 4 }}>
+
+        {/* Back / Forward */}
+        <Button
+          variant="flat"
+          style={{ minWidth: "unset" }}
+          aria-label="Go back"
+          disabled={!canGoBack}
+          onClick={onBack}
+        >
+          <Icon icon={GoPrevious} width={16} height={16} />
+        </Button>
+        <Button
+          variant="flat"
+          style={{ minWidth: "unset" }}
+          aria-label="Go forward"
+          disabled={!canGoForward}
+          onClick={onForward}
+        >
+          <Icon icon={GoNext} width={16} height={16} />
+        </Button>
+
+        {/* PathBar */}
+        <div style={{
+          flex: "1 1 auto",
+          display: "flex",
+          alignItems: "center",
+          background: "var(--gnome-card-bg-color, rgba(0,0,0,.05))",
+          borderRadius: "var(--gnome-radius-md, 8px)",
+          border: "1px solid var(--gnome-headerbar-border-color, rgba(0,0,0,.1))",
+          padding: "0 6px",
+          minWidth: 0,
+          minHeight: 32,
+          overflow: "hidden",
+        }}>
+          <PathBar
+            segments={segments}
+            onNavigate={onNavigate}
+            style={{ width: "100%" }}
+          />
+        </div>
+
+        {/* Refresh */}
+        <Button variant="flat" style={{ minWidth: "unset" }} aria-label="Refresh">
+          <Icon icon={Refresh} width={16} height={16} />
+        </Button>
+
+        {/* More */}
+        <Button variant="flat" style={{ minWidth: "unset" }} aria-label="More actions">
+          <Icon icon={ViewMore} width={16} height={16} />
+        </Button>
+
+        {/* User */}
+        <Popover
+          placement="bottom"
+          content={<UserCard name="Ada Lovelace" email="ada@gnome.org" actions={userActions} />}
+        >
+          <button type="button" aria-label="User menu" style={{
+            background: "transparent", border: "none", cursor: "pointer",
+            padding: 2, borderRadius: "50%", display: "flex",
+          }}>
+            <Avatar name="Ada Lovelace" size="sm" />
+          </button>
+        </Popover>
+      </Toolbar>
+    </div>
+  );
+}
+
+// ─── Sidebar ───────────────────────────────────────────────────────────────────
+
+function FileManagerSidebar({
+  collapsed,
+  currentPath,
+  onNavigate,
+}: {
+  collapsed: boolean;
+  currentPath: string;
+  onNavigate: (path: string) => void;
+}) {
+  const places = [
+    { id: "/home",           label: "Home",      icon: GoHome     },
+    { id: "/home/documents", label: "Documents", icon: ViewSidebar },
+    { id: "/home/pictures",  label: "Pictures",  icon: Star       },
+    { id: "/home/projects",  label: "Projects",  icon: Settings   },
+  ];
+
+  const network = [
+    { id: "/shared",  label: "Shared",  icon: Share, badge: 2    },
+    { id: "/starred", label: "Starred", icon: Star,  badge: null },
+  ];
+
+  return (
+    <Sidebar collapsed={collapsed} style={{ height: "100%" }}>
+      <SidebarSection title="Places">
+        {places.map(({ id, label, icon }) => (
+          <SidebarItem
+            key={id}
+            label={label}
+            icon={icon}
+            active={currentPath === id || currentPath.startsWith(`${id}/`)}
+            onClick={() => onNavigate(id)}
+          />
+        ))}
+      </SidebarSection>
+
+      <SidebarSection title="Network">
+        {network.map(({ id, label, icon, badge }) => (
+          <SidebarItem
+            key={id}
+            label={label}
+            icon={icon}
+            active={currentPath === id}
+            suffix={badge ? <Badge variant="accent">{badge}</Badge> : undefined}
+            onClick={() => onNavigate(id)}
+          />
+        ))}
+      </SidebarSection>
+    </Sidebar>
+  );
+}
+
+// ─── File views ────────────────────────────────────────────────────────────────
+
+function FileGrid({ files, onOpen }: { files: FileEntry[]; onOpen: (f: FileEntry) => void }) {
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fill, minmax(104px, 1fr))",
+      gap: 4,
+      padding: "4px 0",
+    }}>
+      {files.map((file) => (
+        <button
+          key={file.name}
+          type="button"
+          onClick={() => onOpen(file)}
+          style={{
+            display: "flex", flexDirection: "column", alignItems: "center",
+            gap: 6, padding: "10px 8px 8px",
+            background: "transparent", border: "1.5px solid transparent",
+            borderRadius: "var(--gnome-radius-md, 8px)",
+            cursor: "pointer", font: "inherit", textAlign: "center",
+          }}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.background = "var(--gnome-hover-overlay, rgba(0,0,0,.06))";
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+          }}
+        >
+          <FileIcon type={file.type} />
+          <span style={{
+            fontSize: "var(--gnome-font-size-caption, 0.75rem)",
+            lineHeight: 1.3,
+            color: "var(--gnome-window-fg-color, rgba(0,0,0,.8))",
+            wordBreak: "break-word", maxWidth: "100%",
+            fontFamily: "var(--gnome-font-family, sans-serif)",
+          }}>
+            {file.name}
+          </span>
+          {file.size && (
+            <span style={{
+              fontSize: "0.65rem", opacity: 0.55,
+              fontFamily: "var(--gnome-font-family, sans-serif)",
+              color: "var(--gnome-window-fg-color)",
+            }}>
+              {file.size}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function FileList({ files, onOpen }: { files: FileEntry[]; onOpen: (f: FileEntry) => void }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      {files.map((file, i) => (
+        <div key={file.name}>
+          {i > 0 && <Separator />}
+          <button
+            type="button"
+            onClick={() => onOpen(file)}
+            style={{
+              display: "flex", alignItems: "center", gap: 12,
+              padding: "6px 16px", width: "100%",
+              background: "transparent", border: "none",
+              cursor: "pointer", font: "inherit", textAlign: "start",
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.background = "var(--gnome-hover-overlay, rgba(0,0,0,.06))";
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+            }}
+          >
+            <span style={{ flexShrink: 0 }}><FileIcon type={file.type} /></span>
+            <span style={{ flex: 1, minWidth: 0 }}>
+              <Text variant="body" style={{ display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {file.name}
+              </Text>
+              {file.modified && (
+                <Text variant="caption" color="dim" style={{ display: "block" }}>
+                  {file.modified}{file.size ? ` · ${file.size}` : ""}
+                </Text>
+              )}
+            </span>
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Full app ──────────────────────────────────────────────────────────────────
+
+function FileManagerApp({ startMobileOpen = false }: { startMobileOpen?: boolean }) {
+  const [currentPath, setCurrentPath] = useState("/home");
+  const [history, setHistory] = useState(["/home"]);
+  const [historyIndex, setHistoryIndex] = useState(0);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(startMobileOpen);
+  const [view, setView] = useState<"grid" | "list">("grid");
+
+  const segments = segmentsForPath(currentPath);
+  const files = FOLDER_MAP[currentPath]?.files ?? FOLDER_MAP["/home"].files;
+
+  function navigate(path: string) {
+    if (!FOLDER_MAP[path]) return;
+    const newHistory = [...history.slice(0, historyIndex + 1), path];
+    setHistory(newHistory);
+    setHistoryIndex(newHistory.length - 1);
+    setCurrentPath(path);
+    setSidebarOpen(false);
+  }
+
+  function goBack() {
+    if (historyIndex > 0) {
+      const newIndex = historyIndex - 1;
+      setHistoryIndex(newIndex);
+      setCurrentPath(history[newIndex]);
+    }
+  }
+
+  function goForward() {
+    if (historyIndex < history.length - 1) {
+      const newIndex = historyIndex + 1;
+      setHistoryIndex(newIndex);
+      setCurrentPath(history[newIndex]);
+    }
+  }
+
+  function openFile(file: FileEntry) {
+    if (file.type === "folder") {
+      navigate(`${currentPath}/${file.name.toLowerCase().replace(/ /g, "-")}`);
+    }
+  }
+
+  function toggleSidebar() {
+    if (window.matchMedia("(max-width: 639px)").matches) {
+      setSidebarOpen((v) => !v);
+    } else {
+      setSidebarCollapsed((v) => !v);
+    }
+  }
+
+  return (
+    <Layout
+      topBar={
+        <DualHeaderBar
+          sidebarCollapsed={sidebarCollapsed}
+          onToggleSidebar={toggleSidebar}
+          segments={segments}
+          onNavigate={navigate}
+          canGoBack={historyIndex > 0}
+          canGoForward={historyIndex < history.length - 1}
+          onBack={goBack}
+          onForward={goForward}
+        />
+      }
+      sidebar={
+        <FileManagerSidebar
+          collapsed={sidebarCollapsed}
+          currentPath={currentPath}
+          onNavigate={navigate}
+        />
+      }
+      sidebarOpen={sidebarOpen}
+      onSidebarClose={() => setSidebarOpen(false)}
+      bottomBar={
+        <Toolbar style={{ minHeight: 32, padding: "0 16px" }}>
+          <Text variant="caption" color="dim">{files.length} items</Text>
+          <Spacer />
+          <Text variant="caption" color="dim">GNOME Files 50.0</Text>
+        </Toolbar>
+      }
+    >
+      {/* Content header */}
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "12px 16px 8px",
+        gap: 12,
+      }}>
+        <Text variant="title-2">{segments.at(-1)?.label ?? "Home"}</Text>
+        <InlineViewSwitcher value={view} onValueChange={(v) => setView(v as "grid" | "list")} aria-label="View">
+          <InlineViewSwitcherItem name="grid" label="Grid" />
+          <InlineViewSwitcherItem name="list" label="List" />
+        </InlineViewSwitcher>
+      </div>
+
+      {/* Files */}
+      <div style={{ padding: "0 12px 16px" }}>
+        {view === "grid"
+          ? <FileGrid files={files} onOpen={openFile} />
+          : <FileList files={files} onOpen={openFile} />
+        }
+      </div>
+    </Layout>
+  );
+}
+
+// ─── Meta ──────────────────────────────────────────────────────────────────────
+
+const meta: Meta = {
+  title: "Layout/FileManager",
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: `
+GNOME Files (Nautilus)–style file browser assembled from **\`@gnome-ui/layout\`**
+and **\`@gnome-ui/react\`** components.
+
+### Dual-headerbar pattern
+
+The top bar is split into two sections that sit side-by-side:
+
+| Section | Width | Contents |
+|---------|-------|----------|
+| Sidebar header | 240 px (56 px collapsed) | Search · Title · Toggle button |
+| Content header | \`flex: 1\` | Back/Forward · **PathBar** · Refresh · More · Avatar |
+
+This mirrors the \`AdwOverlaySplitView\` dual-\`AdwHeaderBar\` pattern used in GNOME Files.
+
+**Closes:** [#16](https://github.com/ElJijuna/gnome-ui/issues/16)
+**Depends on:** [#17 PathBar](https://github.com/ElJijuna/gnome-ui/issues/17)
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+
+// ─── Stories ───────────────────────────────────────────────────────────────────
+
+/** Full GNOME Files–style browser. Click folders or breadcrumbs to navigate; use ← → to go back/forward. */
+export const Default: StoryObj = {
+  name: "File manager",
+  render: () => <FileManagerApp />,
+  parameters: { controls: { disable: true } },
+};
+
+/** 360 px mobile viewport — sidebar becomes an overlay panel. */
+export const MobileOverlay: StoryObj = {
+  name: "Mobile overlay (360 px)",
+  render: () => <FileManagerApp startMobileOpen={false} />,
+  parameters: {
+    controls: { disable: true },
+    viewport: { defaultViewport: "mobile1" },
+    chromatic: { viewports: [360] },
+  },
+};

--- a/packages/layout/src/components/Settings/Settings.stories.tsx
+++ b/packages/layout/src/components/Settings/Settings.stories.tsx
@@ -1,0 +1,337 @@
+/**
+ * Settings — Layout/Settings
+ *
+ * GNOME Settings–style preferences app assembled from @gnome-ui/layout and
+ * @gnome-ui/react components. Demonstrates the NavigationSplitView pattern:
+ * left sidebar with category navigation + right panel showing sub-pages.
+ */
+
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  Search, Settings as SettingsIcon, Share, OpenMenu,
+  Applications, Notifications, Person, Heart,
+  InputMouse, InputKeyboard, InputTablet,
+  ColorManagement, Printer, Accessibility, Lock,
+} from "@gnome-ui/icons";
+import type { IconDefinition } from "@gnome-ui/icons";
+import {
+  Button,
+  Spacer,
+  Sidebar,
+  SidebarSection,
+  SidebarItem,
+  BoxedList,
+  ActionRow,
+  SwitchRow,
+  PreferencesGroup,
+  Text,
+  Icon,
+} from "@gnome-ui/react";
+import { Layout } from "../Layout/Layout";
+
+// ─── Nav structure ─────────────────────────────────────────────────────────────
+
+type NavId =
+  | "apps" | "notifications" | "search" | "online-accounts"
+  | "sharing" | "wellbeing" | "mouse" | "keyboard"
+  | "color" | "printers" | "tablets" | "accessibility"
+  | "privacy" | "system";
+
+interface NavItem { id: NavId; label: string; icon: IconDefinition }
+
+const NAV_ITEMS: NavItem[] = [
+  { id: "apps",            label: "Apps",               icon: Applications },
+  { id: "notifications",   label: "Notifications",      icon: Notifications },
+  { id: "search",          label: "Search",             icon: Search },
+  { id: "online-accounts", label: "Online Accounts",    icon: Person },
+  { id: "sharing",         label: "Sharing",            icon: Share },
+  { id: "wellbeing",       label: "Wellbeing",          icon: Heart },
+  { id: "mouse",           label: "Mouse & Touchpad",   icon: InputMouse },
+  { id: "keyboard",        label: "Keyboard",           icon: InputKeyboard },
+  { id: "color",           label: "Color Management",   icon: ColorManagement },
+  { id: "printers",        label: "Printers",           icon: Printer },
+  { id: "tablets",         label: "Graphics Tablets",   icon: InputTablet },
+  { id: "accessibility",   label: "Accessibility",      icon: Accessibility },
+  { id: "privacy",         label: "Privacy & Security", icon: Lock },
+  { id: "system",          label: "System",             icon: SettingsIcon },
+];
+
+// ─── Sub-page: Accessibility → Seeing ─────────────────────────────────────────
+
+function SeeingPage() {
+  return (
+    <div style={{ padding: "16px 16px 32px", display: "flex", flexDirection: "column", gap: 24 }}>
+
+      {/* Screen Reader */}
+      <PreferencesGroup>
+        <BoxedList>
+          <ActionRow
+            title="Screen Reader"
+            subtitle="The screen reader reads displayed text as you move the focus"
+            trailing={
+              <Button variant="default" style={{ whiteSpace: "nowrap" }}>
+                Configure
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden style={{ marginLeft: 4 }}>
+                  <path d="M7 2h3v3M10 2 5.5 6.5M3 3H2v7h7V9" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </Button>
+            }
+          />
+        </BoxedList>
+      </PreferencesGroup>
+
+      {/* Seeing toggles */}
+      <PreferencesGroup>
+        <BoxedList>
+          <SwitchRow title="High Contrast"    subtitle="Increase color contrast of foreground and background interface elements" />
+          <SwitchRow title="On/Off Shapes"    subtitle="Use shapes to indicate state in addition to or instead of color" />
+          <SwitchRow title="Reduced Motion"   subtitle="Toggle reduced motion animations throughout the user interface" defaultChecked />
+          <SwitchRow title="Large Text"       subtitle="Increase the size of all text in the user interface" />
+          <ActionRow
+            interactive
+            title="Cursor Size"
+            subtitle="Increase the size of the cursor"
+            trailing={
+              <span style={{ display: "flex", alignItems: "center", gap: 4, opacity: 0.55, fontSize: "0.9rem" }}>
+                Default
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
+                  <path d="M4 2l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </span>
+            }
+            onClick={() => {}}
+          />
+          <SwitchRow title="Sound Keys"           subtitle="Beep when Num Lock or Caps Lock are turned on or off" />
+          <SwitchRow title="Always Show Scrollbars" subtitle="Make scrollbars always visible" />
+        </BoxedList>
+      </PreferencesGroup>
+    </div>
+  );
+}
+
+// ─── Placeholder for other pages ───────────────────────────────────────────────
+
+function PlaceholderPage({ title }: { title: string }) {
+  return (
+    <div style={{ padding: 32, display: "flex", alignItems: "center", justifyContent: "center", height: "100%" }}>
+      <Text variant="body" color="dim">{title} settings coming soon.</Text>
+    </div>
+  );
+}
+
+// ─── Dual header (same pattern as FileManager) ─────────────────────────────────
+
+function DualHeader({
+  sidebarCollapsed,
+  onToggleSidebar,
+  activeLabel,
+  subPage,
+  onBack,
+}: {
+  sidebarCollapsed: boolean;
+  onToggleSidebar: () => void;
+  activeLabel: string;
+  subPage: string | null;
+  onBack: () => void;
+}) {
+  const sidebarW = sidebarCollapsed ? 56 : 240;
+
+  return (
+    <div style={{ display: "flex", height: "100%" }}>
+      {/* Sidebar header */}
+      <div style={{
+        width: sidebarW,
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        gap: 4,
+        padding: "0 8px",
+        background: "var(--gnome-sidebar-bg-color, #ebebeb)",
+        borderRight: "1px solid var(--gnome-headerbar-border-color, rgba(0,0,0,.12))",
+        transition: "width 200ms ease",
+        overflow: "hidden",
+        /* Extend 1 px down to cover the topBar's border-bottom under the sidebar section */
+        position: "relative" as const,
+        marginBottom: -1,
+        paddingBottom: 1,
+        zIndex: 1,
+      }}>
+        {sidebarCollapsed ? (
+          /* Collapsed: only the OpenMenu toggle centered */
+          <Button
+            variant="flat"
+            style={{ minWidth: "unset", flexShrink: 0, margin: "0 auto" }}
+            aria-label="Expand sidebar"
+            onClick={onToggleSidebar}
+          >
+            <Icon icon={OpenMenu} width={16} height={16} />
+          </Button>
+        ) : (
+          /* Expanded: Search · Title · OpenMenu toggle */
+          <>
+            <Button variant="flat" style={{ minWidth: "unset", flexShrink: 0 }} aria-label="Search">
+              <Icon icon={Search} width={16} height={16} />
+            </Button>
+            <Text variant="heading" style={{ flex: 1, whiteSpace: "nowrap", overflow: "hidden" }}>
+              Settings
+            </Text>
+            <Button
+              variant="flat"
+              style={{ minWidth: "unset", flexShrink: 0 }}
+              aria-label="Collapse sidebar"
+              onClick={onToggleSidebar}
+            >
+              <Icon icon={OpenMenu} width={16} height={16} />
+            </Button>
+          </>
+        )}
+      </div>
+
+      {/* Content header */}
+      <div style={{
+        flex: 1,
+        display: "flex",
+        alignItems: "center",
+        padding: "0 8px",
+        gap: 4,
+        position: "relative",
+      }}>
+        {/* Back button (sub-page only) */}
+        {subPage && (
+          <Button variant="flat" style={{ minWidth: "unset" }} aria-label="Back" onClick={onBack}>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+              <path d="M10 3L5 8l5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </Button>
+        )}
+
+        {/* Centered title */}
+        <div style={{
+          position: "absolute", left: 0, right: 0,
+          display: "flex", justifyContent: "center", pointerEvents: "none",
+        }}>
+          <Text variant="heading">{subPage ?? activeLabel}</Text>
+        </div>
+
+        <Spacer />
+
+        {/* Close button */}
+        <Button variant="flat" style={{ minWidth: "unset" }} aria-label="Close">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+            <path d="M3 3l10 10M13 3 3 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Full app ──────────────────────────────────────────────────────────────────
+
+function SettingsApp() {
+  const [active, setActive] = useState<NavId>("accessibility");
+  const [subPage, setSubPage] = useState<string | null>("Seeing");
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const activeItem = NAV_ITEMS.find((n) => n.id === active)!;
+
+  function selectNav(id: NavId) {
+    setActive(id);
+    setSubPage(id === "accessibility" ? "Seeing" : null);
+    setSidebarOpen(false);
+  }
+
+  function toggleSidebar() {
+    if (window.matchMedia("(max-width: 639px)").matches) {
+      setSidebarOpen((v) => !v);
+    } else {
+      setSidebarCollapsed((v) => !v);
+    }
+  }
+
+  return (
+    <Layout
+      topBar={
+        <DualHeader
+          sidebarCollapsed={sidebarCollapsed}
+          onToggleSidebar={toggleSidebar}
+          activeLabel={activeItem.label}
+          subPage={subPage}
+          onBack={() => setSubPage(null)}
+        />
+      }
+      sidebar={
+        <Sidebar collapsed={sidebarCollapsed} style={{ height: "100%" }}>
+          <SidebarSection>
+            {NAV_ITEMS.map(({ id, label, icon }) => (
+              <SidebarItem
+                key={id}
+                label={label}
+                icon={icon}
+                active={active === id}
+                onClick={() => selectNav(id)}
+              />
+            ))}
+          </SidebarSection>
+        </Sidebar>
+      }
+      sidebarOpen={sidebarOpen}
+      onSidebarClose={() => setSidebarOpen(false)}
+    >
+      {active === "accessibility" && subPage === "Seeing"
+        ? <SeeingPage />
+        : <PlaceholderPage title={activeItem.label} />
+      }
+    </Layout>
+  );
+}
+
+// ─── Meta ──────────────────────────────────────────────────────────────────────
+
+const meta: Meta = {
+  title: "Layout/Settings",
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: `
+GNOME Settings–style preferences app assembled from **\`@gnome-ui/layout\`** and **\`@gnome-ui/react\`**.
+
+Demonstrates the dual-headerbar + sidebar navigation pattern with sub-page drill-down.
+
+| Component | Role |
+|-----------|------|
+| \`Layout\` | Full-page shell |
+| \`Sidebar\` / \`SidebarItem\` | Category navigation |
+| \`PreferencesGroup\` | Titled section wrapper |
+| \`BoxedList\` | Rounded settings list |
+| \`SwitchRow\` | Toggle setting row |
+| \`ActionRow\` | Navigable / value row |
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+
+/** GNOME Settings — Accessibility → Seeing page. */
+export const Default: StoryObj = {
+  name: "Settings app",
+  render: () => <SettingsApp />,
+  parameters: { controls: { disable: true } },
+};
+
+/** 360 px mobile viewport. */
+export const Mobile: StoryObj = {
+  name: "Mobile (360 px)",
+  render: () => <SettingsApp />,
+  parameters: {
+    controls: { disable: true },
+    viewport: { defaultViewport: "mobile1" },
+    chromatic: { viewports: [360] },
+  },
+};

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -9,14 +9,14 @@ const config: StorybookConfig = {
   },
   docs: {},
   refs: {
-    charts: {
-      title: "@gnome-ui/charts",
-      url: "https://gnome-ui.org/charts",
-      expanded: false,
-    },
     layout: {
       title: "@gnome-ui/layout",
       url: "https://gnome-ui.org/layout",
+      expanded: false,
+    },
+    charts: {
+      title: "@gnome-ui/charts",
+      url: "https://gnome-ui.org/charts",
       expanded: false,
     },
   },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -59,6 +59,7 @@ export default function App() {
 | [`Link`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-link--docs) | Inline hyperlink with accent colour, animated underline, and external-URL variant |
 | [`ToggleGroup`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-togglegroup--docs) / `ToggleGroupItem` | Mutually-exclusive toggle buttons; icon-only, label-only, or icon + label |
 | [`InlineViewSwitcher`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-inlineviewswitcher--docs) / `InlineViewSwitcherItem` | Compact inline view switcher; `default`, `flat`, and `round` variants |
+| [`PathBar`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-pathbar--docs) | Breadcrumb path bar for hierarchical navigation; ancestor segments are interactive buttons, current segment is highlighted |
 
 ### Display
 

--- a/packages/react/src/components/Icon/Icon.stories.tsx
+++ b/packages/react/src/components/Icon/Icon.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import * as Icons from "@gnome-ui/icons";
 import { Icon } from "./Icon";
@@ -55,11 +56,11 @@ export const Default: Story = {
 
 export const Sizes: Story = {
   render: () => (
-    <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+    <div style={{ display: "flex", alignItems: "center", gap: 24 }}>
       {(["sm", "md", "lg"] as const).map((s) => (
-        <div key={s} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+        <div key={s} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8 }}>
           <Icon icon={Icons.Search} size={s} label="Search" />
-          <Text variant="caption" color="dim">{s}</Text>
+          <Text variant="caption" color="dim">{s} · {s === "sm" ? 12 : s === "md" ? 16 : 20}px</Text>
         </div>
       ))}
     </div>
@@ -71,8 +72,8 @@ export const Sizes: Story = {
 
 export const InheritsColor: Story = {
   render: () => (
-    <div style={{ display: "flex", gap: 16 }}>
-      {(["#3584e4", "#e01b24", "#2ec27e", "#f6d32d", "#9141ac"] as const).map((color) => (
+    <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+      {(["#3584e4", "#e01b24", "#2ec27e", "#f6d32d", "#9141ac", "currentColor"] as const).map((color) => (
         <span key={color} style={{ color, display: "flex" }}>
           <Icon icon={Icons.Star} size="lg" label="Star" />
         </span>
@@ -91,74 +92,179 @@ export const InheritsColor: Story = {
 
 // ─── Full icon gallery ─────────────────────────────────────────────────────────
 
-const GALLERY: Array<{ name: string; icon: Icons.IconDefinition }> = [
-  // Navigation
-  { name: "GoPrevious",       icon: Icons.GoPrevious },
-  { name: "GoNext",           icon: Icons.GoNext },
-  { name: "GoHome",           icon: Icons.GoHome },
-  { name: "GoUp",             icon: Icons.GoUp },
-  { name: "PanDown",          icon: Icons.PanDown },
-  { name: "PanUp",            icon: Icons.PanUp },
-  { name: "PanStart",         icon: Icons.PanStart },
-  { name: "PanEnd",           icon: Icons.PanEnd },
-  // Actions
-  { name: "Add",              icon: Icons.Add },
-  { name: "Remove",           icon: Icons.Remove },
-  { name: "Delete",           icon: Icons.Delete },
-  { name: "Edit",             icon: Icons.Edit },
-  { name: "Copy",             icon: Icons.Copy },
-  { name: "Paste",            icon: Icons.Paste },
-  { name: "Cut",              icon: Icons.Cut },
-  { name: "Undo",             icon: Icons.Undo },
-  { name: "Redo",             icon: Icons.Redo },
-  { name: "Save",             icon: Icons.Save },
-  { name: "DocumentOpen",     icon: Icons.DocumentOpen },
-  { name: "Close",            icon: Icons.Close },
-  { name: "Search",           icon: Icons.Search },
-  { name: "Refresh",          icon: Icons.Refresh },
-  { name: "Share",            icon: Icons.Share },
-  { name: "Attachment",       icon: Icons.Attachment },
-  // UI
-  { name: "OpenMenu",         icon: Icons.OpenMenu },
-  { name: "ViewMore",         icon: Icons.ViewMore },
-  { name: "ViewSidebar",      icon: Icons.ViewSidebar },
-  { name: "Settings",         icon: Icons.Settings },
-  // Status
-  { name: "Information",      icon: Icons.Information },
-  { name: "Warning",          icon: Icons.Warning },
-  { name: "Error",            icon: Icons.Error },
-  { name: "Check",            icon: Icons.Check },
-  // Misc
-  { name: "Star",             icon: Icons.Star },
-  { name: "StarOutline",      icon: Icons.StarOutline },
-  // Media
-  { name: "MediaPlay",        icon: Icons.MediaPlay },
-  { name: "MediaPause",       icon: Icons.MediaPause },
-  { name: "MediaSkipForward", icon: Icons.MediaSkipForward },
-  { name: "MediaSkipBackward",icon: Icons.MediaSkipBackward },
+const CATEGORIES: Array<{ title: string; items: Array<{ name: string; icon: Icons.IconDefinition }> }> = [
+  {
+    title: "Navigation",
+    items: [
+      { name: "GoPrevious",  icon: Icons.GoPrevious },
+      { name: "GoNext",      icon: Icons.GoNext },
+      { name: "GoHome",      icon: Icons.GoHome },
+      { name: "GoUp",        icon: Icons.GoUp },
+      { name: "PanDown",     icon: Icons.PanDown },
+      { name: "PanUp",       icon: Icons.PanUp },
+      { name: "PanStart",    icon: Icons.PanStart },
+      { name: "PanEnd",      icon: Icons.PanEnd },
+    ],
+  },
+  {
+    title: "Actions",
+    items: [
+      { name: "Add",          icon: Icons.Add },
+      { name: "Remove",       icon: Icons.Remove },
+      { name: "Delete",       icon: Icons.Delete },
+      { name: "Edit",         icon: Icons.Edit },
+      { name: "Copy",         icon: Icons.Copy },
+      { name: "Paste",        icon: Icons.Paste },
+      { name: "Cut",          icon: Icons.Cut },
+      { name: "Undo",         icon: Icons.Undo },
+      { name: "Redo",         icon: Icons.Redo },
+      { name: "Save",         icon: Icons.Save },
+      { name: "DocumentOpen", icon: Icons.DocumentOpen },
+      { name: "Close",        icon: Icons.Close },
+      { name: "Search",       icon: Icons.Search },
+      { name: "Refresh",      icon: Icons.Refresh },
+      { name: "Share",        icon: Icons.Share },
+      { name: "Attachment",   icon: Icons.Attachment },
+    ],
+  },
+  {
+    title: "UI",
+    items: [
+      { name: "OpenMenu",    icon: Icons.OpenMenu },
+      { name: "ViewMore",    icon: Icons.ViewMore },
+      { name: "ViewSidebar", icon: Icons.ViewSidebar },
+      { name: "ViewReveal",  icon: Icons.ViewReveal },
+      { name: "ViewConceal", icon: Icons.ViewConceal },
+      { name: "Settings",    icon: Icons.Settings },
+    ],
+  },
+  {
+    title: "Status",
+    items: [
+      { name: "Information", icon: Icons.Information },
+      { name: "Warning",     icon: Icons.Warning },
+      { name: "Error",       icon: Icons.Error },
+      { name: "Check",       icon: Icons.Check },
+    ],
+  },
+  {
+    title: "People & Identity",
+    items: [
+      { name: "Person",        icon: Icons.Person },
+      { name: "Accessibility", icon: Icons.Accessibility },
+    ],
+  },
+  {
+    title: "System & Hardware",
+    items: [
+      { name: "Applications",   icon: Icons.Applications },
+      { name: "Notifications",  icon: Icons.Notifications },
+      { name: "InputMouse",     icon: Icons.InputMouse },
+      { name: "InputKeyboard",  icon: Icons.InputKeyboard },
+      { name: "InputTablet",    icon: Icons.InputTablet },
+      { name: "ColorManagement",icon: Icons.ColorManagement },
+      { name: "Printer",        icon: Icons.Printer },
+      { name: "Lock",           icon: Icons.Lock },
+    ],
+  },
+  {
+    title: "Misc",
+    items: [
+      { name: "Star",        icon: Icons.Star },
+      { name: "StarOutline", icon: Icons.StarOutline },
+      { name: "Heart",       icon: Icons.Heart },
+    ],
+  },
+  {
+    title: "Media",
+    items: [
+      { name: "MediaPlay",         icon: Icons.MediaPlay },
+      { name: "MediaPause",        icon: Icons.MediaPause },
+      { name: "MediaSkipForward",  icon: Icons.MediaSkipForward },
+      { name: "MediaSkipBackward", icon: Icons.MediaSkipBackward },
+    ],
+  },
 ];
+
+const TOTAL = CATEGORIES.reduce((n, c) => n + c.items.length, 0);
+
+function IconTile({ name, icon }: { name: string; icon: Icons.IconDefinition }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleClick() {
+    navigator.clipboard.writeText(`import { ${name} } from "@gnome-ui/icons";`).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      title={`${name} — click to copy import`}
+      onClick={handleClick}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 6,
+        padding: "12px 8px 10px",
+        width: 92,
+        background: copied
+          ? "var(--gnome-accent-bg-color, #3584e4)"
+          : "transparent",
+        color: copied
+          ? "var(--gnome-accent-fg-color, #fff)"
+          : "inherit",
+        border: "1.5px solid transparent",
+        borderRadius: 8,
+        cursor: "pointer",
+        font: "inherit",
+        transition: "background 120ms ease, color 120ms ease",
+      }}
+      onMouseEnter={(e) => {
+        if (!copied) (e.currentTarget as HTMLButtonElement).style.background = "var(--gnome-hover-overlay, rgba(0,0,0,.06))";
+      }}
+      onMouseLeave={(e) => {
+        if (!copied) (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+      }}
+    >
+      <Icon icon={icon} size="lg" label={name} />
+      <span style={{
+        fontSize: "0.7rem",
+        lineHeight: 1.3,
+        textAlign: "center",
+        wordBreak: "break-word",
+        fontFamily: "var(--gnome-font-family, sans-serif)",
+        opacity: copied ? 1 : 0.7,
+      }}>
+        {copied ? "Copied!" : name}
+      </span>
+    </button>
+  );
+}
 
 export const Gallery: Story = {
   render: () => (
-    <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-      {GALLERY.map(({ name, icon }) => (
-        <div
-          key={name}
-          title={name}
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            gap: 6,
-            padding: "12px 10px",
-            width: 88,
-            borderRadius: 8,
-          }}
-        >
-          <Icon icon={icon} size="lg" label={name} />
-          <Text variant="caption" color="dim" style={{ textAlign: "center", wordBreak: "break-word" }}>
-            {name}
+    <div style={{ display: "flex", flexDirection: "column", gap: 32, padding: 8 }}>
+      <Text variant="caption" color="dim">
+        {TOTAL} icons — click any icon to copy its import statement.
+      </Text>
+
+      {CATEGORIES.map(({ title, items }) => (
+        <div key={title}>
+          <Text
+            variant="caption-heading"
+            color="dim"
+            style={{ marginBottom: 8, paddingLeft: 4, display: "block" }}
+          >
+            {title}
           </Text>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+            {items.map(({ name, icon }) => (
+              <IconTile key={name} name={name} icon={icon} />
+            ))}
+          </div>
         </div>
       ))}
     </div>
@@ -166,7 +272,9 @@ export const Gallery: Story = {
   parameters: {
     controls: { disable: true },
     docs: {
-      description: { story: "All 38 icons available in `@gnome-ui/icons`." },
+      description: {
+        story: `All **${TOTAL} icons** from \`@gnome-ui/icons\`, grouped by category. Click any icon to copy its import statement to the clipboard.`,
+      },
     },
   },
 };

--- a/packages/react/src/components/PathBar/PathBar.module.css
+++ b/packages/react/src/components/PathBar/PathBar.module.css
@@ -1,0 +1,122 @@
+/* ─── Root ────────────────────────────────────────────────────────────────── */
+
+.pathBar {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  font-family: var(--gnome-font-family, sans-serif);
+}
+
+/* ─── List ────────────────────────────────────────────────────────────────── */
+
+.list {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  min-width: 0;
+}
+
+/* ─── Item ────────────────────────────────────────────────────────────────── */
+
+.item {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+/* ─── Separator ───────────────────────────────────────────────────────────── */
+
+.separator {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.35));
+  opacity: 0.5;
+  margin: 0 1px;
+}
+
+/* ─── Ancestor segment (button) ───────────────────────────────────────────── */
+
+.segment {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: var(--gnome-radius-sm, 6px);
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: var(--gnome-font-size-body, 1rem);
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 160px;
+  transition: background-color var(--gnome-duration-fast, 100ms) var(--gnome-easing-default, ease);
+}
+
+.segment:hover {
+  background-color: var(--gnome-hover-overlay, rgba(0, 0, 0, 0.06));
+}
+
+.segment:active {
+  background-color: var(--gnome-active-overlay, rgba(0, 0, 0, 0.12));
+}
+
+.segment:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 var(--gnome-focus-ring-offset, 2px) var(--gnome-window-bg-color, #fafafa),
+    0 0 0 calc(var(--gnome-focus-ring-offset, 2px) + var(--gnome-focus-ring-width, 2px))
+      var(--gnome-focus-ring-color, #3584e4);
+}
+
+/* ─── Current segment (non-interactive) ──────────────────────────────────── */
+
+.current {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  font-family: inherit;
+  font-size: var(--gnome-font-size-body, 1rem);
+  font-weight: var(--gnome-font-weight-semibold, 600);
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+/* ─── Icon ────────────────────────────────────────────────────────────────── */
+
+.icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+/* ─── Reduced motion ──────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .segment {
+    transition: none;
+  }
+}
+
+/* ─── Dark mode ───────────────────────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .segment:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .segment:active {
+    background-color: rgba(255, 255, 255, 0.14);
+  }
+}

--- a/packages/react/src/components/PathBar/PathBar.stories.tsx
+++ b/packages/react/src/components/PathBar/PathBar.stories.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { PathBar } from "./PathBar";
+import type { PathBarSegment } from "./PathBar";
+
+const meta: Meta<typeof PathBar> = {
+  title: "Components/PathBar",
+  component: PathBar,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+Breadcrumb path bar for navigating a hierarchical location.
+
+Mirrors the location bar in **GNOME Files (Nautilus)**. Segments are separated
+by chevron dividers. All segments except the last are interactive — clicking
+them calls \`onNavigate\`. The last segment represents the current location and
+is rendered as a bold, non-interactive label.
+
+\`\`\`tsx
+import { PathBar } from "@gnome-ui/react";
+
+<PathBar
+  segments={[
+    { label: "Home",      path: "/home"                     },
+    { label: "Documents", path: "/home/documents"           },
+    { label: "Projects",  path: "/home/documents/projects"  },
+  ]}
+  onNavigate={(path) => navigate(path)}
+/>
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PathBar>;
+
+// ─── Shared segments ──────────────────────────────────────────────────────────
+
+const deepSegments: PathBarSegment[] = [
+  { label: "Home",      path: "/home"                            },
+  { label: "Documents", path: "/home/documents"                  },
+  { label: "Projects",  path: "/home/documents/projects"         },
+  { label: "gnome-ui",  path: "/home/documents/projects/gnome-ui" },
+];
+
+// ─── Stories ──────────────────────────────────────────────────────────────────
+
+/** Standard breadcrumb path — click ancestor segments to navigate. */
+export const Default: Story = {
+  args: {
+    segments: deepSegments,
+  },
+};
+
+/** Only a single segment (root). No buttons, no separators. */
+export const Root: Story = {
+  args: {
+    segments: [{ label: "Home", path: "/home" }],
+  },
+};
+
+/** Two-level path. */
+export const TwoLevels: Story = {
+  args: {
+    segments: [
+      { label: "Home",      path: "/home"           },
+      { label: "Documents", path: "/home/documents" },
+    ],
+  },
+};
+
+/** Interactive demo: clicking a segment truncates the path to that point. */
+export const Interactive: Story = {
+  render: () => {
+    const allSegments: PathBarSegment[] = deepSegments;
+    const [current, setCurrent] = useState(allSegments.length - 1);
+
+    const handleNavigate = (_path: string, index: number) => {
+      setCurrent(index);
+    };
+
+    return (
+      <PathBar
+        segments={allSegments.slice(0, current + 1)}
+        onNavigate={handleNavigate}
+      />
+    );
+  },
+  parameters: { controls: { disable: true } },
+};
+
+/** Segments with folder icons at the leading edge. */
+export const WithIcons: Story = {
+  render: () => {
+    const FolderIcon = () => (
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+        <path
+          d="M1 3.5A1.5 1.5 0 0 1 2.5 2H5l1.5 2H11.5A1.5 1.5 0 0 1 13 5.5v5A1.5 1.5 0 0 1 11.5 12h-9A1.5 1.5 0 0 1 1 10.5v-7Z"
+          fill="currentColor"
+        />
+      </svg>
+    );
+
+    const segments: PathBarSegment[] = [
+      { label: "Home",      path: "/home",           icon: <FolderIcon /> },
+      { label: "Documents", path: "/home/documents", icon: <FolderIcon /> },
+      { label: "Projects",  path: "/home/documents/projects", icon: <FolderIcon /> },
+    ];
+
+    return <PathBar segments={segments} />;
+  },
+  parameters: { controls: { disable: true } },
+};

--- a/packages/react/src/components/PathBar/PathBar.test.tsx
+++ b/packages/react/src/components/PathBar/PathBar.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { PathBar } from "./PathBar";
+import type { PathBarSegment } from "./PathBar";
+
+const segments: PathBarSegment[] = [
+  { label: "Home", path: "/home" },
+  { label: "Documents", path: "/home/documents" },
+  { label: "Projects", path: "/home/documents/projects" },
+];
+
+describe("PathBar", () => {
+  it("renders all segment labels", () => {
+    render(<PathBar segments={segments} />);
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("Documents")).toBeInTheDocument();
+    expect(screen.getByText("Projects")).toBeInTheDocument();
+  });
+
+  it("renders ancestor segments as buttons", () => {
+    render(<PathBar segments={segments} />);
+    expect(screen.getByRole("button", { name: "Home" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Documents" })).toBeInTheDocument();
+  });
+
+  it("renders the last segment as non-interactive with aria-current=page", () => {
+    render(<PathBar segments={segments} />);
+    const current = screen.getByText("Projects");
+    expect(current).not.toHaveRole("button");
+    expect(current).toHaveAttribute("aria-current", "page");
+  });
+
+  it("calls onNavigate with path and index when ancestor segment is clicked", () => {
+    const onNavigate = vi.fn();
+    render(<PathBar segments={segments} onNavigate={onNavigate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
+    expect(onNavigate).toHaveBeenCalledWith("/home", 0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Documents" }));
+    expect(onNavigate).toHaveBeenCalledWith("/home/documents", 1);
+  });
+
+  it("does not call onNavigate when current segment is absent onNavigate", () => {
+    const onNavigate = vi.fn();
+    render(<PathBar segments={segments} onNavigate={onNavigate} />);
+    // Projects is the current segment and is a span, not button — can't be clicked
+    expect(screen.queryByRole("button", { name: "Projects" })).toBeNull();
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("renders single segment as current (no buttons)", () => {
+    const single: PathBarSegment[] = [{ label: "Home", path: "/" }];
+    render(<PathBar segments={single} />);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    expect(screen.getByText("Home")).toHaveAttribute("aria-current", "page");
+  });
+
+  it("forwards className to root nav", () => {
+    const { container } = render(<PathBar segments={segments} className="my-pathbar" />);
+    expect(container.querySelector("nav")).toHaveClass("my-pathbar");
+  });
+
+  it("has accessible breadcrumb landmark", () => {
+    render(<PathBar segments={segments} />);
+    expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toBeInTheDocument();
+  });
+
+  it("renders segment icons when provided", () => {
+    const withIcons: PathBarSegment[] = [
+      { label: "Home", path: "/", icon: <span data-testid="home-icon" /> },
+      { label: "Docs", path: "/docs", icon: <span data-testid="docs-icon" /> },
+    ];
+    render(<PathBar segments={withIcons} />);
+    expect(screen.getByTestId("home-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("docs-icon")).toBeInTheDocument();
+  });
+
+  it("does not render separators for single segment", () => {
+    const { container } = render(<PathBar segments={[{ label: "Root", path: "/" }]} />);
+    expect(container.querySelectorAll("svg")).toHaveLength(0);
+  });
+
+  it("renders N-1 separators for N segments", () => {
+    render(<PathBar segments={segments} />);
+    // 3 segments → 2 separators (each is a span with an svg inside)
+    const separators = screen.getAllByRole("listitem")
+      .map((li) => li.querySelector("svg"))
+      .filter(Boolean);
+    expect(separators).toHaveLength(2);
+  });
+});

--- a/packages/react/src/components/PathBar/PathBar.tsx
+++ b/packages/react/src/components/PathBar/PathBar.tsx
@@ -1,0 +1,94 @@
+import { type HTMLAttributes, type ReactNode } from "react";
+import styles from "./PathBar.module.css";
+
+export interface PathBarSegment {
+  /** Display label for this path segment. */
+  label: string;
+  /** Opaque path value passed to `onNavigate` when the segment is clicked. */
+  path: string;
+  /** Optional icon placed before the label (e.g. a folder icon). */
+  icon?: ReactNode;
+}
+
+export interface PathBarProps extends HTMLAttributes<HTMLElement> {
+  /**
+   * Ordered path segments from root to current location.
+   * The last segment is the current folder and is rendered non-interactive.
+   */
+  segments: PathBarSegment[];
+  /**
+   * Called when the user clicks on a non-current segment.
+   * Receives the `path` and zero-based `index` of the clicked segment.
+   */
+  onNavigate?: (path: string, index: number) => void;
+}
+
+/**
+ * Breadcrumb path bar for navigating a hierarchical location.
+ *
+ * Mirrors the location bar in GNOME Files (Nautilus). Segments are separated
+ * by chevron dividers. All segments except the last are interactive — clicking
+ * them calls `onNavigate`. The last segment represents the current location and
+ * is rendered as a static label.
+ *
+ * @see https://developer.gnome.org/hig/patterns/nav/search.html
+ */
+export function PathBar({ segments, onNavigate, className, ...props }: PathBarProps) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={[styles.pathBar, className].filter(Boolean).join(" ")}
+      {...props}
+    >
+      <ol className={styles.list} aria-label="Path segments">
+        {segments.map((segment, index) => {
+          const isCurrent = index === segments.length - 1;
+          return (
+            <li key={segment.path} className={styles.item}>
+              {/* Separator chevron (not before the first segment) */}
+              {index > 0 && (
+                <span className={styles.separator} aria-hidden="true">
+                  <svg width="12" height="12" viewBox="0 0 12 12" focusable="false">
+                    <path
+                      d="M4 2l4 4-4 4"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </span>
+              )}
+
+              {isCurrent ? (
+                /* Current folder — non-interactive */
+                <span
+                  className={styles.current}
+                  aria-current="page"
+                >
+                  {segment.icon && (
+                    <span className={styles.icon} aria-hidden="true">{segment.icon}</span>
+                  )}
+                  {segment.label}
+                </span>
+              ) : (
+                /* Ancestor folder — clickable */
+                <button
+                  type="button"
+                  className={styles.segment}
+                  onClick={() => onNavigate?.(segment.path, index)}
+                >
+                  {segment.icon && (
+                    <span className={styles.icon} aria-hidden="true">{segment.icon}</span>
+                  )}
+                  {segment.label}
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/packages/react/src/components/PathBar/index.ts
+++ b/packages/react/src/components/PathBar/index.ts
@@ -1,0 +1,2 @@
+export { PathBar } from "./PathBar";
+export type { PathBarProps, PathBarSegment } from "./PathBar";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -225,3 +225,6 @@ export type { PreferencesDialogProps } from "./components/PreferencesDialog";
 
 export { Timeline } from "./components/Timeline";
 export type { TimelineProps, TimelineItem, TimelineOrientation, TimelineVariant } from "./components/Timeline";
+
+export { PathBar } from "./components/PathBar";
+export type { PathBarProps, PathBarSegment } from "./components/PathBar";


### PR DESCRIPTION
Fixes #17
- add icons, update layouts, README and ROADMAPs

## What

add component PathBar and example layout to use this
add new icons

## Why

needs to implement layouts.

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [x] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [x] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
