### PR TITLE
feat(react): mobile-first audit & OverlaySplitView swipe-to-dismiss —…

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -359,7 +359,7 @@ React hooks that surface every `@gnome-ui/platform` module as idiomatic React st
 
 | Status | Item | Description |
 |--------|------|-------------|
-| ⬜ | **Mobile-first audit** | Review `NavigationSplitView` and `OverlaySplitView` default breakpoints against updated GNOME 50 HIG ("design from most constrained screen first") — issue [#15](https://github.com/ElJijuna/gnome-ui/issues/15) |
+| ✅ | **Mobile-first audit** | Verified 400/550/860 sp thresholds and mobile-first defaults; added swipe-to-dismiss to `OverlaySplitView`; added `NarrowViewport` stories to `NavigationSplitView`, `OverlaySplitView`, and `BreakpointBin` — issue [#15](https://github.com/ElJijuna/gnome-ui/issues/15) |
 
 ### New widgets
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -135,8 +135,8 @@ export default function App() {
 |-----------|-------------|
 | [`useBreakpoint`](https://eljijuna.github.io/gnome-ui/?path=/docs/adaptive-usebreakpoint--docs) | Hook tracking viewport width against GNOME breakpoints (400 / 550 / 860 px) |
 | [`Clamp`](https://eljijuna.github.io/gnome-ui/?path=/docs/adaptive-clamp--docs) | Constrains content to a max width, centering it — mirrors `AdwClamp` |
-| [`NavigationSplitView`](https://eljijuna.github.io/gnome-ui/?path=/docs/adaptive-navigationsplitview--docs) | Two-pane layout that collapses to a single pane at ≤ 400 px |
-| [`OverlaySplitView`](https://eljijuna.github.io/gnome-ui/?path=/docs/adaptive-overlaysplitview--docs) | Sidebar becomes slide-over overlay at ≤ 400 px |
+| [`NavigationSplitView`](https://eljijuna.github.io/gnome-ui/?path=/docs/adaptive-navigationsplitview--docs) | Two-pane layout that collapses to a single pane at ≤ 400 px; sidebar shown first (mobile-first default) |
+| [`OverlaySplitView`](https://eljijuna.github.io/gnome-ui/?path=/docs/adaptive-overlaysplitview--docs) | Sidebar becomes slide-over overlay at ≤ 400 px; supports backdrop, Escape, and swipe-to-dismiss |
 | [`NavigationView`](https://eljijuna.github.io/gnome-ui/?path=/docs/adaptive-navigationview--docs) / `NavigationPage` | Mobile-style navigation stack with forward/back slide transitions — mirrors `AdwNavigationView` |
 | [`ViewSwitcherBar`](https://eljijuna.github.io/gnome-ui/?path=/docs/adaptive-viewswitcherbar--docs) | Bottom bar for `ViewSwitcher` items on narrow screens (≤ 550 px) |
 | [`BreakpointBin`](https://eljijuna.github.io/gnome-ui/?path=/docs/adaptive-breakpointbin--docs) | Applies layout changes when the **component** crosses a size threshold — CSS container queries equivalent |

--- a/packages/react/src/components/BreakpointBin/BreakpointBin.stories.tsx
+++ b/packages/react/src/components/BreakpointBin/BreakpointBin.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { BreakpointBin } from "./BreakpointBin";
+import { GNOME_BREAKPOINTS } from "../../hooks/useBreakpoint";
 import { Text } from "../Text";
 import { Button } from "../Button";
 import { ActionRow } from "../ActionRow";
@@ -51,6 +52,44 @@ const BREAKPOINTS = [
 ];
 
 // ─── Active breakpoint indicator ──────────────────────────────────────────────
+
+export const NarrowViewport: Story = {
+  render: () => (
+    <BreakpointBin
+      breakpoints={[
+        { name: "compact", maxWidth: GNOME_BREAKPOINTS.narrow },
+        { name: "medium",  maxWidth: GNOME_BREAKPOINTS.medium },
+      ]}
+      style={{ width: "100%" }}
+    >
+      {({ activeBreakpoint, width }) => (
+        <div style={{ padding: 16, background: "var(--gnome-card-bg-color)", borderRadius: 12, border: "1px solid rgba(0,0,0,0.08)" }}>
+          <Text variant="title-4">
+            {activeBreakpoint === "compact"
+              ? "Compact (≤ 400 px)"
+              : activeBreakpoint === "medium"
+              ? "Medium (≤ 550 px)"
+              : "Regular (> 550 px)"}
+          </Text>
+          <Text variant="body" color="dim" style={{ marginTop: 4 }}>
+            Container width: {Math.round(width)} px · breakpoint: <strong>{activeBreakpoint ?? "none"}</strong>
+          </Text>
+        </div>
+      )}
+    </BreakpointBin>
+  ),
+  parameters: {
+    controls: { disable: true },
+    viewport: { defaultViewport: "mobile1" },
+    docs: {
+      description: {
+        story:
+          "Uses the canonical GNOME breakpoints (`narrow` = 400 px, `medium` = 550 px). " +
+          "On this mobile viewport the container is in `compact` mode.",
+      },
+    },
+  },
+};
 
 export const ActiveBreakpoint: Story = {
   render: () => (

--- a/packages/react/src/components/NavigationSplitView/NavigationSplitView.stories.tsx
+++ b/packages/react/src/components/NavigationSplitView/NavigationSplitView.stories.tsx
@@ -45,6 +45,69 @@ const items = [
   { id: "settings", label: "Settings", icon: Settings },
 ];
 
+export const NarrowViewport: Story = {
+  render: function NarrowStory() {
+    const [active, setActive]           = useState("home");
+    const [showContent, setShowContent] = useState(false);
+    const { isNarrow }                  = useBreakpoint();
+
+    return (
+      <div style={{ height: 480, display: "flex", flexDirection: "column", border: "1px solid rgba(0,0,0,0.1)", borderRadius: 12, overflow: "hidden" }}>
+        <HeaderBar
+          title={isNarrow && showContent
+            ? items.find(i => i.id === active)?.label
+            : "Mail"}
+          start={isNarrow && showContent
+            ? (
+              <Button variant="flat" aria-label="Back" onClick={() => setShowContent(false)}>
+                <Icon icon={GoPrevious} size="md" aria-hidden />
+                Back
+              </Button>
+            )
+            : undefined}
+        />
+        <NavigationSplitView
+          style={{ flex: 1 }}
+          showContent={showContent}
+          sidebar={
+            <Sidebar style={{ height: "100%" }}>
+              {items.map(({ id, label, icon }) => (
+                <SidebarItem
+                  key={id}
+                  icon={icon}
+                  label={label}
+                  active={active === id}
+                  onClick={() => { setActive(id); setShowContent(true); }}
+                />
+              ))}
+            </Sidebar>
+          }
+          content={
+            <div style={{ padding: 24 }}>
+              <Text variant="title-3">{items.find(i => i.id === active)?.label}</Text>
+              <Text variant="body" color="dim" style={{ marginTop: 8 }}>
+                Tap an item in the sidebar list to drill into the detail view.
+                Use the Back button to return.
+              </Text>
+            </div>
+          }
+        />
+      </div>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
+    viewport: { defaultViewport: "mobile1" },
+    docs: {
+      description: {
+        story:
+          "Narrow viewport (≤ 400 px): only one pane is visible at a time. " +
+          "Tap an item to navigate to the content pane; use Back to return to the sidebar list.",
+      },
+    },
+  },
+};
+
 export const Default: Story = {
   render: function DefaultStory() {
     const [active, setActive]           = useState("home");

--- a/packages/react/src/components/OverlaySplitView/OverlaySplitView.stories.tsx
+++ b/packages/react/src/components/OverlaySplitView/OverlaySplitView.stories.tsx
@@ -45,6 +45,67 @@ const items = [
   { id: "settings", label: "Settings", icon: Settings },
 ];
 
+export const NarrowViewport: Story = {
+  render: function NarrowStory() {
+    const [active, setActive]    = useState("home");
+    const [showSidebar, setShow] = useState(false);
+    const { isNarrow }           = useBreakpoint();
+
+    return (
+      <div style={{ height: 480, display: "flex", flexDirection: "column", border: "1px solid rgba(0,0,0,0.1)", borderRadius: 12, overflow: "hidden" }}>
+        <HeaderBar
+          title={items.find(i => i.id === active)?.label}
+          start={isNarrow
+            ? (
+              <Button variant="flat" shape="circular" aria-label="Toggle sidebar" onClick={() => setShow(s => !s)}>
+                <Icon icon={ViewSidebar} size="md" aria-hidden />
+              </Button>
+            )
+            : undefined}
+        />
+        <OverlaySplitView
+          style={{ flex: 1 }}
+          showSidebar={showSidebar}
+          onClose={() => setShow(false)}
+          sidebar={
+            <Sidebar style={{ height: "100%" }}>
+              {items.map(({ id, label, icon }) => (
+                <SidebarItem
+                  key={id}
+                  icon={icon}
+                  label={label}
+                  active={active === id}
+                  onClick={() => { setActive(id); setShow(false); }}
+                />
+              ))}
+            </Sidebar>
+          }
+          content={
+            <div style={{ padding: 24 }}>
+              <Text variant="title-3">{items.find(i => i.id === active)?.label}</Text>
+              <Text variant="body" color="dim" style={{ marginTop: 8 }}>
+                Tap the sidebar icon to open the overlay. Tap the backdrop,
+                press Escape, or swipe the sidebar toward the edge to close it.
+              </Text>
+            </div>
+          }
+        />
+      </div>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
+    viewport: { defaultViewport: "mobile1" },
+    docs: {
+      description: {
+        story:
+          "Narrow viewport (≤ 400 px): content fills full width, sidebar slides in as an overlay. " +
+          "Close via backdrop tap, Escape, or swipe toward the leading edge.",
+      },
+    },
+  },
+};
+
 export const Default: Story = {
   render: function DefaultStory() {
     const [active, setActive]         = useState("home");

--- a/packages/react/src/components/OverlaySplitView/OverlaySplitView.tsx
+++ b/packages/react/src/components/OverlaySplitView/OverlaySplitView.tsx
@@ -101,6 +101,30 @@ export function OverlaySplitView({
 
   const isEnd = sidebarPosition === "end";
 
+  // Swipe-to-dismiss: drag the sidebar in the close direction to trigger onClose
+  useEffect(() => {
+    if (!isNarrow || !showSidebar) return;
+    const el = sidebarRef.current;
+    if (!el) return;
+
+    let startX = 0;
+    const THRESHOLD = 80;
+
+    const onTouchStart = (e: TouchEvent) => { startX = e.touches[0].clientX; };
+    const onTouchEnd   = (e: TouchEvent) => {
+      const dx = e.changedTouches[0].clientX - startX;
+      const closeSwipe = isEnd ? dx > THRESHOLD : dx < -THRESHOLD;
+      if (closeSwipe) onClose?.();
+    };
+
+    el.addEventListener("touchstart", onTouchStart, { passive: true });
+    el.addEventListener("touchend",   onTouchEnd,   { passive: true });
+    return () => {
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchend",   onTouchEnd);
+    };
+  }, [isNarrow, showSidebar, isEnd, onClose]);
+
   return (
     <div
       className={[


### PR DESCRIPTION
… closes #15

- Verified 400/550/860 sp breakpoints are current in GNOME 50 HIG (no changes needed)
- NavigationSplitView: showContent=false default confirmed correct (sidebar first)
- OverlaySplitView: add swipe-to-dismiss (touchstart/touchend, 80 px threshold, respects sidebarPosition start/end)
- Add NarrowViewport story to NavigationSplitView, OverlaySplitView, BreakpointBin (viewport: mobile1 so the narrow layout is visible without resizing)
- BreakpointBin NarrowViewport story uses canonical GNOME_BREAKPOINTS constants

## Changes

- [ ] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [x] Keyboard accessible
- [ ] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
