### PR TITLE
19 independize storybook icons

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -105,7 +105,7 @@ jobs:
 
   build-storybook-react:
     name: Build Storybook (@gnome-ui/react)
-    needs: [build-core, build-icons, build-react]
+    needs: [build-icons]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -132,7 +132,7 @@ jobs:
 
   build-storybook-layout:
     name: Build Storybook (@gnome-ui/layout)
-    needs: [build-core, build-icons, build-react]
+    needs: [build-react]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -164,7 +164,7 @@ jobs:
 
   build-storybook-charts:
     name: Build Storybook (@gnome-ui/charts)
-    needs: [build-core, build-charts]
+    needs: [build-charts]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -103,6 +103,27 @@ jobs:
           name: charts-dist
           path: packages/charts/dist/
 
+  build-storybook-icons:
+    name: Build Storybook (@gnome-ui/icons)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook --workspace packages/icons
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: storybook-icons
+          path: packages/icons/storybook-static/
+
   build-storybook-react:
     name: Build Storybook (@gnome-ui/react)
     needs: [build-icons]
@@ -191,7 +212,7 @@ jobs:
 
   combine-and-deploy:
     name: Combine & Deploy to GitHub Pages
-    needs: [build-storybook-react, build-storybook-layout, build-storybook-charts]
+    needs: [build-storybook-react, build-storybook-layout, build-storybook-charts, build-storybook-icons]
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -211,6 +232,11 @@ jobs:
         with:
           name: storybook-charts
           path: site/charts/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: storybook-icons
+          path: site/icons/
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/packages/icons/.storybook/main.ts
+++ b/packages/icons/.storybook/main.ts
@@ -19,9 +19,9 @@ const config: StorybookConfig = {
       url: "https://gnome-ui.org/layout",
       expanded: false,
     },
-    icons: {
-      title: "@gnome-ui/icons",
-      url: "https://gnome-ui.org/icons",
+    charts: {
+      title: "@gnome-ui/charts",
+      url: "https://gnome-ui.org/charts",
       expanded: false,
     },
   },

--- a/packages/icons/.storybook/preview.ts
+++ b/packages/icons/.storybook/preview.ts
@@ -1,0 +1,27 @@
+import type { Preview } from "@storybook/react";
+import { parameters as docsParameters } from "@storybook/addon-docs/preview";
+
+const preview: Preview = {
+  parameters: {
+    layout: "fullscreen",
+    backgrounds: {
+      default: "gnome-light",
+      values: [
+        { name: "gnome-light", value: "#fafafa" },
+        { name: "gnome-dark", value: "#242424" },
+      ],
+    },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    docs: {
+      ...docsParameters.docs,
+      toc: true,
+    },
+  },
+};
+
+export default preview;

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -18,12 +18,24 @@
   ],
   "scripts": {
     "build": "tsc && vite build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "storybook": "storybook dev -p 6008",
+    "build-storybook": "storybook build"
   },
   "publishConfig": {
     "access": "public"
   },
   "devDependencies": {
+    "@storybook/addon-a11y": "^10.3.3",
+    "@storybook/addon-docs": "^10.3.3",
+    "@storybook/react": "^10.3.3",
+    "@storybook/react-vite": "^10.3.3",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^6.0.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "storybook": "^10.3.3",
     "vite": "^8.0.3",
     "vite-plugin-dts": "^4.5.4"
   }

--- a/packages/icons/src/Icons.stories.tsx
+++ b/packages/icons/src/Icons.stories.tsx
@@ -1,0 +1,227 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { IconDefinition } from "./types.ts";
+import * as icons from "./icons/index.ts";
+
+// ─── Minimal inline SVG renderer ──────────────────────────────────────────────
+
+interface IconProps {
+  icon: IconDefinition;
+  size?: number;
+  color?: string;
+}
+
+function Icon({ icon, size = 16, color = "currentColor" }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox={icon.viewBox}
+      width={size}
+      height={size}
+      fill={color}
+      aria-hidden
+    >
+      {icon.paths.map((p, i) => (
+        <path
+          key={i}
+          d={p.d}
+          fillRule={p.fillRule}
+          clipRule={p.clipRule}
+        />
+      ))}
+    </svg>
+  );
+}
+
+// ─── Gallery component ────────────────────────────────────────────────────────
+
+const iconEntries = Object.entries(icons) as [string, IconDefinition][];
+
+interface GalleryProps {
+  size: number;
+  color: string;
+  filter: string;
+}
+
+function Gallery({ size, color, filter }: GalleryProps) {
+  const filtered = filter
+    ? iconEntries.filter(([name]) =>
+        name.toLowerCase().includes(filter.toLowerCase())
+      )
+    : iconEntries;
+
+  return (
+    <div style={{ padding: "2rem", fontFamily: "sans-serif" }}>
+      <p style={{ color: "#666", marginBottom: "1.5rem", fontSize: "0.875rem" }}>
+        {filtered.length} icon{filtered.length !== 1 ? "s" : ""}
+        {filter ? ` matching "${filter}"` : ""}
+      </p>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(100px, 1fr))",
+          gap: "1rem",
+        }}
+      >
+        {filtered.map(([name, def]) => (
+          <div
+            key={name}
+            title={name}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "0.5rem",
+              padding: "0.75rem",
+              borderRadius: "8px",
+              border: "1px solid #e0e0e0",
+              backgroundColor: "#fff",
+            }}
+          >
+            <Icon icon={def} size={size} color={color} />
+            <span
+              style={{
+                fontSize: "0.7rem",
+                color: "#555",
+                textAlign: "center",
+                wordBreak: "break-word",
+              }}
+            >
+              {name}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta = {
+  title: "Icons/Gallery",
+  component: Gallery,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "All Adwaita symbolic icons exported by `@gnome-ui/icons`. Each icon is a framework-agnostic `IconDefinition` (viewBox + SVG paths) that can be consumed by any adapter.",
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      control: { type: "range", min: 12, max: 64, step: 4 },
+      description: "Rendered icon size in px",
+    },
+    color: {
+      control: "color",
+      description: "SVG fill color",
+    },
+    filter: {
+      control: "text",
+      description: "Filter icons by name",
+    },
+  },
+  args: {
+    size: 16,
+    color: "#1c1c1c",
+    filter: "",
+  },
+} satisfies Meta<typeof Gallery>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ─── Stories ──────────────────────────────────────────────────────────────────
+
+export const AllIcons: Story = {
+  name: "All Icons",
+};
+
+export const LargeSize: Story = {
+  name: "Large (32px)",
+  args: { size: 32 },
+};
+
+export const DarkBackground: Story = {
+  name: "Dark Background",
+  args: { color: "#ffffff" },
+  parameters: {
+    backgrounds: { default: "gnome-dark" },
+  },
+};
+
+// ─── Individual icon stories by category ──────────────────────────────────────
+
+const categories: Record<string, string[]> = {
+  Navigation: ["GoPrevious", "GoNext", "GoHome", "GoUp", "PanDown", "PanUp", "PanStart", "PanEnd"],
+  Actions: ["Add", "Remove", "Delete", "Edit", "Copy", "Paste", "Cut", "Undo", "Redo", "Save", "DocumentOpen", "Close", "Search", "Refresh", "Share", "Attachment"],
+  UI: ["OpenMenu", "ViewMore", "ViewSidebar", "ViewReveal", "ViewConceal", "Settings"],
+  Status: ["Information", "Warning", "Error", "Check"],
+  "People & Identity": ["Person", "Accessibility"],
+  "System & Hardware": ["Applications", "Notifications", "InputMouse", "InputKeyboard", "InputTablet", "ColorManagement", "Printer", "Lock"],
+  Misc: ["Star", "StarOutline", "Heart"],
+  Media: ["MediaPlay", "MediaPause", "MediaSkipForward", "MediaSkipBackward"],
+};
+
+function CategoryGrid({ category, size, color }: { category: string; size: number; color: string }) {
+  const names = categories[category] ?? [];
+  const entries = names
+    .map((n) => [n, (icons as Record<string, IconDefinition>)[n]] as [string, IconDefinition])
+    .filter(([, def]) => def != null);
+
+  return (
+    <div style={{ padding: "2rem", fontFamily: "sans-serif" }}>
+      <h2 style={{ marginBottom: "1rem", fontSize: "1rem", color: "#333" }}>{category}</h2>
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "1rem",
+        }}
+      >
+        {entries.map(([name, def]) => (
+          <div
+            key={name}
+            title={name}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "0.5rem",
+              padding: "0.75rem",
+              borderRadius: "8px",
+              border: "1px solid #e0e0e0",
+              backgroundColor: "#fff",
+              minWidth: "80px",
+            }}
+          >
+            <Icon icon={def} size={size} color={color} />
+            <span style={{ fontSize: "0.7rem", color: "#555", textAlign: "center" }}>{name}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export const NavigationIcons: Story = {
+  name: "Navigation",
+  render: (args) => <CategoryGrid category="Navigation" size={args.size} color={args.color} />,
+};
+
+export const ActionIcons: Story = {
+  name: "Actions",
+  render: (args) => <CategoryGrid category="Actions" size={args.size} color={args.color} />,
+};
+
+export const StatusIcons: Story = {
+  name: "Status",
+  render: (args) => <CategoryGrid category="Status" size={args.size} color={args.color} />,
+};
+
+export const MediaIcons: Story = {
+  name: "Media",
+  render: (args) => <CategoryGrid category="Media" size={args.size} color={args.color} />,
+};

--- a/packages/layout/.storybook/main.ts
+++ b/packages/layout/.storybook/main.ts
@@ -37,6 +37,11 @@ const config: StorybookConfig = {
       url: "https://gnome-ui.org/charts",
       expanded: false,
     },
+    icons: {
+      title: "@gnome-ui/icons",
+      url: "https://gnome-ui.org/icons",
+      expanded: false,
+    },
   },
 };
 

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -19,6 +19,11 @@ const config: StorybookConfig = {
       url: "https://gnome-ui.org/charts",
       expanded: false,
     },
+    icons: {
+      title: "@gnome-ui/icons",
+      url: "https://gnome-ui.org/icons",
+      expanded: false,
+    },
   },
 };
 


### PR DESCRIPTION
## What

Create new storybook for icons

## Why

Having the icon storybook separate and not within the React storybook causes some confusion.

## Changes

- [ ] New component
- [ ] Bug fix
- [ ] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [ ] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [ ] All styles use CSS custom properties from `@gnome-ui/core`
- [ ] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [ ] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
