### PR TITLE
feat: add IconBadge component (closes #64)

### DIFF
--- a/packages/layout/src/components/IconBadge/IconBadge.module.css
+++ b/packages/layout/src/components/IconBadge/IconBadge.module.css
@@ -1,0 +1,88 @@
+/* ─── Base ────────────────────────────────────────────────────────────────── */
+
+.badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* ─── Sizes ───────────────────────────────────────────────────────────────── */
+
+.xs {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  font-size: 0.75rem;
+}
+
+.sm {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+.md {
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  font-size: 1.1rem;
+}
+
+.lg {
+  width: 44px;
+  height: 44px;
+  border-radius: 11px;
+  font-size: 1.5rem;
+}
+
+.xl {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  font-size: 2rem;
+}
+
+/* ─── Neutral (no color) ──────────────────────────────────────────────────── */
+
+.neutral {
+  background: var(--gnome-hover-overlay, rgba(0, 0, 0, 0.06));
+}
+
+/* ─── Color variants ──────────────────────────────────────────────────────── */
+
+.blue {
+  background: color-mix(in srgb, var(--gnome-blue-3) 15%, transparent);
+  color: var(--gnome-blue-3);
+}
+
+.green {
+  background: color-mix(in srgb, var(--gnome-green-3) 15%, transparent);
+  color: var(--gnome-green-3);
+}
+
+.yellow {
+  background: color-mix(in srgb, var(--gnome-yellow-3) 15%, transparent);
+  color: var(--gnome-yellow-5);
+}
+
+.orange {
+  background: color-mix(in srgb, var(--gnome-orange-3) 15%, transparent);
+  color: var(--gnome-orange-3);
+}
+
+.red {
+  background: color-mix(in srgb, var(--gnome-red-3) 15%, transparent);
+  color: var(--gnome-red-3);
+}
+
+.purple {
+  background: color-mix(in srgb, var(--gnome-purple-3) 15%, transparent);
+  color: var(--gnome-purple-3);
+}
+
+.brown {
+  background: color-mix(in srgb, var(--gnome-brown-3) 15%, transparent);
+  color: var(--gnome-brown-3);
+}

--- a/packages/layout/src/components/IconBadge/IconBadge.stories.tsx
+++ b/packages/layout/src/components/IconBadge/IconBadge.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Icon } from "@gnome-ui/react";
+import { IconBadge } from "./IconBadge";
+import type { IconBadgeColor, IconBadgeSize } from "./IconBadge";
+import { GoHome } from "@gnome-ui/icons";
+
+const meta: Meta<typeof IconBadge> = {
+  title: "Layout/IconBadge",
+  component: IconBadge,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+Rounded-square tinted icon container that follows the gnome-ui color token system.
+
+\`\`\`tsx
+import { IconBadge } from "@gnome-ui/layout";
+
+<IconBadge color="blue" size="lg">🚀</IconBadge>
+<IconBadge color="green" size="md"><Icon icon={GoHome} /></IconBadge>
+<IconBadge size="sm">📄</IconBadge>
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof IconBadge>;
+
+// ─── All sizes × colors ────────────────────────────────────────────────────────
+
+const COLORS: (IconBadgeColor | undefined)[] = [
+  "blue", "green", "yellow", "orange", "red", "purple", "brown", undefined,
+];
+const SIZES: IconBadgeSize[] = ["xs", "sm", "md", "lg", "xl"];
+
+export const AllColors: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+      {COLORS.map((color) => (
+        <IconBadge key={color ?? "neutral"} color={color} size="md">
+          🎨
+        </IconBadge>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "All color variants at `md` size. The last badge has no `color` prop — falls back to the neutral overlay." },
+    },
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+      {SIZES.map((size) => (
+        <IconBadge key={size} color="blue" size={size}>
+          🔵
+        </IconBadge>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "All five size variants (`xs` → `xl`) with `color=\"blue\"`." },
+    },
+  },
+};
+
+export const WithIcon: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+      {COLORS.filter(Boolean).map((color) => (
+        <IconBadge key={color} color={color} size="md">
+          <Icon icon={GoHome} size="sm" />
+        </IconBadge>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "Using an `<Icon>` as children. The icon inherits the container `color` automatically." },
+    },
+  },
+};
+
+export const WithEmoji: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+      <IconBadge color="blue" size="xl">🚀</IconBadge>
+      <IconBadge color="green" size="lg">🌿</IconBadge>
+      <IconBadge color="yellow" size="md">⚡</IconBadge>
+      <IconBadge color="red" size="sm">🔥</IconBadge>
+      <IconBadge size="xs">📄</IconBadge>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "Emoji content across different sizes and colors." },
+    },
+  },
+};
+
+export const Neutral: Story = {
+  args: {
+    size: "md",
+    children: "📄",
+  },
+  parameters: {
+    docs: {
+      description: { story: "When `color` is omitted the background uses `--gnome-hover-overlay` (neutral grey tray)." },
+    },
+  },
+};

--- a/packages/layout/src/components/IconBadge/IconBadge.test.tsx
+++ b/packages/layout/src/components/IconBadge/IconBadge.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { IconBadge } from "./IconBadge";
+
+describe("IconBadge", () => {
+  describe("rendering", () => {
+    it("renders children", () => {
+      render(<IconBadge>🚀</IconBadge>);
+      expect(screen.getByText("🚀")).toBeInTheDocument();
+    });
+
+    it("renders with a color prop", () => {
+      render(<IconBadge color="blue">🔵</IconBadge>);
+      expect(screen.getByText("🔵")).toBeInTheDocument();
+    });
+
+    it("renders without a color prop (neutral)", () => {
+      render(<IconBadge>📄</IconBadge>);
+      expect(screen.getByText("📄")).toBeInTheDocument();
+    });
+  });
+
+  describe("CSS classes", () => {
+    it("applies the color class when color is provided", () => {
+      const { container } = render(<IconBadge color="green">🌿</IconBadge>);
+      expect((container.firstChild as HTMLElement).className).toMatch(/green/);
+    });
+
+    it("applies the neutral class when color is omitted", () => {
+      const { container } = render(<IconBadge>📄</IconBadge>);
+      expect((container.firstChild as HTMLElement).className).toMatch(/neutral/);
+    });
+
+    it("applies the size class", () => {
+      const { container } = render(<IconBadge size="lg">🌿</IconBadge>);
+      expect((container.firstChild as HTMLElement).className).toMatch(/lg/);
+    });
+
+    it("defaults to md size", () => {
+      const { container } = render(<IconBadge>📄</IconBadge>);
+      expect((container.firstChild as HTMLElement).className).toMatch(/md/);
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className", () => {
+      const { container } = render(<IconBadge className="custom">📄</IconBadge>);
+      expect(container.firstChild).toHaveClass("custom");
+    });
+
+    it("forwards inline style", () => {
+      const { container } = render(<IconBadge style={{ opacity: 0.5 }}>📄</IconBadge>);
+      expect((container.firstChild as HTMLElement).style.opacity).toBe("0.5");
+    });
+
+    it("forwards arbitrary HTML attributes", () => {
+      render(<IconBadge data-testid="badge">📄</IconBadge>);
+      expect(screen.getByTestId("badge")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/layout/src/components/IconBadge/IconBadge.tsx
+++ b/packages/layout/src/components/IconBadge/IconBadge.tsx
@@ -1,0 +1,45 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import styles from "./IconBadge.module.css";
+
+export type IconBadgeColor =
+  | "blue"
+  | "green"
+  | "yellow"
+  | "orange"
+  | "red"
+  | "purple"
+  | "brown";
+
+export type IconBadgeSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+export interface IconBadgeProps extends HTMLAttributes<HTMLDivElement> {
+  color?: IconBadgeColor;
+  size?: IconBadgeSize;
+  children: ReactNode;
+}
+
+export function IconBadge({
+  color,
+  size = "md",
+  className,
+  style,
+  children,
+  ...props
+}: IconBadgeProps) {
+  return (
+    <div
+      className={[
+        styles.badge,
+        styles[size],
+        color ? styles[color] : styles.neutral,
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={style}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/layout/src/components/IconBadge/index.ts
+++ b/packages/layout/src/components/IconBadge/index.ts
@@ -1,0 +1,2 @@
+export { IconBadge } from "./IconBadge";
+export type { IconBadgeProps, IconBadgeColor, IconBadgeSize } from "./IconBadge";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -16,3 +16,6 @@ export type { PanelCardProps, PanelCardHandle } from "./components/PanelCard";
 
 export { AdaptiveLayout } from "./components/AdaptiveLayout";
 export type { AdaptiveLayoutProps, AdaptiveNavItem } from "./components/AdaptiveLayout";
+
+export { IconBadge } from "./components/IconBadge";
+export type { IconBadgeProps, IconBadgeColor, IconBadgeSize } from "./components/IconBadge";


### PR DESCRIPTION
## What
IconBadge

Rounded-square tinted icon container with 5 size variants (xs→xl) and 7 semantic color tokens (blue, green, yellow, orange, red, purple, brown) using color-mix against --gnome-{color}-3. Falls back to --gnome-hover-overlay when no color is provided. Children inherit the container color, so <Icon> tints automatically.

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
