### PR TITLE
feat(react): add ColumnView component — closes #14

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -364,7 +364,7 @@ React hooks that surface every `@gnome-ui/platform` module as idiomatic React st
 
 | Status | Component | Description |
 |--------|-----------|-------------|
-| ⬜ | **`ColumnView`** | Multi-column sortable data table — mirrors `GtkColumnView` / `AdwColumnView` (issue [#14](https://github.com/ElJijuna/gnome-ui/issues/14)) |
+| ✅ | **`ColumnView`** | Multi-column sortable data table — mirrors `GtkColumnView` / `AdwColumnView` (issue [#14](https://github.com/ElJijuna/gnome-ui/issues/14)) |
 
 ---
 

--- a/packages/react/src/components/ColumnView/ColumnView.module.css
+++ b/packages/react/src/components/ColumnView/ColumnView.module.css
@@ -1,0 +1,212 @@
+/* ─── Outer container (border + radius, no overflow to preserve sticky) ────── */
+
+.outer {
+  border: 1px solid var(--gnome-divider-color, rgba(0, 0, 0, 0.15));
+  border-radius: var(--gnome-radius-lg, 12px);
+  background: var(--gnome-card-bg-color, #ffffff);
+  /* overflow:clip clips to border-radius without creating a scroll ctx */
+  overflow: clip;
+}
+
+/* ─── Scroll container ──────────────────────────────────────────────────────── */
+
+.scroll {
+  overflow-y: auto;
+  width: 100%;
+}
+
+/* ─── Table ─────────────────────────────────────────────────────────────────── */
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: auto;
+}
+
+/* ─── Header ────────────────────────────────────────────────────────────────── */
+
+.thead {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--gnome-card-bg-color, #ffffff);
+  /* Separator below sticky header */
+  box-shadow: 0 1px 0 var(--gnome-divider-color, rgba(0, 0, 0, 0.15));
+}
+
+.th {
+  padding: 0 var(--gnome-space-4, 24px);
+  height: 40px;
+  text-align: start;
+  font-family: var(--gnome-font-family, system-ui);
+  font-size: var(--gnome-font-size-caption, 0.75rem);
+  font-weight: 700;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.headerLabel {
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  opacity: 0.55;
+}
+
+/* ─── Sort button ───────────────────────────────────────────────────────────── */
+
+.sortBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--gnome-font-size-caption, 0.75rem);
+  font-weight: 700;
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  opacity: 0.55;
+  outline: none;
+  border-radius: var(--gnome-radius-sm, 4px);
+  transition: opacity var(--gnome-transition-fast, 100ms) ease;
+}
+
+.sortBtn:hover {
+  opacity: 0.8;
+}
+
+.sortBtn:focus-visible {
+  outline: 2px solid var(--gnome-accent-color, #3584e4);
+  outline-offset: 2px;
+  opacity: 0.8;
+}
+
+.sortBtnActive {
+  opacity: 1;
+  color: var(--gnome-accent-color, #3584e4);
+}
+
+.sortActive {
+  color: var(--gnome-accent-color, #3584e4);
+}
+
+.sortNeutral {
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+}
+
+/* ─── Body ──────────────────────────────────────────────────────────────────── */
+
+.tbody {
+  color: var(--gnome-card-fg-color, rgba(0, 0, 0, 0.8));
+}
+
+/* ─── Row ───────────────────────────────────────────────────────────────────── */
+
+.row {
+  outline: none;
+  transition: background-color var(--gnome-transition-fast, 100ms) ease;
+}
+
+.row:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--gnome-accent-color, #3584e4);
+}
+
+.rowSelectable {
+  cursor: pointer;
+}
+
+.rowSelectable:hover {
+  background-color: var(--gnome-hover-overlay, rgba(0, 0, 0, 0.07));
+}
+
+.rowSelectable:active {
+  background-color: var(--gnome-active-overlay, rgba(0, 0, 0, 0.12));
+}
+
+.rowSelected {
+  background-color: color-mix(
+    in srgb,
+    var(--gnome-accent-color, #3584e4) 15%,
+    transparent
+  );
+}
+
+.rowSelected:hover {
+  background-color: color-mix(
+    in srgb,
+    var(--gnome-accent-color, #3584e4) 22%,
+    transparent
+  );
+}
+
+/* ─── Cell ──────────────────────────────────────────────────────────────────── */
+
+.td {
+  padding: var(--gnome-space-2, 12px) var(--gnome-space-4, 24px);
+  font-family: var(--gnome-font-family, system-ui);
+  font-size: var(--gnome-font-size-body, 1rem);
+  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ─── Alignment ─────────────────────────────────────────────────────────────── */
+
+.alignStart {
+  text-align: start;
+}
+
+.alignCenter {
+  text-align: center;
+}
+
+.alignEnd {
+  text-align: end;
+}
+
+/* ─── Checkbox column ───────────────────────────────────────────────────────── */
+
+.checkboxCol {
+  width: 48px;
+  padding-inline: var(--gnome-space-3, 18px);
+  text-align: center;
+}
+
+.checkbox {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--gnome-accent-color, #3584e4);
+  vertical-align: middle;
+}
+
+/* ─── Empty state ───────────────────────────────────────────────────────────── */
+
+.emptyCell {
+  padding: var(--gnome-space-6, 36px) var(--gnome-space-4, 24px);
+  text-align: center;
+}
+
+.emptyLabel {
+  font-family: var(--gnome-font-family, system-ui);
+  font-size: var(--gnome-font-size-body, 1rem);
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  opacity: 0.55;
+}
+
+/* ─── High contrast ─────────────────────────────────────────────────────────── */
+
+@media (prefers-contrast: more) {
+  .outer {
+    border-width: 2px;
+  }
+
+  .row + .row .td {
+    border-top: 1px solid var(--gnome-divider-color, rgba(0, 0, 0, 0.15));
+  }
+
+  .sortBtn {
+    text-decoration: underline;
+  }
+}

--- a/packages/react/src/components/ColumnView/ColumnView.stories.tsx
+++ b/packages/react/src/components/ColumnView/ColumnView.stories.tsx
@@ -1,0 +1,220 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ColumnView } from "./ColumnView";
+import type { ColumnDef, ColumnViewSortState, SortDirection } from "./ColumnView";
+
+const meta: Meta<typeof ColumnView> = {
+  title: "Data Display/ColumnView",
+  component: ColumnView,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+Multi-column sortable data table styled with Adwaita design tokens.
+
+Mirrors \`GtkColumnView\` / \`AdwColumnView\` — the canonical GNOME widget for tabular data in file managers, settings lists, and dashboards.
+
+**Guidelines (GNOME HIG):**
+- Use for datasets where users benefit from comparing values across columns.
+- Prefer \`selectionMode="single"\` for navigation (open on click) and \`"multiple"\` for batch operations.
+- Always provide an \`ariaLabel\` describing the data set.
+- Set \`height\` when the dataset may exceed the viewport — this enables vertical scroll with a sticky header.
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ColumnView>;
+
+interface FileRow {
+  id: number;
+  name: string;
+  type: string;
+  size: string;
+  modified: string;
+}
+
+const FILES: FileRow[] = [
+  { id: 1, name: "Documents",  type: "Folder", size: "—",       modified: "2 days ago"  },
+  { id: 2, name: "Downloads",  type: "Folder", size: "—",       modified: "Today"       },
+  { id: 3, name: "Pictures",   type: "Folder", size: "—",       modified: "Last week"   },
+  { id: 4, name: "Music",      type: "Folder", size: "—",       modified: "1 month ago" },
+  { id: 5, name: "report.pdf", type: "PDF",    size: "1.2 MB",  modified: "Yesterday"   },
+  { id: 6, name: "photo.jpg",  type: "Image",  size: "3.8 MB",  modified: "3 days ago"  },
+  { id: 7, name: "notes.txt",  type: "Text",   size: "4 KB",    modified: "Today"       },
+  { id: 8, name: "backup.zip", type: "Archive","size": "48 MB", modified: "Last month"  },
+];
+
+const FILE_COLUMNS: ColumnDef<FileRow>[] = [
+  { id: "name",     header: "Name",     cell: (r) => r.name,     sortable: true, width: "40%" },
+  { id: "type",     header: "Type",     cell: (r) => r.type,     sortable: true               },
+  { id: "size",     header: "Size",     cell: (r) => r.size,     align: "end"                 },
+  { id: "modified", header: "Modified", cell: (r) => r.modified, sortable: true               },
+];
+
+export const Default: Story = {
+  render: () => (
+    <ColumnView
+      columns={FILE_COLUMNS}
+      rows={FILES}
+      rowKey={(r) => r.id}
+      ariaLabel="Files"
+    />
+  ),
+};
+
+export const WithSort: Story = {
+  render: () => {
+    const [sort, setSort] = useState<ColumnViewSortState>({
+      columnId: "name",
+      direction: "asc",
+    });
+
+    const sorted = [...FILES].sort((a, b) => {
+      const dir = sort.direction === "asc" ? 1 : -1;
+      const key = sort.columnId as keyof FileRow;
+      return String(a[key]).localeCompare(String(b[key])) * dir;
+    });
+
+    return (
+      <ColumnView
+        columns={FILE_COLUMNS}
+        rows={sorted}
+        rowKey={(r) => r.id}
+        sortState={sort}
+        onSort={(columnId, direction) => setSort({ columnId, direction })}
+        ariaLabel="Files — sortable"
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Controlled sort state. Click a column header to sort; click again to toggle direction.",
+      },
+    },
+  },
+};
+
+export const SingleSelection: Story = {
+  render: () => {
+    const [selected, setSelected] = useState<(string | number)[]>([]);
+    return (
+      <ColumnView
+        columns={FILE_COLUMNS}
+        rows={FILES}
+        rowKey={(r) => r.id}
+        selectionMode="single"
+        selectedRows={selected}
+        onSelectionChange={setSelected}
+        ariaLabel="Files — single selection"
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Click a row to select it; click again to deselect. Use ↑/↓ to navigate, Space/Enter to toggle.",
+      },
+    },
+  },
+};
+
+export const MultipleSelection: Story = {
+  render: () => {
+    const [selected, setSelected] = useState<(string | number)[]>([2, 5]);
+    return (
+      <ColumnView
+        columns={FILE_COLUMNS}
+        rows={FILES}
+        rowKey={(r) => r.id}
+        selectionMode="multiple"
+        selectedRows={selected}
+        onSelectionChange={setSelected}
+        ariaLabel="Files — multiple selection"
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Checkbox column added automatically. Header checkbox selects/deselects all rows and shows indeterminate state for partial selection.",
+      },
+    },
+  },
+};
+
+export const FixedHeight: Story = {
+  render: () => {
+    const [sort, setSort] = useState<ColumnViewSortState>({ columnId: "name", direction: "asc" });
+    const [selected, setSelected] = useState<(string | number)[]>([]);
+
+    const sorted = [...FILES].sort((a, b) => {
+      const dir = sort.direction === "asc" ? 1 : -1;
+      const key = sort.columnId as keyof FileRow;
+      return String(a[key]).localeCompare(String(b[key])) * dir;
+    });
+
+    return (
+      <ColumnView
+        columns={FILE_COLUMNS}
+        rows={sorted}
+        rowKey={(r) => r.id}
+        selectionMode="single"
+        selectedRows={selected}
+        onSelectionChange={setSelected}
+        sortState={sort}
+        onSort={(id, dir: SortDirection) => setSort({ columnId: id, direction: dir })}
+        height={260}
+        ariaLabel="Files — scrollable"
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Fixed `height` enables vertical scroll with a sticky header. Combines sort and single selection.",
+      },
+    },
+  },
+};
+
+export const EmptyState: Story = {
+  render: () => (
+    <ColumnView
+      columns={FILE_COLUMNS}
+      rows={[]}
+      rowKey={(r) => r.id}
+      ariaLabel="Files — empty"
+    />
+  ),
+  parameters: {
+    docs: {
+      description: { story: "When `rows` is empty the default \"No items\" label is shown." },
+    },
+  },
+};
+
+export const CustomEmptyState: Story = {
+  render: () => (
+    <ColumnView
+      columns={FILE_COLUMNS}
+      rows={[]}
+      rowKey={(r) => r.id}
+      ariaLabel="Search results"
+      emptyState={
+        <span style={{ fontStyle: "italic", opacity: 0.6 }}>
+          No files match your search.
+        </span>
+      }
+    />
+  ),
+};

--- a/packages/react/src/components/ColumnView/ColumnView.tsx
+++ b/packages/react/src/components/ColumnView/ColumnView.tsx
@@ -1,0 +1,287 @@
+import { type ReactNode, useRef, useState } from "react";
+import styles from "./ColumnView.module.css";
+
+export interface ColumnDef<TRow> {
+  id: string;
+  header: ReactNode;
+  cell: (row: TRow, index: number) => ReactNode;
+  sortable?: boolean;
+  /** CSS width value — e.g. "200px", "30%". */
+  width?: string;
+  align?: "start" | "center" | "end";
+}
+
+export type SortDirection = "asc" | "desc";
+
+export interface ColumnViewSortState {
+  columnId: string;
+  direction: SortDirection;
+}
+
+export type ColumnViewSelectionMode = "none" | "single" | "multiple";
+
+export interface ColumnViewProps<TRow extends object = Record<string, unknown>> {
+  columns: ColumnDef<TRow>[];
+  rows: TRow[];
+  /** Extract a stable unique key per row. */
+  rowKey: (row: TRow) => string | number;
+  /** @default "none" */
+  selectionMode?: ColumnViewSelectionMode;
+  /** Controlled set of selected row keys. */
+  selectedRows?: (string | number)[];
+  onSelectionChange?: (keys: (string | number)[]) => void;
+  /** Controlled sort state. */
+  sortState?: ColumnViewSortState;
+  onSort?: (columnId: string, direction: SortDirection) => void;
+  /** Constrains height and enables vertical scroll. */
+  height?: string | number;
+  /** Rendered when `rows` is empty. */
+  emptyState?: ReactNode;
+  className?: string;
+  ariaLabel?: string;
+}
+
+const ALIGN: Record<string, string> = {
+  start: styles.alignStart,
+  center: styles.alignCenter,
+  end: styles.alignEnd,
+};
+
+function SortChevron({ direction }: { direction: SortDirection | null }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      aria-hidden="true"
+      className={direction ? styles.sortActive : styles.sortNeutral}
+    >
+      {direction === "asc" ? (
+        <path d="M5 2 L9 8 L1 8 Z" fill="currentColor" />
+      ) : direction === "desc" ? (
+        <path d="M5 8 L1 2 L9 2 Z" fill="currentColor" />
+      ) : (
+        <>
+          <path d="M5 1 L8 5 L2 5 Z" fill="currentColor" opacity="0.4" />
+          <path d="M5 9 L2 5 L8 5 Z" fill="currentColor" opacity="0.4" />
+        </>
+      )}
+    </svg>
+  );
+}
+
+export function ColumnView<TRow extends object = Record<string, unknown>>({
+  columns,
+  rows,
+  rowKey,
+  selectionMode = "none",
+  selectedRows = [],
+  onSelectionChange,
+  sortState,
+  onSort,
+  height,
+  emptyState,
+  className,
+  ariaLabel,
+}: ColumnViewProps<TRow>) {
+  const tbodyRef = useRef<HTMLTableSectionElement>(null);
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const selectedSet = new Set(selectedRows);
+  const hasCheckbox = selectionMode === "multiple";
+  const colSpan = columns.length + (hasCheckbox ? 1 : 0);
+
+  function handleSort(colId: string) {
+    if (!onSort) return;
+    const next: SortDirection =
+      sortState?.columnId === colId && sortState.direction === "asc"
+        ? "desc"
+        : "asc";
+    onSort(colId, next);
+  }
+
+  function toggleRow(key: string | number) {
+    if (selectionMode === "none" || !onSelectionChange) return;
+    if (selectionMode === "single") {
+      onSelectionChange(selectedSet.has(key) ? [] : [key]);
+    } else {
+      const next = new Set(selectedSet);
+      next.has(key) ? next.delete(key) : next.add(key);
+      onSelectionChange([...next]);
+    }
+  }
+
+  function handleRowKey(
+    e: React.KeyboardEvent,
+    index: number,
+    key: string | number,
+  ) {
+    const rows_els =
+      tbodyRef.current?.querySelectorAll<HTMLTableRowElement>("tr") ?? [];
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const next = Math.min(rows.length - 1, index + 1);
+      setFocusedIndex(next);
+      rows_els[next]?.focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const prev = Math.max(0, index - 1);
+      setFocusedIndex(prev);
+      rows_els[prev]?.focus();
+    } else if (e.key === " " || e.key === "Enter") {
+      e.preventDefault();
+      toggleRow(key);
+    }
+  }
+
+  function handleSelectAll(checked: boolean) {
+    if (!onSelectionChange) return;
+    onSelectionChange(checked ? rows.map(rowKey) : []);
+  }
+
+  const containerStyle: React.CSSProperties = height
+    ? { height: typeof height === "number" ? `${height}px` : height }
+    : {};
+
+  return (
+    <div className={[styles.outer, className].filter(Boolean).join(" ")}>
+      <div className={styles.scroll} style={containerStyle}>
+        <table
+          className={styles.table}
+          role="grid"
+          aria-label={ariaLabel}
+          aria-multiselectable={selectionMode === "multiple" || undefined}
+        >
+          <thead className={styles.thead}>
+            <tr>
+              {hasCheckbox && (
+                <th className={[styles.th, styles.checkboxCol].join(" ")}>
+                  <input
+                    type="checkbox"
+                    className={styles.checkbox}
+                    checked={
+                      rows.length > 0 && selectedRows.length === rows.length
+                    }
+                    ref={(el) => {
+                      if (el)
+                        el.indeterminate =
+                          selectedRows.length > 0 &&
+                          selectedRows.length < rows.length;
+                    }}
+                    onChange={(e) => handleSelectAll(e.target.checked)}
+                    aria-label="Select all rows"
+                  />
+                </th>
+              )}
+              {columns.map((col) => {
+                const isSorted = sortState?.columnId === col.id;
+                return (
+                  <th
+                    key={col.id}
+                    className={[styles.th, col.align ? ALIGN[col.align] : null]
+                      .filter(Boolean)
+                      .join(" ")}
+                    style={col.width ? { width: col.width } : undefined}
+                    aria-sort={
+                      isSorted
+                        ? sortState!.direction === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : col.sortable
+                          ? "none"
+                          : undefined
+                    }
+                  >
+                    {col.sortable && onSort ? (
+                      <button
+                        type="button"
+                        className={[
+                          styles.sortBtn,
+                          isSorted ? styles.sortBtnActive : null,
+                        ]
+                          .filter(Boolean)
+                          .join(" ")}
+                        onClick={() => handleSort(col.id)}
+                      >
+                        <span>{col.header}</span>
+                        <SortChevron
+                          direction={isSorted ? sortState!.direction : null}
+                        />
+                      </button>
+                    ) : (
+                      <span className={styles.headerLabel}>{col.header}</span>
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+
+          <tbody ref={tbodyRef} className={styles.tbody}>
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={colSpan} className={styles.emptyCell}>
+                  {emptyState ?? (
+                    <span className={styles.emptyLabel}>No items</span>
+                  )}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row, index) => {
+                const key = rowKey(row);
+                const isSelected = selectedSet.has(key);
+                return (
+                  <tr
+                    key={key}
+                    className={[
+                      styles.row,
+                      isSelected ? styles.rowSelected : null,
+                      selectionMode !== "none" ? styles.rowSelectable : null,
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                    role="row"
+                    aria-selected={
+                      selectionMode !== "none" ? isSelected : undefined
+                    }
+                    tabIndex={focusedIndex === index ? 0 : -1}
+                    onClick={() => toggleRow(key)}
+                    onKeyDown={(e) => handleRowKey(e, index, key)}
+                    onFocus={() => setFocusedIndex(index)}
+                  >
+                    {hasCheckbox && (
+                      <td className={[styles.td, styles.checkboxCol].join(" ")}>
+                        <input
+                          type="checkbox"
+                          className={styles.checkbox}
+                          checked={isSelected}
+                          onChange={() => toggleRow(key)}
+                          onClick={(e) => e.stopPropagation()}
+                          tabIndex={-1}
+                          aria-label={`Select row ${index + 1}`}
+                        />
+                      </td>
+                    )}
+                    {columns.map((col) => (
+                      <td
+                        key={col.id}
+                        className={[
+                          styles.td,
+                          col.align ? ALIGN[col.align] : null,
+                        ]
+                          .filter(Boolean)
+                          .join(" ")}
+                        role="gridcell"
+                      >
+                        {col.cell(row, index)}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/components/ColumnView/index.ts
+++ b/packages/react/src/components/ColumnView/index.ts
@@ -1,0 +1,8 @@
+export { ColumnView } from "./ColumnView";
+export type {
+  ColumnViewProps,
+  ColumnDef,
+  ColumnViewSortState,
+  ColumnViewSelectionMode,
+  SortDirection,
+} from "./ColumnView";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -231,3 +231,12 @@ export type { PathBarProps, PathBarSegment } from "./components/PathBar";
 
 export { ContributionGraph } from "./components/ContributionGraph";
 export type { ContributionGraphProps, ContributionDay } from "./components/ContributionGraph";
+
+export { ColumnView } from "./components/ColumnView";
+export type {
+  ColumnViewProps,
+  ColumnDef,
+  ColumnViewSortState,
+  ColumnViewSelectionMode,
+  SortDirection,
+} from "./components/ColumnView";


### PR DESCRIPTION
Multi-column sortable data table mirroring GtkColumnView/AdwColumnView. Supports controlled sort (asc/desc chevron indicator, aria-sort), single and multiple row selection (checkbox column, select-all with indeterminate state), fixed-height scroll with sticky header (overflow:clip outer + overflow-y:auto inner), roving tabindex keyboard nav (↑↓ arrows, Space/Enter), and dark mode via CSS vars.

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
