### PR TITLE
feat: uodate SIdebarSection for support Icon, and collapsible and expand functions (closes  #34)

### DIFF
--- a/packages/react/src/components/Sidebar/Sidebar.module.css
+++ b/packages/react/src/components/Sidebar/Sidebar.module.css
@@ -30,8 +30,54 @@
   border-top: 1px solid var(--gnome-divider-color);
 }
 
+/* ─── Section header (title row, optionally a button when collapsible) ──────── */
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--gnome-space-1, 6px);
+  width: 100%;
+  margin: 4px 0 2px;
+  padding: 2px var(--gnome-space-1, 6px);
+  border-radius: var(--gnome-radius-sm, 4px);
+  background: transparent;
+  border: none;
+  font: inherit;
+  text-align: start;
+  cursor: default;
+}
+
+button.sectionHeader {
+  cursor: pointer;
+  transition: background-color var(--gnome-duration-fast) var(--gnome-easing-default);
+}
+
+button.sectionHeader:hover {
+  background-color: var(--gnome-hover-overlay);
+}
+
+button.sectionHeader:active {
+  background-color: var(--gnome-active-overlay);
+}
+
+button.sectionHeader:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 var(--gnome-focus-ring-offset, 2px) var(--gnome-sidebar-bg-color, #ebebeb),
+    0 0 0 calc(var(--gnome-focus-ring-offset, 2px) + var(--gnome-focus-ring-width, 3px))
+      var(--gnome-focus-ring-color, #3584e4);
+}
+
+.sectionHeaderIcon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
 .sectionTitle {
-  margin: 4px var(--gnome-space-1, 6px) 2px;
+  flex: 1;
+  min-width: 0;
   padding: 0;
   font-family: var(--gnome-font-family);
   font-size: var(--gnome-font-size-caption, 0.875rem);
@@ -40,6 +86,33 @@
   letter-spacing: 0.06em;
   opacity: 0.5;
   user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sectionChevron {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: auto;
+  opacity: 0.5;
+}
+
+/* ─── Collapsible section body ──────────────────────────────────────────────── */
+
+.sectionBody {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 200ms var(--gnome-easing-default, ease);
+}
+
+.sectionBodyCollapsed {
+  grid-template-rows: 0fr;
+}
+
+.sectionBodyInner {
+  overflow: hidden;
 }
 
 /* ─── List ─────────────────────────────────────────────────────────────────── */
@@ -355,7 +428,9 @@
 /* ─── Reduced motion ───────────────────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
-  .itemBtn {
+  .itemBtn,
+  button.sectionHeader,
+  .sectionBody {
     transition: none;
   }
 }

--- a/packages/react/src/components/Sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,11 +1,12 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   GoHome, Search, Settings, Star, Delete,
-  ViewMore, MediaPlay, Share, Add,
+  ViewMore, MediaPlay, Share, Add, Applications, DocumentOpen,
 } from "@gnome-ui/icons";
 import { Sidebar } from "./Sidebar";
 import { SidebarSection } from "./SidebarSection";
+import type { SidebarSectionHandle } from "./SidebarSection";
 import { SidebarItem } from "./SidebarItem";
 import { Badge } from "../Badge";
 import { HeaderBar } from "../HeaderBar";
@@ -411,4 +412,198 @@ export const InLayout: Story = {
     );
   },
   parameters: { controls: { disable: true } },
+};
+
+// ─── SidebarSection: icon prop ───────────────────────────────────────────────
+
+export const SectionWithIcon: Story = {
+  render: function SectionWithIconStory() {
+    const [active, setActive] = useState("shared");
+    return (
+      <Sidebar style={{ height: 280 }}>
+        <SidebarSection title="Network" icon={Applications}>
+          <SidebarItem icon={Share}  label="Shared"  active={active === "shared"}  onClick={() => setActive("shared")} />
+          <SidebarItem icon={Star}   label="Starred" active={active === "starred"} onClick={() => setActive("starred")} />
+        </SidebarSection>
+        <SidebarSection title="Local" icon={DocumentOpen}>
+          <SidebarItem icon={GoHome}    label="Home"      active={active === "home"}     onClick={() => setActive("home")} />
+          <SidebarItem icon={Settings}  label="Settings"  active={active === "settings"} onClick={() => setActive("settings")} />
+        </SidebarSection>
+      </Sidebar>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "Use `icon` on `SidebarSection` to render an icon left of the section title." },
+    },
+  },
+};
+
+// ─── SidebarSection: collapsible (uncontrolled) ──────────────────────────────
+
+export const CollapsibleSection: Story = {
+  render: function CollapsibleStory() {
+    const [active, setActive] = useState("inbox");
+    return (
+      <Sidebar style={{ height: 360 }}>
+        <SidebarSection title="Mailboxes" icon={GoHome} collapsible defaultOpen>
+          <SidebarItem icon={GoHome}   label="Inbox"  active={active === "inbox"}  onClick={() => setActive("inbox")}  suffix={<Badge variant="accent">12</Badge>} />
+          <SidebarItem icon={Share}    label="Sent"   active={active === "sent"}   onClick={() => setActive("sent")} />
+          <SidebarItem icon={Delete}   label="Trash"  active={active === "trash"}  onClick={() => setActive("trash")} />
+        </SidebarSection>
+        <SidebarSection title="Tags" icon={Star} collapsible defaultOpen={false}>
+          <SidebarItem icon={Star} label="Work"     active={active === "work"}     onClick={() => setActive("work")} />
+          <SidebarItem icon={Star} label="Personal" active={active === "personal"} onClick={() => setActive("personal")} />
+        </SidebarSection>
+      </Sidebar>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: "Add `collapsible` to let users toggle a section. `defaultOpen={false}` starts it collapsed.",
+      },
+    },
+  },
+};
+
+// ─── SidebarSection: collapsible (controlled) ────────────────────────────────
+
+export const CollapsibleSectionControlled: Story = {
+  render: function ControlledStory() {
+    const [open, setOpen] = useState(true);
+    const [active, setActive] = useState("inbox");
+    return (
+      <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
+        <Sidebar style={{ height: 280 }}>
+          <SidebarSection
+            title="Mailboxes"
+            icon={GoHome}
+            collapsible
+            open={open}
+            onOpenChange={setOpen}
+          >
+            <SidebarItem icon={GoHome}  label="Inbox" active={active === "inbox"} onClick={() => setActive("inbox")} />
+            <SidebarItem icon={Share}   label="Sent"  active={active === "sent"}  onClick={() => setActive("sent")} />
+            <SidebarItem icon={Delete}  label="Trash" active={active === "trash"} onClick={() => setActive("trash")} />
+          </SidebarSection>
+        </Sidebar>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, paddingTop: 12 }}>
+          <Button variant="flat" onClick={() => setOpen((v) => !v)}>
+            {open ? "Collapse section" : "Expand section"}
+          </Button>
+          <Text variant="caption" color="dim">open: <strong>{String(open)}</strong></Text>
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: "Controlled mode: drive `open` externally with `onOpenChange`. The external button and the section header both toggle the same state.",
+      },
+    },
+  },
+};
+
+// ─── SidebarSection: imperative ref ──────────────────────────────────────────
+
+export const CollapsibleSectionWithRef: Story = {
+  render: function RefStory() {
+    const sectionRef = useRef<SidebarSectionHandle>(null);
+    const [active, setActive] = useState("inbox");
+    return (
+      <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
+        <Sidebar style={{ height: 280 }}>
+          <SidebarSection ref={sectionRef} title="Mailboxes" icon={GoHome} collapsible>
+            <SidebarItem icon={GoHome}  label="Inbox" active={active === "inbox"} onClick={() => setActive("inbox")} />
+            <SidebarItem icon={Share}   label="Sent"  active={active === "sent"}  onClick={() => setActive("sent")} />
+            <SidebarItem icon={Delete}  label="Trash" active={active === "trash"} onClick={() => setActive("trash")} />
+          </SidebarSection>
+        </Sidebar>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, paddingTop: 12 }}>
+          <Button variant="flat" onClick={() => sectionRef.current?.expand()}>expand()</Button>
+          <Button variant="flat" onClick={() => sectionRef.current?.collapse()}>collapse()</Button>
+          <Button variant="flat" onClick={() => sectionRef.current?.toggle()}>toggle()</Button>
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: "Drive the section imperatively via `ref`. Use `expand()`, `collapse()`, and `toggle()` from outside the component.",
+      },
+    },
+  },
+};
+
+// ─── SidebarSection: collapsible in rail mode ─────────────────────────────────
+
+export const CollapsibleSectionInRailMode: Story = {
+  render: function RailStory() {
+    const [collapsed, setCollapsed] = useState(false);
+    const [active, setActive] = useState("inbox");
+    return (
+      <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
+        <Sidebar collapsed={collapsed} style={{ height: 300 }}>
+          <SidebarSection title="Mailboxes" icon={GoHome} collapsible defaultOpen={false}>
+            <SidebarItem icon={GoHome}  label="Inbox" active={active === "inbox"} onClick={() => setActive("inbox")} />
+            <SidebarItem icon={Share}   label="Sent"  active={active === "sent"}  onClick={() => setActive("sent")} />
+            <SidebarItem icon={Delete}  label="Trash" active={active === "trash"} onClick={() => setActive("trash")} />
+          </SidebarSection>
+        </Sidebar>
+        <div style={{ paddingTop: 12 }}>
+          <Button variant="flat" onClick={() => setCollapsed((v) => !v)}>
+            {collapsed ? "Expand sidebar" : "Collapse sidebar (rail)"}
+          </Button>
+          <Text variant="caption" color="dim" style={{ marginTop: 8, display: "block" }}>
+            In rail mode the body is always visible, even when defaultOpen is false.
+          </Text>
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: "When the sidebar is in rail (icon-only) mode, collapsible sections always show their body — there's no title row to tap. The chevron is hidden.",
+      },
+    },
+  },
+};
+
+// ─── SidebarSection: filter hides empty sections ─────────────────────────────
+
+export const CollapsibleSectionWithFilter: Story = {
+  render: function FilterStory() {
+    const [active, setActive] = useState("inbox");
+    return (
+      <Sidebar style={{ height: 360 }} searchable>
+        <SidebarSection title="Mailboxes" icon={GoHome} collapsible>
+          <SidebarItem icon={GoHome}   label="Inbox"  active={active === "inbox"}  onClick={() => setActive("inbox")} />
+          <SidebarItem icon={Share}    label="Sent"   active={active === "sent"}   onClick={() => setActive("sent")} />
+          <SidebarItem icon={Delete}   label="Trash"  active={active === "trash"}  onClick={() => setActive("trash")} />
+        </SidebarSection>
+        <SidebarSection title="Tags" icon={Star} collapsible>
+          <SidebarItem icon={Star} label="Work"     active={active === "work"}     onClick={() => setActive("work")} />
+          <SidebarItem icon={Star} label="Personal" active={active === "personal"} onClick={() => setActive("personal")} />
+          <SidebarItem icon={Star} label="Finance"  active={active === "finance"}  onClick={() => setActive("finance")} />
+        </SidebarSection>
+      </Sidebar>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: "When a filter is active, sections with no matching items are hidden entirely. Try searching for \"finance\" or \"trash\".",
+      },
+    },
+  },
 };

--- a/packages/react/src/components/Sidebar/SidebarSection.tsx
+++ b/packages/react/src/components/Sidebar/SidebarSection.tsx
@@ -1,5 +1,45 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import {
+  forwardRef,
+  useImperativeHandle,
+  useState,
+  useContext,
+  useId,
+  isValidElement,
+  Children,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+import type { IconDefinition } from "@gnome-ui/icons";
+import { PanDown, PanUp } from "@gnome-ui/icons";
+import { Icon } from "../Icon";
+import { useSidebarCollapsed, SidebarFilterContext } from "./Sidebar";
 import styles from "./Sidebar.module.css";
+
+// ─── Filter helper ────────────────────────────────────────────────────────────
+
+function countMatchingItems(children: ReactNode, filter: string): number {
+  let count = 0;
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const props = child.props as Record<string, unknown>;
+    if (typeof props.label === "string") {
+      if (props.label.toLowerCase().includes(filter.toLowerCase())) count++;
+    } else if (props.children) {
+      count += countMatchingItems(props.children as ReactNode, filter);
+    }
+  });
+  return count;
+}
+
+// ─── Handle ───────────────────────────────────────────────────────────────────
+
+export interface SidebarSectionHandle {
+  expand: () => void;
+  collapse: () => void;
+  toggle: () => void;
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
 
 export interface SidebarSectionProps extends HTMLAttributes<HTMLElement> {
   /**
@@ -7,48 +47,131 @@ export interface SidebarSectionProps extends HTMLAttributes<HTMLElement> {
    * Omit for an untitled section (e.g. the first group in a sidebar).
    */
   title?: string;
+  /** Icon rendered left of the title. Same type as `SidebarItem.icon`. */
+  icon?: IconDefinition;
+  /** Whether the section body can be toggled open/closed. Defaults to `false`. */
+  collapsible?: boolean;
+  /** Initial open state when `collapsible` is true. Defaults to `true`. */
+  defaultOpen?: boolean;
+  /** Controlled open state. */
+  open?: boolean;
+  /** Called when open state changes. */
+  onOpenChange?: (open: boolean) => void;
   children?: ReactNode;
 }
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 /**
  * Named group of `SidebarItem` entries inside a `Sidebar`.
  *
- * Sections are separated by a thin divider. The title is optional —
- * omit it for the primary section when the grouping is self-evident.
+ * Sections are separated by a thin divider. The title and icon are optional.
+ * When `collapsible` is true the body can be toggled via the header button or
+ * imperatively via a `ref` (`expand`, `collapse`, `toggle`).
  *
- * Mirrors the `AdwSidebar` section model (libadwaita 1.9 / GNOME 50).
+ * In rail (icon-only) mode the body is always visible regardless of open state.
+ * When a sidebar filter is active and no children match, the section is hidden.
  *
- * @example
- * ```tsx
- * <Sidebar>
- *   <SidebarSection title="Mailboxes">
- *     <SidebarItem label="Inbox" icon={GoHome} active />
- *     <SidebarItem label="Sent"  icon={Share} />
- *   </SidebarSection>
- *   <SidebarSection title="Tags">
- *     <SidebarItem label="Work"     icon={Star} />
- *     <SidebarItem label="Personal" icon={Star} />
- *   </SidebarSection>
- * </Sidebar>
- * ```
+ * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Sidebar.html
  */
-export function SidebarSection({
-  title,
-  children,
-  className,
-  ...props
-}: SidebarSectionProps) {
-  return (
-    <section
-      className={[styles.section, className].filter(Boolean).join(" ")}
-      {...props}
-    >
-      {title && (
-        <h3 className={styles.sectionTitle}>{title}</h3>
-      )}
-      <ul role="list" className={styles.list}>
-        {children}
-      </ul>
-    </section>
-  );
-}
+export const SidebarSection = forwardRef<SidebarSectionHandle, SidebarSectionProps>(
+  function SidebarSection(
+    {
+      title,
+      icon,
+      collapsible = false,
+      defaultOpen = true,
+      open: controlledOpen,
+      onOpenChange,
+      children,
+      className,
+      ...props
+    },
+    ref,
+  ) {
+    const [internalOpen, setInternalOpen] = useState(defaultOpen);
+    const isControlled = controlledOpen !== undefined;
+    const open = isControlled ? controlledOpen : internalOpen;
+
+    const sidebarCollapsed = useSidebarCollapsed();
+    const filterValue = useContext(SidebarFilterContext);
+    const bodyId = useId();
+
+    const setAndNotify = (next: boolean) => {
+      if (!isControlled) setInternalOpen(next);
+      onOpenChange?.(next);
+    };
+
+    useImperativeHandle(ref, () => ({
+      expand: () => setAndNotify(true),
+      collapse: () => setAndNotify(false),
+      toggle: () => setAndNotify(!open),
+    }));
+
+    // Hide section entirely when filter is active and no children match
+    const hasVisibleChildren =
+      filterValue.length === 0 || countMatchingItems(children, filterValue) > 0;
+
+    if (!hasVisibleChildren) return null;
+
+    // In rail mode the body is always visible
+    const isOpen = sidebarCollapsed ? true : open;
+
+    const showHeader = !!(title || icon || (collapsible && !sidebarCollapsed));
+
+    return (
+      <section
+        className={[styles.section, className].filter(Boolean).join(" ")}
+        {...props}
+      >
+        {showHeader && (
+          collapsible && !sidebarCollapsed ? (
+            <button
+              type="button"
+              className={styles.sectionHeader}
+              onClick={() => setAndNotify(!open)}
+              aria-expanded={open}
+              aria-controls={bodyId}
+            >
+              {icon && (
+                <span className={styles.sectionHeaderIcon}>
+                  <Icon icon={icon} size="sm" aria-hidden />
+                </span>
+              )}
+              {title && <span className={styles.sectionTitle}>{title}</span>}
+              <span className={styles.sectionChevron}>
+                <Icon icon={open ? PanUp : PanDown} size="sm" aria-hidden />
+              </span>
+            </button>
+          ) : (
+            <div className={styles.sectionHeader}>
+              {icon && (
+                <span className={styles.sectionHeaderIcon}>
+                  <Icon icon={icon} size="sm" aria-hidden />
+                </span>
+              )}
+              {title && <span className={styles.sectionTitle}>{title}</span>}
+            </div>
+          )
+        )}
+
+        <div
+          id={bodyId}
+          className={[
+            styles.sectionBody,
+            !isOpen ? styles.sectionBodyCollapsed : null,
+          ]
+            .filter(Boolean)
+            .join(" ")}
+          aria-hidden={!isOpen || undefined}
+        >
+          <div className={styles.sectionBodyInner}>
+            <ul role="list" className={styles.list}>
+              {children}
+            </ul>
+          </div>
+        </div>
+      </section>
+    );
+  },
+);

--- a/packages/react/src/components/Sidebar/index.ts
+++ b/packages/react/src/components/Sidebar/index.ts
@@ -2,7 +2,7 @@ export { Sidebar, SidebarCollapsedContext, useSidebarCollapsed } from "./Sidebar
 export type { SidebarProps } from "./Sidebar";
 
 export { SidebarSection } from "./SidebarSection";
-export type { SidebarSectionProps } from "./SidebarSection";
+export type { SidebarSectionProps, SidebarSectionHandle } from "./SidebarSection";
 
 export { SidebarItem } from "./SidebarItem";
 export type { SidebarItemProps, SidebarMenuEntry } from "./SidebarItem";


### PR DESCRIPTION
## What

Sidebar section update
closes #34


## Changes

- [ ] New component
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [ ] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
