### PR TITLE
feat(core): add [data-theme] support to tokens.css for runtime theme …

### DIFF
--- a/packages/charts/.storybook/preview.tsx
+++ b/packages/charts/.storybook/preview.tsx
@@ -1,8 +1,42 @@
 import type { Preview } from "@storybook/react";
+import { useEffect } from "react";
 import { parameters as docsParameters } from "@storybook/addon-docs/preview";
 import "@gnome-ui/core/styles";
 
 const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: "Color theme",
+      toolbar: {
+        title: "Theme",
+        icon: "paintbrush",
+        items: [
+          { value: "", title: "System (OS preference)" },
+          { value: "light", title: "Light" },
+          { value: "dark", title: "Dark" },
+          { value: "high-contrast", title: "High Contrast" },
+          { value: "high-contrast-dark", title: "High Contrast Dark" },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: "",
+  },
+  decorators: [
+    (Story, context) => {
+      const { theme } = context.globals;
+      useEffect(() => {
+        if (theme) {
+          document.documentElement.setAttribute("data-theme", theme);
+        } else {
+          document.documentElement.removeAttribute("data-theme");
+        }
+      }, [theme]);
+      return <Story />;
+    },
+  ],
   parameters: {
     layout: "fullscreen",
     backgrounds: {

--- a/packages/core/src/tokens.css
+++ b/packages/core/src/tokens.css
@@ -310,6 +310,171 @@
   }
 }
 
+/* ─── [data-theme] overrides ─────────────────────────────────────── */
+/*
+ * Apply data-theme to <html> or any container element to force a specific
+ * theme regardless of the OS preference (prefers-color-scheme).
+ *
+ * Usage:
+ *   <html data-theme="dark">   → force dark mode
+ *   <html data-theme="light">  → force light mode
+ *   <html data-theme="high-contrast">      → force high-contrast light
+ *   <html data-theme="high-contrast-dark"> → force high-contrast dark
+ *
+ * These selectors come after the @media blocks in source order so they
+ * win the cascade at equal specificity without needing !important.
+ */
+
+[data-theme="dark"] {
+  --gnome-accent-color: var(--gnome-blue-2);
+  --gnome-accent-bg-color: var(--gnome-blue-3);
+
+  --gnome-window-bg-color: #242424;
+  --gnome-window-fg-color: rgba(255, 255, 255, 0.87);
+
+  --gnome-view-bg-color: #1e1e1e;
+  --gnome-view-fg-color: rgba(255, 255, 255, 0.87);
+
+  --gnome-card-bg-color: #383838;
+  --gnome-card-fg-color: rgba(255, 255, 255, 0.87);
+  --gnome-card-shade-color: rgba(0, 0, 0, 0.36);
+
+  --gnome-headerbar-bg-color: #303030;
+  --gnome-headerbar-fg-color: rgba(255, 255, 255, 0.87);
+  --gnome-headerbar-border-color: rgba(255, 255, 255, 0.1);
+  --gnome-headerbar-shade-color: rgba(0, 0, 0, 0.36);
+
+  --gnome-sidebar-bg-color: #303030;
+  --gnome-sidebar-fg-color: rgba(255, 255, 255, 0.87);
+
+  --gnome-popover-bg-color: #383838;
+  --gnome-popover-fg-color: rgba(255, 255, 255, 0.87);
+
+  --gnome-dialog-bg-color: #242424;
+  --gnome-dialog-fg-color: rgba(255, 255, 255, 0.87);
+
+  --gnome-hover-overlay: rgba(255, 255, 255, 0.08);
+  --gnome-active-overlay: rgba(255, 255, 255, 0.14);
+  --gnome-border-subtle: rgba(255, 255, 255, 0.15);
+  --gnome-divider-color: rgba(255, 255, 255, 0.07);
+}
+
+[data-theme="light"] {
+  --gnome-accent-color: var(--gnome-blue-3);
+  --gnome-accent-bg-color: var(--gnome-blue-3);
+
+  --gnome-window-bg-color: #fafafa;
+  --gnome-window-fg-color: rgba(0, 0, 0, 0.8);
+
+  --gnome-view-bg-color: #ffffff;
+  --gnome-view-fg-color: rgba(0, 0, 0, 0.8);
+
+  --gnome-card-bg-color: #ffffff;
+  --gnome-card-fg-color: rgba(0, 0, 0, 0.8);
+  --gnome-card-shade-color: rgba(0, 0, 0, 0.07);
+
+  --gnome-headerbar-bg-color: #ebebeb;
+  --gnome-headerbar-fg-color: rgba(0, 0, 0, 0.8);
+  --gnome-headerbar-border-color: rgba(0, 0, 0, 0.12);
+  --gnome-headerbar-shade-color: rgba(0, 0, 0, 0.12);
+
+  --gnome-sidebar-bg-color: #ebebeb;
+  --gnome-sidebar-fg-color: rgba(0, 0, 0, 0.8);
+
+  --gnome-popover-bg-color: #ffffff;
+  --gnome-popover-fg-color: rgba(0, 0, 0, 0.8);
+
+  --gnome-dialog-bg-color: #fafafa;
+  --gnome-dialog-fg-color: rgba(0, 0, 0, 0.8);
+
+  --gnome-hover-overlay: rgba(0, 0, 0, 0.06);
+  --gnome-active-overlay: rgba(0, 0, 0, 0.12);
+  --gnome-border-subtle: rgba(0, 0, 0, 0.15);
+  --gnome-divider-color: rgba(0, 0, 0, 0.07);
+}
+
+[data-theme="high-contrast"] {
+  --gnome-accent-color: var(--gnome-blue-5);
+  --gnome-accent-bg-color: var(--gnome-blue-5);
+
+  --gnome-destructive-color: var(--gnome-red-5);
+  --gnome-destructive-bg-color: var(--gnome-red-5);
+
+  --gnome-success-color: var(--gnome-green-5);
+  --gnome-success-bg-color: var(--gnome-green-5);
+
+  --gnome-warning-color: var(--gnome-orange-5);
+  --gnome-warning-bg-color: var(--gnome-orange-4);
+
+  --gnome-error-color: var(--gnome-red-5);
+  --gnome-error-bg-color: var(--gnome-red-5);
+
+  --gnome-hover-overlay: rgba(0, 0, 0, 0.12);
+  --gnome-active-overlay: rgba(0, 0, 0, 0.22);
+  --gnome-border-subtle: rgba(0, 0, 0, 0.5);
+  --gnome-divider-color: rgba(0, 0, 0, 0.2);
+
+  --gnome-focus-ring-color: var(--gnome-blue-5);
+  --gnome-focus-ring-width: 3px;
+
+  --gnome-opacity-disabled: 0.6;
+  --gnome-opacity-dim: 0.7;
+  --gnome-opacity-border: 0.4;
+}
+
+[data-theme="high-contrast-dark"] {
+  --gnome-accent-color: var(--gnome-blue-1);
+  --gnome-accent-bg-color: var(--gnome-blue-2);
+
+  --gnome-destructive-color: var(--gnome-red-1);
+  --gnome-destructive-bg-color: var(--gnome-red-2);
+
+  --gnome-success-color: var(--gnome-green-1);
+  --gnome-success-bg-color: var(--gnome-green-2);
+
+  --gnome-warning-color: var(--gnome-yellow-1);
+  --gnome-warning-bg-color: var(--gnome-yellow-2);
+  --gnome-warning-fg-color: rgba(0, 0, 0, 0.9);
+
+  --gnome-error-color: var(--gnome-red-1);
+  --gnome-error-bg-color: var(--gnome-red-2);
+
+  --gnome-window-bg-color: #242424;
+  --gnome-window-fg-color: #ffffff;
+
+  --gnome-view-bg-color: #1e1e1e;
+  --gnome-view-fg-color: #ffffff;
+
+  --gnome-card-bg-color: #383838;
+  --gnome-card-fg-color: #ffffff;
+  --gnome-card-shade-color: rgba(0, 0, 0, 0.36);
+
+  --gnome-headerbar-bg-color: #303030;
+  --gnome-headerbar-fg-color: #ffffff;
+  --gnome-headerbar-border-color: rgba(255, 255, 255, 0.3);
+  --gnome-headerbar-shade-color: rgba(0, 0, 0, 0.36);
+
+  --gnome-sidebar-bg-color: #303030;
+  --gnome-sidebar-fg-color: #ffffff;
+
+  --gnome-popover-bg-color: #383838;
+  --gnome-popover-fg-color: #ffffff;
+
+  --gnome-dialog-bg-color: #242424;
+  --gnome-dialog-fg-color: #ffffff;
+
+  --gnome-hover-overlay: rgba(255, 255, 255, 0.12);
+  --gnome-active-overlay: rgba(255, 255, 255, 0.22);
+  --gnome-border-subtle: rgba(255, 255, 255, 0.5);
+  --gnome-divider-color: rgba(255, 255, 255, 0.2);
+
+  --gnome-focus-ring-color: var(--gnome-blue-1);
+
+  --gnome-opacity-disabled: 0.6;
+  --gnome-opacity-dim: 0.7;
+  --gnome-opacity-border: 0.4;
+}
+
 /* ─── Base Reset ─────────────────────────────────────────────────── */
 
 *,

--- a/packages/icons/.storybook/preview.ts
+++ b/packages/icons/.storybook/preview.ts
@@ -2,6 +2,37 @@ import type { Preview } from "@storybook/react";
 import { parameters as docsParameters } from "@storybook/addon-docs/preview";
 
 const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: "Color theme",
+      toolbar: {
+        title: "Theme",
+        icon: "paintbrush",
+        items: [
+          { value: "", title: "System (OS preference)" },
+          { value: "light", title: "Light" },
+          { value: "dark", title: "Dark" },
+          { value: "high-contrast", title: "High Contrast" },
+          { value: "high-contrast-dark", title: "High Contrast Dark" },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: "",
+  },
+  decorators: [
+    (Story, context) => {
+      const { theme } = context.globals;
+      if (theme) {
+        document.documentElement.setAttribute("data-theme", theme);
+      } else {
+        document.documentElement.removeAttribute("data-theme");
+      }
+      return Story();
+    },
+  ],
   parameters: {
     layout: "fullscreen",
     backgrounds: {

--- a/packages/layout/.storybook/preview.tsx
+++ b/packages/layout/.storybook/preview.tsx
@@ -1,8 +1,43 @@
 import type { Preview } from "@storybook/react";
+import { useEffect } from "react";
 import { parameters as docsParameters } from "@storybook/addon-docs/preview";
 import "@gnome-ui/react/styles";
+import "@gnome-ui/core/styles"; // source import: ensures live [data-theme] tokens override the dist bundle
 
 const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: "Color theme",
+      toolbar: {
+        title: "Theme",
+        icon: "paintbrush",
+        items: [
+          { value: "", title: "System (OS preference)" },
+          { value: "light", title: "Light" },
+          { value: "dark", title: "Dark" },
+          { value: "high-contrast", title: "High Contrast" },
+          { value: "high-contrast-dark", title: "High Contrast Dark" },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: "",
+  },
+  decorators: [
+    (Story, context) => {
+      const { theme } = context.globals;
+      useEffect(() => {
+        if (theme) {
+          document.documentElement.setAttribute("data-theme", theme);
+        } else {
+          document.documentElement.removeAttribute("data-theme");
+        }
+      }, [theme]);
+      return <Story />;
+    },
+  ],
   parameters: {
     layout: "fullscreen",
     backgrounds: {

--- a/packages/layout/src/components/CounterCard/CounterCard.module.css
+++ b/packages/layout/src/components/CounterCard/CounterCard.module.css
@@ -30,6 +30,7 @@
 }
 
 .affix {
+  font-family: var(--gnome-font-family);
   font-size: 0.9375rem;
   line-height: 1;
   color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));

--- a/packages/layout/src/components/PanelCard/PanelCard.module.css
+++ b/packages/layout/src/components/PanelCard/PanelCard.module.css
@@ -139,14 +139,3 @@
   }
 }
 
-/* ─── Dark mode ──────────────────────────────────────────────────────────── */
-
-@media (prefers-color-scheme: dark) {
-  .toggle:hover {
-    background-color: rgba(255, 255, 255, 0.08);
-  }
-
-  .toggle:active {
-    background-color: rgba(255, 255, 255, 0.14);
-  }
-}

--- a/packages/layout/src/components/UserCard/UserCard.module.css
+++ b/packages/layout/src/components/UserCard/UserCard.module.css
@@ -11,7 +11,16 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 12px 10px;
+  padding: 10px 12px;
+}
+
+/* vertical: avatar centrado arriba, identity centrado abajo */
+.headerVertical {
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 16px 12px 12px;
+  gap: 8px;
 }
 
 .identity {
@@ -19,6 +28,10 @@
   flex-direction: column;
   gap: 1px;
   min-width: 0;
+}
+
+.identityVertical {
+  align-items: center;
 }
 
 .name {
@@ -92,18 +105,3 @@
   background-color: color-mix(in srgb, var(--gnome-destructive-color, #e01b24) 18%, transparent);
 }
 
-/* ─── Dark mode ──────────────────────────────────────────────────────────────── */
-
-@media (prefers-color-scheme: dark) {
-  .separator {
-    background: rgba(255, 255, 255, 0.08);
-  }
-
-  .action:hover {
-    background-color: rgba(255, 255, 255, 0.08);
-  }
-
-  .action:active {
-    background-color: rgba(255, 255, 255, 0.14);
-  }
-}

--- a/packages/layout/src/components/UserCard/UserCard.stories.tsx
+++ b/packages/layout/src/components/UserCard/UserCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Card, Popover, Avatar, Button } from "@gnome-ui/react";
+import { Card, Popover, Avatar } from "@gnome-ui/react";
 import { UserCard } from "./UserCard";
 
 const meta: Meta<typeof UserCard> = {
@@ -48,7 +48,7 @@ const defaultActions = [
   { label: "Sign Out",         onClick: () => alert("sign out"), variant: "destructive" as const },
 ];
 
-// ─── Default ──────────────────────────────────────────────────────────────────
+// ─── Default (vertical) ───────────────────────────────────────────────────────
 
 export const Default: Story = {
   args: {
@@ -58,7 +58,23 @@ export const Default: Story = {
   },
   parameters: {
     docs: {
-      description: { story: "Full user card: avatar, name, e-mail, and three actions with an auto-separator before Sign Out." },
+      description: { story: "Default orientation (`vertical`): avatar centered on top, identity below, actions at the bottom." },
+    },
+  },
+};
+
+// ─── Horizontal ───────────────────────────────────────────────────────────────
+
+export const Horizontal: Story = {
+  args: {
+    name: "Ada Lovelace",
+    email: "ada@gnome.org",
+    orientation: "horizontal",
+    actions: defaultActions,
+  },
+  parameters: {
+    docs: {
+      description: { story: "`orientation=\"horizontal\"` places the avatar on the left — suited for popovers and compact sidebar footers." },
     },
   },
 };

--- a/packages/layout/src/components/UserCard/UserCard.tsx
+++ b/packages/layout/src/components/UserCard/UserCard.tsx
@@ -28,6 +28,12 @@ export interface UserCardProps extends HTMLAttributes<HTMLDivElement> {
    */
   avatarSize?: AvatarSize;
   /**
+   * Layout orientation of the identity header.
+   * - `"vertical"` (default) — avatar centered on top, name/email centered below.
+   * - `"horizontal"` — avatar on the left, name/email on the right.
+   */
+  orientation?: "vertical" | "horizontal";
+  /**
    * Action items rendered below the identity header.
    * A separator is automatically inserted before the first
    * `"destructive"` action when non-destructive actions precede it.
@@ -69,12 +75,15 @@ export function UserCard({
   avatarSrc,
   avatarColor,
   avatarSize = "md",
+  orientation = "vertical",
   actions = [],
   minWidth = 200,
   className,
   style,
   ...props
 }: UserCardProps) {
+  const isVertical = orientation === "vertical";
+
   // Insert a separator before the first destructive action when there are
   // non-destructive actions above it.
   const hasNonDestructiveBefore = (index: number) =>
@@ -87,14 +96,14 @@ export function UserCard({
       {...props}
     >
       {/* ── Header ── */}
-      <div className={styles.header}>
+      <div className={[styles.header, isVertical ? styles.headerVertical : null].filter(Boolean).join(" ")}>
         <Avatar
           name={name}
           src={avatarSrc}
           color={avatarColor}
           size={avatarSize}
         />
-        <div className={styles.identity}>
+        <div className={[styles.identity, isVertical ? styles.identityVertical : null].filter(Boolean).join(" ")}>
           <Text variant="body" className={styles.name}>{name}</Text>
           {email && (
             <Text variant="caption" color="dim" className={styles.email}>

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import type { Preview } from "@storybook/react";
 import type { ReactNode } from "react";
+import { useEffect } from "react";
 import { parameters as docsParameters } from "@storybook/addon-docs/preview";
 import "@gnome-ui/core/styles";
 
@@ -28,7 +29,38 @@ function CenteredDecorator({ children }: { children: ReactNode }) {
 }
 
 const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: "Color theme",
+      toolbar: {
+        title: "Theme",
+        icon: "paintbrush",
+        items: [
+          { value: "", title: "System (OS preference)" },
+          { value: "light", title: "Light" },
+          { value: "dark", title: "Dark" },
+          { value: "high-contrast", title: "High Contrast" },
+          { value: "high-contrast-dark", title: "High Contrast Dark" },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: "",
+  },
   decorators: [
+    (Story, context) => {
+      const { theme } = context.globals;
+      useEffect(() => {
+        if (theme) {
+          document.documentElement.setAttribute("data-theme", theme);
+        } else {
+          document.documentElement.removeAttribute("data-theme");
+        }
+      }, [theme]);
+      return <Story />;
+    },
     (Story) => (
       <CenteredDecorator>
         <Story />

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,10 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./styles": "./dist/style.css"
+    "./styles": {
+      "types": "./src/style.d.ts",
+      "default": "./dist/style.css"
+    }
   },
   "files": [
     "dist"

--- a/packages/react/src/style.d.ts
+++ b/packages/react/src/style.d.ts
@@ -1,0 +1,1 @@
+// CSS side-effect module — no exports


### PR DESCRIPTION

## What

overrides (closes #27) and add orientation prop in UserCard.

## Why

clients does change or override theme from client app.

## Changes

- [ ] New component
- [x] Bug fix
- [x] Enhancement
- [ ] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
