### PR TITLE
feat(react): add ContributionGraph component — closes #21

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -365,3 +365,25 @@ React hooks that surface every `@gnome-ui/platform` module as idiomatic React st
 | Status | Component | Description |
 |--------|-----------|-------------|
 | ⬜ | **`ColumnView`** | Multi-column sortable data table — mirrors `GtkColumnView` / `AdwColumnView` (issue [#14](https://github.com/ElJijuna/gnome-ui/issues/14)) |
+
+---
+
+## `@gnome-ui/charts` — Chart Components
+
+> Data visualisation components built on top of Recharts, fully styled with Adwaita design tokens.
+
+| Status | Component | Description |
+|--------|-----------|-------------|
+| ✅ | **`LineChart`** | Multi-series time-series line chart |
+| ✅ | **`BarChart`** | Grouped and stacked bar chart |
+| ✅ | **`AreaChart`** | Filled-area chart for cumulative data |
+
+---
+
+## Tier 18 — Data Display
+
+> Read-only data display widgets rendered in pure HTML/SVG — no Recharts dependency.
+
+| Status | Component | Description |
+|--------|-----------|-------------|
+| 🚧 | **`ContributionGraph`** | Activity heatmap calendar: a 52-week grid of rounded SVG cells where colour intensity (Adwaita green palette) represents activity count; supports dark mode, keyboard navigation (`role="grid"`), and screen-reader labels — issue [#21](https://github.com/ElJijuna/gnome-ui/issues/21) |

--- a/packages/react/src/components/ContributionGraph/ContributionGraph.module.css
+++ b/packages/react/src/components/ContributionGraph/ContributionGraph.module.css
@@ -1,0 +1,92 @@
+.wrapper {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--gnome-space-1, 6px);
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+.svg {
+  display: block;
+  flex-shrink: 0;
+}
+
+.label {
+  font-family: var(--gnome-font-family, system-ui);
+  font-size: 11px;
+  fill: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  opacity: 0.6;
+  user-select: none;
+}
+
+.cell {
+  cursor: default;
+  transition: transform var(--gnome-transition-fast, 100ms) ease;
+  transform-box: fill-box;
+  transform-origin: center;
+  outline: none;
+}
+
+.cell:not([aria-disabled="true"]):hover {
+  transform: scale(1.2);
+}
+
+.cell:not([aria-disabled="true"]) {
+  cursor: pointer;
+}
+
+.cell:focus-visible {
+  outline: 2px solid var(--gnome-accent-color, #3584e4);
+  outline-offset: 1px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cell {
+    transition: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .cell {
+    stroke: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+    stroke-width: 0.5;
+    stroke-opacity: 0.3;
+  }
+}
+
+.tooltip {
+  position: absolute;
+  transform: translate(-50%, calc(-100% - 6px));
+  background: var(--gnome-popover-bg-color, #fff);
+  border: 1px solid var(--gnome-light-3, #deddda);
+  border-radius: var(--gnome-radius-md, 8px);
+  padding: 4px 8px;
+  font-family: var(--gnome-font-family, system-ui);
+  font-size: 12px;
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  box-shadow: var(--gnome-shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.12));
+  pointer-events: none;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+.legend {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--gnome-space-1, 6px);
+}
+
+.legendLabel {
+  font-family: var(--gnome-font-family, system-ui);
+  font-size: 11px;
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  opacity: 0.6;
+  user-select: none;
+}
+
+.legendCell {
+  display: block;
+  flex-shrink: 0;
+}

--- a/packages/react/src/components/ContributionGraph/ContributionGraph.stories.tsx
+++ b/packages/react/src/components/ContributionGraph/ContributionGraph.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ContributionGraph } from "./ContributionGraph";
+import type { ContributionDay } from "./ContributionGraph";
+
+const meta: Meta<typeof ContributionGraph> = {
+  title: "Data Display/ContributionGraph",
+  component: ContributionGraph,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+A 52-week activity heatmap calendar styled with Adwaita design tokens.
+Colour intensity (Adwaita green palette) represents activity count per day.
+
+**Guidelines (GNOME HIG):**
+- Use inside a \`Card\` to frame the graph on a dashboard or profile page.
+- The default green scale follows the Adwaita success/positive colour meaning.
+- Dark mode is handled automatically via CSS custom properties — no extra configuration needed.
+- Keyboard users can navigate every cell with arrow keys (\`role="grid"\`).
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ContributionGraph>;
+
+function generateData(days = 365): ContributionDay[] {
+  const result: ContributionDay[] = [];
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  // Use a simple deterministic pattern so the story is stable across renders
+  for (let i = 0; i < days; i++) {
+    const date = new Date(today);
+    date.setDate(today.getDate() - i);
+    const iso = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    // ~40 % of days have activity; count varies by weekday and week
+    const seed = (i * 7 + i % 13) % 10;
+    if (seed > 5) {
+      result.push({ date: iso, count: (seed * 3) % 14 + 1 });
+    }
+  }
+  return result;
+}
+
+const SAMPLE_DATA = generateData(365);
+
+export const Default: Story = {
+  args: {
+    data: SAMPLE_DATA,
+  },
+};
+
+export const SundayStart: Story = {
+  args: {
+    data: SAMPLE_DATA,
+    weekStartDay: 0,
+  },
+  parameters: {
+    docs: {
+      description: { story: "Week columns start on Sunday instead of Monday." },
+    },
+  },
+};
+
+export const CustomColors: Story = {
+  args: {
+    data: SAMPLE_DATA,
+    colorScale: [
+      "var(--gnome-card-shade-color, rgba(0,0,0,0.07))",
+      "var(--gnome-blue-1, #99c1f1)",
+      "var(--gnome-blue-2, #62a0ea)",
+      "var(--gnome-blue-3, #3584e4)",
+      "var(--gnome-blue-4, #1c71d8)",
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Custom `colorScale` using the Adwaita blue palette — useful when green implies a different meaning in context.",
+      },
+    },
+  },
+};
+
+export const LargerCells: Story = {
+  args: {
+    data: SAMPLE_DATA,
+    cellSize: 16,
+    cellGap: 4,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Larger cells for touch-friendly or high-density displays.",
+      },
+    },
+  },
+};
+
+export const NoLabels: Story = {
+  args: {
+    data: SAMPLE_DATA,
+    showMonthLabels: false,
+    showDayLabels: false,
+    showLegend: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All labels hidden — suitable for compact inline usage where surrounding context provides the date range.",
+      },
+    },
+  },
+};
+
+export const WithClickHandler: Story = {
+  args: {
+    data: SAMPLE_DATA,
+    onDayClick: (day) => alert(`${day.count} contributions on ${day.date}`),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pass `onDayClick` to make cells interactive. Keyboard users can activate cells with Enter or Space.",
+      },
+    },
+  },
+};

--- a/packages/react/src/components/ContributionGraph/ContributionGraph.tsx
+++ b/packages/react/src/components/ContributionGraph/ContributionGraph.tsx
@@ -1,0 +1,359 @@
+import { useMemo, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import styles from "./ContributionGraph.module.css";
+
+export interface ContributionDay {
+  /** ISO 8601 date — "YYYY-MM-DD". */
+  date: string;
+  /** Non-negative activity count. */
+  count: number;
+}
+
+export interface ContributionGraphProps {
+  /** Activity data. Days absent from the array are treated as count = 0. */
+  data: ContributionDay[];
+  /**
+   * Number of intensity levels (excluding 0).
+   * @default 4
+   */
+  maxLevel?: number;
+  /**
+   * Colour scale — length must be maxLevel + 1 (index 0 = empty).
+   * Defaults to the Adwaita green palette.
+   */
+  colorScale?: string[];
+  /** Cell side length in pixels. @default 12 */
+  cellSize?: number;
+  /** Gap between cells in pixels. @default 3 */
+  cellGap?: number;
+  /** 0 = Sunday · 1 = Monday (GNOME locale default). @default 1 */
+  weekStartDay?: 0 | 1;
+  /** @default true */
+  showMonthLabels?: boolean;
+  /** @default true */
+  showDayLabels?: boolean;
+  /** @default true */
+  showLegend?: boolean;
+  /** Number of week columns to display. @default 52 */
+  weeks?: number;
+  /** @default "Contribution graph" */
+  ariaLabel?: string;
+  onDayClick?: (day: ContributionDay) => void;
+  /** Returns a plain-text tooltip string for a day. */
+  tooltipContent?: (day: ContributionDay) => string;
+  className?: string;
+}
+
+const SHORT_MONTHS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+// 0=Sun … 6=Sat
+const SHORT_DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+const DAY_LABEL_WIDTH = 28;
+const MONTH_LABEL_HEIGHT = 20;
+
+const DEFAULT_COLORS = [
+  "var(--gnome-card-shade-color, rgba(0,0,0,0.07))",
+  "var(--gnome-green-1, #8ff0a4)",
+  "var(--gnome-green-2, #57e389)",
+  "var(--gnome-green-4, #2ec27e)",
+  "var(--gnome-green-5, #26a269)",
+];
+
+function dateToIso(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function isoToLocal(iso: string): Date {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function fullDateLabel(iso: string): string {
+  return isoToLocal(iso).toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+interface GridCell {
+  iso: string;
+  count: number;
+  level: number;
+  future: boolean;
+}
+
+export function ContributionGraph({
+  data,
+  maxLevel = 4,
+  colorScale,
+  cellSize = 12,
+  cellGap = 3,
+  weekStartDay = 1,
+  showMonthLabels = true,
+  showDayLabels = true,
+  showLegend = true,
+  weeks = 52,
+  ariaLabel = "Contribution graph",
+  onDayClick,
+  tooltipContent,
+  className,
+}: ContributionGraphProps) {
+  const stride = cellSize + cellGap;
+  const svgRef = useRef<SVGSVGElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const colors = colorScale ?? DEFAULT_COLORS;
+
+  const [focusedCell, setFocusedCell] = useState({ col: 0, row: 0 });
+  const [tooltip, setTooltip] = useState<{
+    x: number;
+    y: number;
+    text: string;
+  } | null>(null);
+
+  const countMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const d of data) map.set(d.date, d.count);
+    return map;
+  }, [data]);
+
+  const maxCount = useMemo(
+    () => Math.max(1, ...data.map((d) => d.count)),
+    [data],
+  );
+
+  const { grid, monthLabels } = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // Align to start of current week
+    const daysFromWeekStart = (today.getDay() - weekStartDay + 7) % 7;
+    const lastWeekStart = new Date(today);
+    lastWeekStart.setDate(today.getDate() - daysFromWeekStart);
+
+    const firstDay = new Date(lastWeekStart);
+    firstDay.setDate(lastWeekStart.getDate() - (weeks - 1) * 7);
+
+    const gridResult: GridCell[][] = [];
+    const labels: { col: number; month: string }[] = [];
+    let lastMonth = -1;
+
+    for (let col = 0; col < weeks; col++) {
+      const colStart = new Date(firstDay);
+      colStart.setDate(firstDay.getDate() + col * 7);
+
+      // Month label when the column starts a new month
+      if (colStart.getMonth() !== lastMonth) {
+        labels.push({ col, month: SHORT_MONTHS[colStart.getMonth()] });
+        lastMonth = colStart.getMonth();
+      }
+
+      const column: GridCell[] = [];
+      for (let row = 0; row < 7; row++) {
+        const date = new Date(firstDay);
+        date.setDate(firstDay.getDate() + col * 7 + row);
+        const future = date > today;
+        const iso = dateToIso(date);
+        const count = future ? 0 : (countMap.get(iso) ?? 0);
+        const level =
+          count === 0
+            ? 0
+            : Math.min(maxLevel, Math.ceil((count / maxCount) * maxLevel));
+        column.push({ iso, count, level, future });
+      }
+      gridResult.push(column);
+    }
+
+    return { grid: gridResult, monthLabels: labels };
+  }, [countMap, maxCount, maxLevel, weeks, weekStartDay]);
+
+  // Always label Mon(1), Wed(3), Fri(5) — rows shift with weekStartDay
+  const labelRows = useMemo(
+    () =>
+      [1, 3, 5].map((dayIndex) => ({
+        row: (dayIndex - weekStartDay + 7) % 7,
+        label: SHORT_DAYS[dayIndex],
+      })),
+    [weekStartDay],
+  );
+
+  const dayLabelW = showDayLabels ? DAY_LABEL_WIDTH : 0;
+  const monthLabelH = showMonthLabels ? MONTH_LABEL_HEIGHT : 0;
+  const svgWidth = dayLabelW + weeks * stride - cellGap;
+  const svgHeight = monthLabelH + 7 * stride - cellGap;
+  const cellRx = Math.min(4, Math.floor(cellSize / 3));
+
+  function focusCell(col: number, row: number) {
+    const c = Math.max(0, Math.min(weeks - 1, col));
+    const r = Math.max(0, Math.min(6, row));
+    setFocusedCell({ col: c, row: r });
+    svgRef.current
+      ?.querySelector<SVGRectElement>(`[data-col="${c}"][data-row="${r}"]`)
+      ?.focus();
+  }
+
+  function handleCellKey(e: KeyboardEvent, col: number, row: number) {
+    const moves: Record<string, [number, number]> = {
+      ArrowRight: [col + 1, row],
+      ArrowLeft: [col - 1, row],
+      ArrowDown: [col, row + 1],
+      ArrowUp: [col, row - 1],
+    };
+    if (moves[e.key]) {
+      e.preventDefault();
+      focusCell(...moves[e.key]);
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      const cell = grid[col]?.[row];
+      if (cell && !cell.future) onDayClick?.({ date: cell.iso, count: cell.count });
+    }
+  }
+
+  function handleMouseEnter(
+    e: React.MouseEvent<SVGRectElement>,
+    text: string,
+  ) {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+    const wRect = wrapper.getBoundingClientRect();
+    const rRect = (e.currentTarget as Element).getBoundingClientRect();
+    setTooltip({
+      x: rRect.left - wRect.left + cellSize / 2,
+      y: rRect.top - wRect.top,
+      text,
+    });
+  }
+
+  function cellColor(cell: GridCell): string {
+    if (cell.future) return colors[0];
+    return colors[Math.min(cell.level, colors.length - 1)] ?? colors[colors.length - 1];
+  }
+
+  function cellTooltip(cell: GridCell): string {
+    if (cell.future) return fullDateLabel(cell.iso);
+    return (
+      tooltipContent?.({ date: cell.iso, count: cell.count }) ??
+      `${cell.count} contribution${cell.count !== 1 ? "s" : ""} on ${fullDateLabel(cell.iso)}`
+    );
+  }
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={[styles.wrapper, className].filter(Boolean).join(" ")}
+    >
+      <svg
+        ref={svgRef}
+        width={svgWidth}
+        height={svgHeight}
+        className={styles.svg}
+        aria-label={ariaLabel}
+        role="img"
+      >
+        {/* Month labels */}
+        {showMonthLabels &&
+          monthLabels.map(({ col, month }) => (
+            <text
+              key={`m-${col}`}
+              x={dayLabelW + col * stride}
+              y={12}
+              className={styles.label}
+            >
+              {month}
+            </text>
+          ))}
+
+        {/* Day-of-week labels: Mon, Wed, Fri */}
+        {showDayLabels &&
+          labelRows.map(({ row, label }) => (
+            <text
+              key={`d-${row}`}
+              x={0}
+              y={monthLabelH + row * stride + cellSize - 1}
+              className={styles.label}
+            >
+              {label}
+            </text>
+          ))}
+
+        {/* Activity grid */}
+        <g role="grid" aria-label={ariaLabel}>
+          {grid.map((column, col) => (
+            <g key={col} role="row">
+              {column.map((cell, row) => {
+                const tipText = cellTooltip(cell);
+                const isFocused =
+                  focusedCell.col === col && focusedCell.row === row;
+
+                return (
+                  <rect
+                    key={`${col}-${row}`}
+                    data-col={col}
+                    data-row={row}
+                    x={dayLabelW + col * stride}
+                    y={monthLabelH + row * stride}
+                    width={cellSize}
+                    height={cellSize}
+                    rx={cellRx}
+                    fill={cellColor(cell)}
+                    opacity={cell.future ? 0.35 : 1}
+                    className={styles.cell}
+                    role="gridcell"
+                    aria-label={tipText}
+                    aria-disabled={cell.future || undefined}
+                    tabIndex={isFocused ? 0 : -1}
+                    onClick={() => !cell.future && onDayClick?.({ date: cell.iso, count: cell.count })}
+                    onKeyDown={(e) => handleCellKey(e, col, row)}
+                    onFocus={() => setFocusedCell({ col, row })}
+                    onMouseEnter={(e) => handleMouseEnter(e, tipText)}
+                    onMouseLeave={() => setTooltip(null)}
+                  />
+                );
+              })}
+            </g>
+          ))}
+        </g>
+      </svg>
+
+      {tooltip && (
+        <div
+          className={styles.tooltip}
+          style={{ left: tooltip.x, top: tooltip.y }}
+          role="tooltip"
+        >
+          {tooltip.text}
+        </div>
+      )}
+
+      {showLegend && (
+        <div className={styles.legend}>
+          <span className={styles.legendLabel}>Less</span>
+          {Array.from({ length: maxLevel + 1 }, (_, i) => (
+            <svg
+              key={i}
+              width={cellSize}
+              height={cellSize}
+              aria-hidden="true"
+              className={styles.legendCell}
+            >
+              <rect
+                width={cellSize}
+                height={cellSize}
+                rx={cellRx}
+                fill={colors[Math.min(i, colors.length - 1)]}
+              />
+            </svg>
+          ))}
+          <span className={styles.legendLabel}>More</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/components/ContributionGraph/index.ts
+++ b/packages/react/src/components/ContributionGraph/index.ts
@@ -1,0 +1,2 @@
+export { ContributionGraph } from "./ContributionGraph";
+export type { ContributionGraphProps, ContributionDay } from "./ContributionGraph";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -228,3 +228,6 @@ export type { TimelineProps, TimelineItem, TimelineOrientation, TimelineVariant 
 
 export { PathBar } from "./components/PathBar";
 export type { PathBarProps, PathBarSegment } from "./components/PathBar";
+
+export { ContributionGraph } from "./components/ContributionGraph";
+export type { ContributionGraphProps, ContributionDay } from "./components/ContributionGraph";


### PR DESCRIPTION
52-week activity heatmap calendar rendered in pure SVG/HTML with Adwaita design tokens. Supports dark mode, prefers-contrast, prefers-reduced-motion, roving tabindex keyboard nav (role="grid"), per-cell aria-label, custom colour scales, and onDayClick handler.

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
