### PR TITLE
feat: add CountDown component (closes #12)

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -72,6 +72,7 @@ export default function App() {
 | [`Blockquote`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-blockquote--docs) | Styled pull-quote with left-border accent; default, info, warning, error, success variants; optional icon and attribution |
 | [`Spinner`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-spinner--docs) | Indeterminate loading indicator; sm/md/lg sizes |
 | [`ProgressBar`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-progressbar--docs) | Determinate (0–1) and indeterminate progress indicator |
+| [`CountDownTimer`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-countdowntimer--docs) | Countdown timer showing remaining time until a specified date; `date`, `time`, or `datetime` formats; executes callback on completion |
 | [`StatusPage`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-statuspage--docs) | Empty-state page with icon, title, description, and optional actions; `compact` prop for sidebars/popovers |
 | [`Separator`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-separator--docs) | Horizontal/vertical dividing line between content groups |
 | [`Chip`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-chip--docs) | Compact pill-shaped label for tags, filters, and multi-select; static, removable, and selectable modes |

--- a/packages/react/src/components/CountDownTimer/CountDownTimer.module.css
+++ b/packages/react/src/components/CountDownTimer/CountDownTimer.module.css
@@ -1,0 +1,110 @@
+/* ─── Base container ──────────────────────────────────────────────────────── */
+
+.countdownTimer {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+
+  padding: 0.5rem 1rem;
+  border-radius: var(--gnome-radius-default, 6px);
+  background-color: var(--gnome-view-bg-color, #f6f5f4);
+
+  font-family: var(--gnome-font-family);
+  font-size: 1rem;
+  font-weight: var(--gnome-font-weight-medium, 500);
+  line-height: 1.5;
+  letter-spacing: 0.02em;
+
+  user-select: none;
+  transition: all 200ms ease-out;
+}
+
+/* ─── Value display ────────────────────────────────────────────────────────── */
+
+.value {
+  font-family: "Fira Mono", monospace;
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: 0.025em;
+}
+
+/* ─── Variant: accent (default) ────────────────────────────────────────────── */
+
+.accent {
+  background-color: rgba(53, 132, 228, 0.1);
+  color: #3584e4;
+  border: 1px solid rgba(53, 132, 228, 0.2);
+}
+
+.accent .value {
+  color: #3584e4;
+}
+
+/* ─── Variant: success ─────────────────────────────────────────────────────── */
+
+.success {
+  background-color: rgba(51, 209, 122, 0.1);
+  color: #33d17a;
+  border: 1px solid rgba(51, 209, 122, 0.2);
+}
+
+.success .value {
+  color: #33d17a;
+}
+
+/* ─── Variant: warning ─────────────────────────────────────────────────────── */
+
+.warning {
+  background-color: rgba(255, 190, 0, 0.1);
+  color: #f8e45c;
+  border: 1px solid rgba(255, 190, 0, 0.2);
+}
+
+.warning .value {
+  color: #f8e45c;
+}
+
+/* ─── Variant: destructive ────────────────────────────────────────────────── */
+
+.destructive {
+  background-color: rgba(225, 59, 59, 0.1);
+  color: #e13b3b;
+  border: 1px solid rgba(225, 59, 59, 0.2);
+}
+
+.destructive .value {
+  color: #e13b3b;
+}
+
+/* ─── Finished state ───────────────────────────────────────────────────────── */
+
+.finished {
+  opacity: 0.7;
+}
+
+@media (prefers-color-scheme: dark) {
+  .countdownTimer {
+    background-color: var(--gnome-view-bg-color, #3d3846);
+  }
+
+  .accent {
+    background-color: rgba(53, 132, 228, 0.15);
+    border-color: rgba(53, 132, 228, 0.3);
+  }
+
+  .success {
+    background-color: rgba(51, 209, 122, 0.15);
+    border-color: rgba(51, 209, 122, 0.3);
+  }
+
+  .warning {
+    background-color: rgba(255, 190, 0, 0.15);
+    border-color: rgba(255, 190, 0, 0.3);
+  }
+
+  .destructive {
+    background-color: rgba(225, 59, 59, 0.15);
+    border-color: rgba(225, 59, 59, 0.3);
+  }
+}

--- a/packages/react/src/components/CountDownTimer/CountDownTimer.stories.tsx
+++ b/packages/react/src/components/CountDownTimer/CountDownTimer.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CountDownTimer } from "./CountDownTimer";
+
+const meta: Meta<typeof CountDownTimer> = {
+    title: "Components/CountDownTimer",
+    component: CountDownTimer,
+    tags: ["autodocs"],
+    parameters: {
+        docs: {
+            description: {
+                component: `
+Displays a countdown timer showing the remaining time until a specified end date.
+
+### Guidelines
+- Use \`format="time"\` to display countdown in HH:MM:SS format.
+- Use \`format="date"\` to display the target end date.
+- Provide an \`action\` callback that executes when the countdown reaches zero.
+- Choose the \`variant\` that matches the urgency: \`accent\` → neutral, \`success\` → positive, \`warning\` → caution, \`destructive\` → urgent.
+- The component automatically switches to destructive styling when time runs out.
+        `,
+            },
+        },
+    },
+    argTypes: {
+        start: { control: "date" },
+        end: { control: "date" },
+        format: { control: "select", options: ["time", "date", "datetime"] },
+        variant: { control: "select", options: ["accent", "success", "warning", "destructive"] },
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Get dates for examples
+const now = new Date();
+const endTime = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
+
+export const Default: Story = {
+    args: {
+        start: now,
+        end: endTime,
+        format: "time",
+        variant: "accent",
+    },
+};
+
+export const DateFormat: Story = {
+    args: {
+        start: now,
+        end: endTime,
+        format: "date",
+        variant: "accent",
+    },
+};
+
+export const DateTimeFormat: Story = {
+    args: {
+        start: now,
+        end: endTime,
+        format: "datetime",
+        variant: "accent",
+    },
+};
+
+export const SuccessVariant: Story = {
+    args: {
+        start: now,
+        end: endTime,
+        format: "time",
+        variant: "success",
+    },
+};
+
+export const WarningVariant: Story = {
+    args: {
+        start: now,
+        end: new Date(now.getTime() + 5 * 60 * 1000), // 5 minutes
+        format: "time",
+        variant: "warning",
+    },
+};
+
+export const LongCountdown: Story = {
+    args: {
+        start: now,
+        end: new Date(now.getTime() + 24 * 60 * 60 * 1000), // 24 hours
+        format: "time",
+        variant: "accent",
+    },
+};
+
+export const WithCallback: Story = {
+    args: {
+        start: now,
+        end: endTime,
+        format: "time",
+        variant: "accent",
+        action: () => {
+            console.log("Countdown finished!");
+        },
+    },
+};

--- a/packages/react/src/components/CountDownTimer/CountDownTimer.test.tsx
+++ b/packages/react/src/components/CountDownTimer/CountDownTimer.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { CountDownTimer } from "./CountDownTimer";
+
+describe("CountDownTimer", () => {
+  describe("rendering", () => {
+    it("renders with time format", () => {
+      const futureDate = new Date(Date.now() + 60 * 60 * 1000); // 1 hour from now
+      render(<CountDownTimer start={new Date()} end={futureDate} format="time" />);
+      // Allow for some variance in rendering
+      const elements = screen.queryAllByText(/\d+:\d+:\d+/);
+      expect(elements.length).toBeGreaterThan(0);
+    });
+
+    it("renders with date format", () => {
+      const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+      render(<CountDownTimer start={new Date()} end={futureDate} format="date" />);
+      const dateText = screen.getByText(/\d+\/\d+\/\d+/);
+      expect(dateText).toBeInTheDocument();
+    });
+
+    it("renders with datetime format", () => {
+      const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+      const { container } = render(
+        <CountDownTimer start={new Date()} end={futureDate} format="datetime" />
+      );
+      const textContent = container.textContent || "";
+      expect(textContent).toMatch(/\d+\/\d+\/\d+/);
+    });
+
+    it("renders with default time format when format is not specified", () => {
+      const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+      render(<CountDownTimer start={new Date()} end={futureDate} />);
+      const elements = screen.queryAllByText(/\d+:\d+:\d+/);
+      expect(elements.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("variants", () => {
+    it("applies accent variant class", () => {
+      const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+      const { container } = render(
+        <CountDownTimer start={new Date()} end={futureDate} variant="accent" />
+      );
+      const className = (container.firstChild as HTMLElement)?.className || "";
+      expect(className).toContain("accent");
+    });
+
+    it("applies success variant class", () => {
+      const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+      const { container } = render(
+        <CountDownTimer start={new Date()} end={futureDate} variant="success" />
+      );
+      const className = (container.firstChild as HTMLElement)?.className || "";
+      expect(className).toContain("success");
+    });
+
+    it("applies warning variant class", () => {
+      const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+      const { container } = render(
+        <CountDownTimer start={new Date()} end={futureDate} variant="warning" />
+      );
+      const className = (container.firstChild as HTMLElement)?.className || "";
+      expect(className).toContain("warning");
+    });
+  });
+
+  describe("countdown behavior", () => {
+    it("should update timer state correctly", async () => {
+      const futureDate = new Date(Date.now() + 60 * 1000); // 60 seconds from now
+      const { container } = render(
+        <CountDownTimer start={new Date()} end={futureDate} format="time" />
+      );
+
+      await waitFor(
+        () => {
+          const textContent = container.textContent || "";
+          expect(textContent).toMatch(/\d+:\d+:\d+/);
+        },
+        { timeout: 3000 }
+      );
+    });
+
+    it("shows 00:00:00 when end date is in the past", () => {
+      const pastDate = new Date(Date.now() - 1000);
+      render(<CountDownTimer start={new Date()} end={pastDate} format="time" />);
+
+      expect(screen.getByText(/00:00:00/)).toBeInTheDocument();
+    });
+
+    it("applies finished class when end date is in the past", () => {
+      const pastDate = new Date(Date.now() - 1000);
+      const { container } = render(
+        <CountDownTimer start={new Date()} end={pastDate} />
+      );
+
+      const className = (container.firstChild as HTMLElement)?.className || "";
+      expect(className).toContain("finished");
+    });
+
+    it("switches to destructive variant when countdown finishes", () => {
+      const pastDate = new Date(Date.now() - 1000);
+      const { container } = render(
+        <CountDownTimer
+          start={new Date()}
+          end={pastDate}
+          variant="accent"
+        />
+      );
+
+      const className = (container.firstChild as HTMLElement)?.className || "";
+      expect(className).toContain("destructive");
+    });
+  });
+
+  describe("callback", () => {
+    it("calls the action callback when countdown finishes", async () => {
+      const mockAction = vi.fn();
+      const pastDate = new Date(Date.now() - 100);
+      render(
+        <CountDownTimer
+          start={new Date()}
+          end={pastDate}
+          action={mockAction}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockAction).toHaveBeenCalled();
+      }, { timeout: 2000 });
+    });
+  });
+
+  describe("time format display", () => {
+    it("displays time in HH:MM:SS format", () => {
+      const futureDate = new Date(Date.now() + 60 * 60 * 1000); // 1 hour from now
+      const { container } = render(
+        <CountDownTimer
+          start={new Date()}
+          end={futureDate}
+          format="time"
+        />
+      );
+
+      const textContent = container.textContent || "";
+      expect(textContent).toMatch(/\d+:\d+:\d+/);
+    });
+
+    it("displays days when countdown exceeds 24 hours", () => {
+      const futureDate = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000); // 2 days from now
+      const { container } = render(
+        <CountDownTimer
+          start={new Date()}
+          end={futureDate}
+          format="time"
+        />
+      );
+
+      const textContent = container.textContent || "";
+      expect(textContent).toMatch(/d.*h.*m/);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles end date in the past gracefully", () => {
+      const pastDate = new Date(Date.now() - 5000);
+      const { container } = render(
+        <CountDownTimer start={new Date()} end={pastDate} />
+      );
+
+      expect(screen.getByText(/00:00:00/)).toBeInTheDocument();
+      const className = (container.firstChild as HTMLElement)?.className || "";
+      expect(className).toContain("finished");
+    });
+
+    it("accepts custom className", () => {
+      const futureDate = new Date(Date.now() + 60 * 1000);
+      const { container } = render(
+        <CountDownTimer
+          start={new Date()}
+          end={futureDate}
+          className="custom-class"
+        />
+      );
+
+      const className = (container.firstChild as HTMLElement)?.className || "";
+      expect(className).toContain("custom-class");
+    });
+
+    it("renders correctly with all props", () => {
+      const futureDate = new Date(Date.now() + 60 * 1000);
+      const mockAction = vi.fn();
+      const { container } = render(
+        <CountDownTimer
+          start={new Date()}
+          end={futureDate}
+          format="datetime"
+          variant="success"
+          action={mockAction}
+          className="test-class"
+        />
+      );
+
+      const className = (container.firstChild as HTMLElement)?.className || "";
+      expect(className).toContain("success");
+      expect(className).toContain("test-class");
+    });
+  });
+});

--- a/packages/react/src/components/CountDownTimer/CountDownTimer.tsx
+++ b/packages/react/src/components/CountDownTimer/CountDownTimer.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from "react";
+import type { HTMLAttributes } from "react";
+import styles from "./CountDownTimer.module.css";
+
+export type CountDownVariant = "accent" | "destructive" | "success" | "warning";
+
+export interface CountDownTimerProps extends HTMLAttributes<HTMLDivElement> {
+    /** Start date for the countdown */
+    start: Date;
+    /** End date for the countdown */
+    end: Date;
+    /** Format to display: "date", "time", or "datetime" */
+    format?: "date" | "time" | "datetime";
+    /** Visual style variant. Defaults to `"accent"`. */
+    variant?: CountDownVariant;
+    /** Callback action to execute when countdown reaches zero */
+    action?: () => void;
+}
+
+interface TimeRemaining {
+    days: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    isFinished: boolean;
+}
+
+/**
+ * CountDown timer component that displays remaining time and executes an action when time runs out.
+ *
+ * @see https://developer.gnome.org/hig/patterns/
+ */
+export function CountDownTimer({
+    start,
+    end,
+    format = "time",
+    variant = "accent",
+    action,
+    className,
+    ...props
+}: CountDownTimerProps) {
+    const [timeRemaining, setTimeRemaining] = useState<TimeRemaining | null>(null);
+    const [hasExecutedAction, setHasExecutedAction] = useState(false);
+
+    useEffect(() => {
+        const calculateTimeRemaining = (): TimeRemaining => {
+            const now = new Date();
+            const endTime = new Date(end).getTime();
+            const nowTime = now.getTime();
+            const difference = endTime - nowTime;
+
+            if (difference <= 0) {
+                return {
+                    days: 0,
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 0,
+                    isFinished: true,
+                };
+            }
+
+            const days = Math.floor(difference / (1000 * 60 * 60 * 24));
+            const hours = Math.floor((difference / (1000 * 60 * 60)) % 24);
+            const minutes = Math.floor((difference / 1000 / 60) % 60);
+            const seconds = Math.floor((difference / 1000) % 60);
+
+            return {
+                days,
+                hours,
+                minutes,
+                seconds,
+                isFinished: false,
+            };
+        };
+
+        // Initial calculation
+        setTimeRemaining(calculateTimeRemaining());
+
+        // Update every second
+        const interval = setInterval(() => {
+            const remaining = calculateTimeRemaining();
+            setTimeRemaining(remaining);
+
+            // Execute action when countdown finishes
+            if (remaining.isFinished && !hasExecutedAction) {
+                action?.();
+                setHasExecutedAction(true);
+            }
+        }, 1000);
+
+        return () => clearInterval(interval);
+    }, [end, action, hasExecutedAction]);
+
+    if (!timeRemaining) {
+        return null;
+    }
+
+    const formatTime = (): string => {
+        if (format === "date") {
+            const endDate = new Date(end);
+            return endDate.toLocaleDateString();
+        }
+
+        const { days, hours, minutes, seconds, isFinished } = timeRemaining;
+
+        if (isFinished) {
+            return "00:00:00";
+        }
+
+        if (format === "datetime") {
+            const endDate = new Date(end);
+            const dateString = endDate.toLocaleDateString();
+            const timeString = `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+            return `${dateString} ${timeString}`;
+        }
+
+        if (days > 0) {
+            return `${days}d ${String(hours).padStart(2, "0")}h ${String(minutes).padStart(2, "0")}m`;
+        }
+
+        return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+    };
+
+    const displayVariant = timeRemaining.isFinished ? "destructive" : variant;
+
+    return (
+        <div
+            className={[
+                styles.countdownTimer,
+                styles[displayVariant],
+                timeRemaining.isFinished ? styles.finished : null,
+                className,
+            ]
+                .filter(Boolean)
+                .join(" ")}
+            {...props}
+        >
+            <span className={styles.value}>{formatTime()}</span>
+        </div>
+    );
+}

--- a/packages/react/src/components/CountDownTimer/index.ts
+++ b/packages/react/src/components/CountDownTimer/index.ts
@@ -1,0 +1,2 @@
+export { CountDownTimer } from "./CountDownTimer";
+export type { CountDownTimerProps, CountDownVariant } from "./CountDownTimer";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -51,6 +51,9 @@ export type { FooterProps } from "./components/Footer";
 export { Badge } from "./components/Badge";
 export type { BadgeProps, BadgeVariant } from "./components/Badge";
 
+export { CountDownTimer } from "./components/CountDownTimer";
+export type { CountDownTimerProps, CountDownVariant } from "./components/CountDownTimer";
+
 export { Icon } from "./components/Icon";
 export type { IconProps, IconSize } from "./components/Icon";
 

--- a/packages/react/src/test/setup.ts
+++ b/packages/react/src/test/setup.ts
@@ -1,1 +1,3 @@
+/// <reference types="@testing-library/jest-dom" />
+
 import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## What

Add componente CountDownTimer

closes #12 

## Why
Needs show countdown in date, time and datetime formats.

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
