### PR TITLE
Feature/31 addon storybook viewport

### DIFF
--- a/packages/charts/.storybook/preview.tsx
+++ b/packages/charts/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Preview } from "@storybook/react";
 import { useEffect } from "react";
 import { parameters as docsParameters } from "@storybook/addon-docs/preview";
+import { INITIAL_VIEWPORTS } from 'storybook/viewport';
 import "@gnome-ui/core/styles";
 
 const preview: Preview = {
@@ -47,14 +48,7 @@ const preview: Preview = {
       ],
     },
     viewport: {
-      options: {
-        mobilePortrait:  { name: "Mobile Portrait",  styles: { width: "390px",  height: "844px"  }, type: "mobile"  },
-        mobileLandscape: { name: "Mobile Landscape",  styles: { width: "844px",  height: "390px"  }, type: "mobile"  },
-        tabletPortrait:  { name: "Tablet Portrait",  styles: { width: "768px",  height: "1024px" }, type: "tablet"  },
-        tabletLandscape: { name: "Tablet Landscape",  styles: { width: "1024px", height: "768px"  }, type: "tablet"  },
-        desktop:         { name: "Desktop",          styles: { width: "1280px", height: "800px"  }, type: "desktop" },
-        largeDesktop:    { name: "Large Desktop",    styles: { width: "1920px", height: "1080px" }, type: "desktop" },
-      },
+      options: INITIAL_VIEWPORTS,
     },
     controls: {
       matchers: {

--- a/packages/charts/.storybook/preview.tsx
+++ b/packages/charts/.storybook/preview.tsx
@@ -46,6 +46,16 @@ const preview: Preview = {
         { name: "gnome-dark", value: "#242424" },
       ],
     },
+    viewport: {
+      options: {
+        mobilePortrait:  { name: "Mobile Portrait",  styles: { width: "390px",  height: "844px"  }, type: "mobile"  },
+        mobileLandscape: { name: "Mobile Landscape",  styles: { width: "844px",  height: "390px"  }, type: "mobile"  },
+        tabletPortrait:  { name: "Tablet Portrait",  styles: { width: "768px",  height: "1024px" }, type: "tablet"  },
+        tabletLandscape: { name: "Tablet Landscape",  styles: { width: "1024px", height: "768px"  }, type: "tablet"  },
+        desktop:         { name: "Desktop",          styles: { width: "1280px", height: "800px"  }, type: "desktop" },
+        largeDesktop:    { name: "Large Desktop",    styles: { width: "1920px", height: "1080px" }, type: "desktop" },
+      },
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/packages/icons/.storybook/preview.ts
+++ b/packages/icons/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview } from "@storybook/react";
 import { parameters as docsParameters } from "@storybook/addon-docs/preview";
+import { INITIAL_VIEWPORTS } from 'storybook/viewport';
 
 const preview: Preview = {
   globalTypes: {
@@ -43,14 +44,7 @@ const preview: Preview = {
       ],
     },
     viewport: {
-      options: {
-        mobilePortrait:  { name: "Mobile Portrait",  styles: { width: "390px",  height: "844px"  }, type: "mobile"  },
-        mobileLandscape: { name: "Mobile Landscape",  styles: { width: "844px",  height: "390px"  }, type: "mobile"  },
-        tabletPortrait:  { name: "Tablet Portrait",  styles: { width: "768px",  height: "1024px" }, type: "tablet"  },
-        tabletLandscape: { name: "Tablet Landscape",  styles: { width: "1024px", height: "768px"  }, type: "tablet"  },
-        desktop:         { name: "Desktop",          styles: { width: "1280px", height: "800px"  }, type: "desktop" },
-        largeDesktop:    { name: "Large Desktop",    styles: { width: "1920px", height: "1080px" }, type: "desktop" },
-      },
+      options: INITIAL_VIEWPORTS,
     },
     controls: {
       matchers: {

--- a/packages/icons/.storybook/preview.ts
+++ b/packages/icons/.storybook/preview.ts
@@ -42,6 +42,16 @@ const preview: Preview = {
         { name: "gnome-dark", value: "#242424" },
       ],
     },
+    viewport: {
+      options: {
+        mobilePortrait:  { name: "Mobile Portrait",  styles: { width: "390px",  height: "844px"  }, type: "mobile"  },
+        mobileLandscape: { name: "Mobile Landscape",  styles: { width: "844px",  height: "390px"  }, type: "mobile"  },
+        tabletPortrait:  { name: "Tablet Portrait",  styles: { width: "768px",  height: "1024px" }, type: "tablet"  },
+        tabletLandscape: { name: "Tablet Landscape",  styles: { width: "1024px", height: "768px"  }, type: "tablet"  },
+        desktop:         { name: "Desktop",          styles: { width: "1280px", height: "800px"  }, type: "desktop" },
+        largeDesktop:    { name: "Large Desktop",    styles: { width: "1920px", height: "1080px" }, type: "desktop" },
+      },
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/packages/layout/.storybook/preview.tsx
+++ b/packages/layout/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Preview } from "@storybook/react";
 import { useEffect } from "react";
 import { parameters as docsParameters } from "@storybook/addon-docs/preview";
+import { INITIAL_VIEWPORTS } from 'storybook/viewport';
 import "@gnome-ui/react/styles";
 import "@gnome-ui/core/styles"; // source import: ensures live [data-theme] tokens override the dist bundle
 
@@ -44,23 +45,16 @@ const preview: Preview = {
       default: "gnome-light",
       values: [
         { name: "gnome-light", value: "#fafafa" },
-        { name: "gnome-dark",  value: "#242424" },
+        { name: "gnome-dark", value: "#242424" },
       ],
     },
     viewport: {
-      options: {
-        mobilePortrait:  { name: "Mobile Portrait",  styles: { width: "390px",  height: "844px"  }, type: "mobile"  },
-        mobileLandscape: { name: "Mobile Landscape",  styles: { width: "844px",  height: "390px"  }, type: "mobile"  },
-        tabletPortrait:  { name: "Tablet Portrait",  styles: { width: "768px",  height: "1024px" }, type: "tablet"  },
-        tabletLandscape: { name: "Tablet Landscape",  styles: { width: "1024px", height: "768px"  }, type: "tablet"  },
-        desktop:         { name: "Desktop",          styles: { width: "1280px", height: "800px"  }, type: "desktop" },
-        largeDesktop:    { name: "Large Desktop",    styles: { width: "1920px", height: "1080px" }, type: "desktop" },
-      },
+      options: INITIAL_VIEWPORTS,
     },
     controls: {
       matchers: {
         color: /(background|color)$/i,
-        date:  /Date$/i,
+        date: /Date$/i,
       },
     },
     docs: {

--- a/packages/layout/.storybook/preview.tsx
+++ b/packages/layout/.storybook/preview.tsx
@@ -47,6 +47,16 @@ const preview: Preview = {
         { name: "gnome-dark",  value: "#242424" },
       ],
     },
+    viewport: {
+      options: {
+        mobilePortrait:  { name: "Mobile Portrait",  styles: { width: "390px",  height: "844px"  }, type: "mobile"  },
+        mobileLandscape: { name: "Mobile Landscape",  styles: { width: "844px",  height: "390px"  }, type: "mobile"  },
+        tabletPortrait:  { name: "Tablet Portrait",  styles: { width: "768px",  height: "1024px" }, type: "tablet"  },
+        tabletLandscape: { name: "Tablet Landscape",  styles: { width: "1024px", height: "768px"  }, type: "tablet"  },
+        desktop:         { name: "Desktop",          styles: { width: "1280px", height: "800px"  }, type: "desktop" },
+        largeDesktop:    { name: "Large Desktop",    styles: { width: "1920px", height: "1080px" }, type: "desktop" },
+      },
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -76,6 +76,16 @@ const preview: Preview = {
         { name: "gnome-dark", value: "#242424" },
       ],
     },
+    viewport: {
+      options: {
+        mobilePortrait:  { name: "Mobile Portrait",  styles: { width: "390px",  height: "844px"  }, type: "mobile"  },
+        mobileLandscape: { name: "Mobile Landscape",  styles: { width: "844px",  height: "390px"  }, type: "mobile"  },
+        tabletPortrait:  { name: "Tablet Portrait",  styles: { width: "768px",  height: "1024px" }, type: "tablet"  },
+        tabletLandscape: { name: "Tablet Landscape",  styles: { width: "1024px", height: "768px"  }, type: "tablet"  },
+        desktop:         { name: "Desktop",          styles: { width: "1280px", height: "800px"  }, type: "desktop" },
+        largeDesktop:    { name: "Large Desktop",    styles: { width: "1920px", height: "1080px" }, type: "desktop" },
+      },
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { parameters as docsParameters } from "@storybook/addon-docs/preview";
 import "@gnome-ui/core/styles";
+import { INITIAL_VIEWPORTS } from "storybook/viewport";
 
 function CenteredDecorator({ children }: { children: ReactNode }) {
   return (
@@ -77,14 +78,7 @@ const preview: Preview = {
       ],
     },
     viewport: {
-      options: {
-        mobilePortrait:  { name: "Mobile Portrait",  styles: { width: "390px",  height: "844px"  }, type: "mobile"  },
-        mobileLandscape: { name: "Mobile Landscape",  styles: { width: "844px",  height: "390px"  }, type: "mobile"  },
-        tabletPortrait:  { name: "Tablet Portrait",  styles: { width: "768px",  height: "1024px" }, type: "tablet"  },
-        tabletLandscape: { name: "Tablet Landscape",  styles: { width: "1024px", height: "768px"  }, type: "tablet"  },
-        desktop:         { name: "Desktop",          styles: { width: "1280px", height: "800px"  }, type: "desktop" },
-        largeDesktop:    { name: "Large Desktop",    styles: { width: "1920px", height: "1080px" }, type: "desktop" },
-      },
+      options: INITIAL_VIEWPORTS,
     },
     controls: {
       matchers: {


### PR DESCRIPTION
## What

Update storybooks and previews config tu use INITIAL_VIEWPORTS from "storybook/viewport"
## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #??? -->

## Changes

- [ ] New component
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [ ] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [ ] All styles use CSS custom properties from `@gnome-ui/core`
- [ ] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [ ] Storybook story added or updated
- [ ] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
