### PR TITLE
feat: add useBreakpoint hook — isMobile, isTablet, isDesktop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12976,7 +12976,7 @@
     },
     "packages/charts": {
       "name": "@gnome-ui/charts",
-      "version": "1.1.0",
+      "version": "1.13.2",
       "dependencies": {
         "@gnome-ui/core": "*",
         "recharts": "^2.15.3"
@@ -13002,20 +13002,25 @@
     },
     "packages/core": {
       "name": "@gnome-ui/core",
-      "version": "1.14.0"
+      "version": "1.27.0"
     },
     "packages/hooks": {
       "name": "@gnome-ui/hooks",
-      "version": "1.0.0",
+      "version": "1.12.2",
       "dependencies": {
         "@gnome-ui/platform": "*"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.1",
+        "jsdom": "^29.0.2",
         "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "vite": "^8.0.3",
-        "vite-plugin-dts": "^4.5.4"
+        "vite-plugin-dts": "^4.5.4",
+        "vitest": "^4.1.4"
       },
       "peerDependencies": {
         "react": "^19.0.0"
@@ -13023,15 +13028,25 @@
     },
     "packages/icons": {
       "name": "@gnome-ui/icons",
-      "version": "1.12.0",
+      "version": "1.24.2",
       "devDependencies": {
+        "@storybook/addon-a11y": "^10.3.3",
+        "@storybook/addon-docs": "^10.3.3",
+        "@storybook/react": "^10.3.3",
+        "@storybook/react-vite": "^10.3.3",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^6.0.1",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "storybook": "^10.3.3",
         "vite": "^8.0.3",
         "vite-plugin-dts": "^4.5.4"
       }
     },
     "packages/layout": {
       "name": "@gnome-ui/layout",
-      "version": "0.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@gnome-ui/core": "*"
       },
@@ -13065,7 +13080,7 @@
     },
     "packages/platform": {
       "name": "@gnome-ui/platform",
-      "version": "1.0.0",
+      "version": "1.12.2",
       "devDependencies": {
         "vite": "^8.0.3",
         "vite-plugin-dts": "^4.5.4"
@@ -13073,7 +13088,7 @@
     },
     "packages/react": {
       "name": "@gnome-ui/react",
-      "version": "1.12.0",
+      "version": "1.23.2",
       "dependencies": {
         "@gnome-ui/core": "*",
         "@gnome-ui/icons": "*"

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -19,6 +19,12 @@ Requires `@gnome-ui/platform` and `react` ≥ 19 as peer dependencies.
 
 ## Hooks
 
+### Viewport
+
+| Hook | Returns | Description |
+| --- | --- | --- |
+| `useBreakpoint()` | `BreakpointInfo` | Reactive `isMobile`, `isTablet`, `isDesktop` flags based on GNOME HIG breakpoints |
+
 ### Platform & runtime
 
 | Hook | Returns | Description |
@@ -39,6 +45,28 @@ Requires `@gnome-ui/platform` and `react` ≥ 19 as peer dependencies.
 | `useWindowState()` | `{ maximized, fullscreen, ... }` | Reactive window state with matching setters |
 
 ## Examples
+
+### Adapt layout to viewport size
+
+```tsx
+import { useBreakpoint } from "@gnome-ui/hooks";
+
+export function AdaptiveLayout() {
+  const { isMobile, isDesktop } = useBreakpoint();
+
+  return isDesktop ? <SidebarLayout /> : <StackedLayout />;
+}
+```
+
+Breakpoints follow the GNOME HIG adaptive layout recommendations:
+
+| Flag | Range |
+| --- | --- |
+| `isMobile` | `width < 480 px` |
+| `isTablet` | `480 px ≤ width < 1024 px` |
+| `isDesktop` | `width ≥ 1024 px` |
+
+SSR-safe: defaults to `isDesktop: true` when `window` is not available.
 
 ### Detect GNOME WebView context
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -18,7 +18,10 @@
   ],
   "scripts": {
     "build": "tsc && vite build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "publishConfig": {
     "access": "public"
@@ -30,10 +33,15 @@
     "react": "^19.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "^29.0.2",
     "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "vite": "^8.0.3",
-    "vite-plugin-dts": "^4.5.4"
+    "vite-plugin-dts": "^4.5.4",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./useRuntime";
 export * from "./usePlatform";
+export * from "./useBreakpoint";
 export * from "./useNativeEvent";
 export * from "./useSettings";
 export * from "./useNotification";

--- a/packages/hooks/src/test/setup.ts
+++ b/packages/hooks/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/packages/hooks/src/useBreakpoint/index.ts
+++ b/packages/hooks/src/useBreakpoint/index.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+
+export interface BreakpointInfo {
+  /** `true` when viewport width is below 480 px. */
+  isMobile: boolean;
+  /** `true` when viewport width is between 480 px and 1023 px. */
+  isTablet: boolean;
+  /** `true` when viewport width is 1024 px or wider. */
+  isDesktop: boolean;
+}
+
+const MOBILE  = "(max-width: 479px)";
+const TABLET  = "(min-width: 480px) and (max-width: 1023px)";
+const DESKTOP = "(min-width: 1024px)";
+
+function getSnapshot(): BreakpointInfo {
+  if (typeof window === "undefined") {
+    return { isMobile: false, isTablet: false, isDesktop: true };
+  }
+  return {
+    isMobile:  window.matchMedia(MOBILE).matches,
+    isTablet:  window.matchMedia(TABLET).matches,
+    isDesktop: window.matchMedia(DESKTOP).matches,
+  };
+}
+
+/**
+ * Reactive viewport-size flags based on GNOME HIG adaptive layout breakpoints.
+ *
+ * @example
+ * const { isMobile, isTablet, isDesktop } = useBreakpoint();
+ * if (isMobile) return <CompactView />;
+ */
+export function useBreakpoint(): BreakpointInfo {
+  const [state, setState] = useState<BreakpointInfo>(getSnapshot);
+
+  useEffect(() => {
+    const queries = [
+      window.matchMedia(MOBILE),
+      window.matchMedia(TABLET),
+      window.matchMedia(DESKTOP),
+    ];
+    const handler = () => setState(getSnapshot());
+    queries.forEach((mql) => mql.addEventListener("change", handler));
+    return () => queries.forEach((mql) => mql.removeEventListener("change", handler));
+  }, []);
+
+  return state;
+}

--- a/packages/hooks/src/useBreakpoint/useBreakpoint.test.ts
+++ b/packages/hooks/src/useBreakpoint/useBreakpoint.test.ts
@@ -1,0 +1,130 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useBreakpoint } from "./index";
+
+// ─── matchMedia mock ──────────────────────────────────────────────────────────
+// jsdom does not implement matchMedia, so we define it via Object.defineProperty.
+
+type ChangeHandler = (e: { matches: boolean }) => void;
+
+function createMQL(matches: boolean) {
+  const listeners: ChangeHandler[] = [];
+  const mql = {
+    matches,
+    addEventListener: vi.fn((_: string, fn: ChangeHandler) => listeners.push(fn)),
+    removeEventListener: vi.fn((_: string, fn: ChangeHandler) => {
+      const i = listeners.indexOf(fn);
+      if (i !== -1) listeners.splice(i, 1);
+    }),
+    trigger(nextMatches: boolean) {
+      mql.matches = nextMatches; // update before handler so getSnapshot() reads the new value
+      listeners.forEach((fn) => fn({ matches: nextMatches }));
+    },
+  };
+  return mql;
+}
+
+type MockMQL = ReturnType<typeof createMQL>;
+
+let mobileMQL:  MockMQL;
+let tabletMQL:  MockMQL;
+let desktopMQL: MockMQL;
+
+function mockMatchMedia(mobile: boolean, tablet: boolean, desktop: boolean) {
+  mobileMQL  = createMQL(mobile);
+  tabletMQL  = createMQL(tablet);
+  desktopMQL = createMQL(desktop);
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn((query: string) => {
+      if (query === "(max-width: 479px)")                          return mobileMQL;
+      if (query === "(min-width: 480px) and (max-width: 1023px)") return tabletMQL;
+      if (query === "(min-width: 1024px)")                        return desktopMQL;
+      return createMQL(false);
+    }),
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("useBreakpoint", () => {
+
+  describe("initial state", () => {
+    it("returns isDesktop=true when viewport ≥ 1024 px", () => {
+      mockMatchMedia(false, false, true);
+      const { result } = renderHook(() => useBreakpoint());
+      expect(result.current).toEqual({ isMobile: false, isTablet: false, isDesktop: true });
+    });
+
+    it("returns isTablet=true when viewport is 480–1023 px", () => {
+      mockMatchMedia(false, true, false);
+      const { result } = renderHook(() => useBreakpoint());
+      expect(result.current).toEqual({ isMobile: false, isTablet: true, isDesktop: false });
+    });
+
+    it("returns isMobile=true when viewport < 480 px", () => {
+      mockMatchMedia(true, false, false);
+      const { result } = renderHook(() => useBreakpoint());
+      expect(result.current).toEqual({ isMobile: true, isTablet: false, isDesktop: false });
+    });
+  });
+
+  describe("reactivity", () => {
+    beforeEach(() => mockMatchMedia(false, false, true));
+
+    it("updates to isMobile when the mobile query fires", () => {
+      const { result } = renderHook(() => useBreakpoint());
+
+      act(() => {
+        desktopMQL.trigger(false);
+        mobileMQL.trigger(true);
+      });
+
+      expect(result.current.isMobile).toBe(true);
+      expect(result.current.isDesktop).toBe(false);
+    });
+
+    it("updates to isTablet when the tablet query fires", () => {
+      const { result } = renderHook(() => useBreakpoint());
+
+      act(() => {
+        desktopMQL.trigger(false);
+        tabletMQL.trigger(true);
+      });
+
+      expect(result.current.isTablet).toBe(true);
+      expect(result.current.isDesktop).toBe(false);
+    });
+
+    it("updates back to isDesktop after switching from mobile", () => {
+      const { result } = renderHook(() => useBreakpoint());
+
+      act(() => {
+        desktopMQL.trigger(false);
+        mobileMQL.trigger(true);
+      });
+      expect(result.current.isMobile).toBe(true);
+
+      act(() => {
+        mobileMQL.trigger(false);
+        desktopMQL.trigger(true);
+      });
+      expect(result.current.isDesktop).toBe(true);
+      expect(result.current.isMobile).toBe(false);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("removes all three listeners on unmount", () => {
+      mockMatchMedia(false, false, true);
+      const { unmount } = renderHook(() => useBreakpoint());
+      unmount();
+      expect(mobileMQL.removeEventListener).toHaveBeenCalledOnce();
+      expect(tabletMQL.removeEventListener).toHaveBeenCalledOnce();
+      expect(desktopMQL.removeEventListener).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/hooks/tsconfig.test.json
+++ b/packages/hooks/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["@testing-library/jest-dom"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/test/**/*"
+  ]
+}

--- a/packages/hooks/vitest.config.ts
+++ b/packages/hooks/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+    globals: true,
+    passWithNoTests: true,
+    typecheck: {
+      tsconfig: "./tsconfig.test.json",
+    },
+  },
+});


### PR DESCRIPTION

## What

update @gnome-ui/hooks to add hook useBreakpoint to return values 
- isMobile
- isTablet
- isDesktop

closes #29 

## Why

needs this information to use in @gnome-ui/layout and was made available for third-party consumer projects 

## Changes

- [ ] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [ ] All styles use CSS custom properties from `@gnome-ui/core`
- [ ] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [ ] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
