### PR TITLE
feat: add 'pill' variant to InlineViewSwitcher (closes #62)

### DIFF
--- a/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcher.module.css
+++ b/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcher.module.css
@@ -230,6 +230,64 @@
   }
 }
 
+/* ─── Variant: pill ─────────────────────────────────────────────────────────── */
+
+.pill {
+  background-color: var(--gnome-hover-overlay, rgba(0, 0, 0, 0.06));
+  border: none;
+  border-radius: var(--gnome-radius-pill, 9999px);
+  box-shadow: none;
+  padding: 3px;
+  gap: 2px;
+}
+
+.pill .item {
+  border-radius: var(--gnome-radius-pill, 9999px);
+  padding: 5px var(--gnome-space-2, 16px);
+  color: var(--gnome-window-fg-color);
+}
+
+.pill .item:hover:not(:disabled):not(.active) {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.pill .item:active:not(:disabled):not(.active) {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.pill .item:focus-visible {
+  box-shadow:
+    0 0 0 var(--gnome-focus-ring-offset, 2px) transparent,
+    0 0 0 calc(var(--gnome-focus-ring-offset, 2px) + var(--gnome-focus-ring-width, 2px))
+      var(--gnome-focus-ring-color, #3584e4);
+}
+
+.pill .active {
+  background-color: var(--gnome-card-bg-color, #ffffff);
+  box-shadow: var(--gnome-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.12));
+  font-weight: var(--gnome-font-weight-semibold, 600);
+  color: var(--gnome-window-fg-color);
+}
+
+@media (prefers-color-scheme: dark) {
+  .pill {
+    background-color: var(--gnome-hover-overlay, rgba(255, 255, 255, 0.08));
+  }
+
+  .pill .item:hover:not(:disabled):not(.active) {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+
+  .pill .item:active:not(:disabled):not(.active) {
+    background-color: rgba(255, 255, 255, 0.10);
+  }
+
+  .pill .active {
+    background-color: var(--gnome-card-bg-color, #383838);
+    box-shadow: none;
+  }
+}
+
 /* ─── Disabled ──────────────────────────────────────────────────────────────── */
 
 .item:disabled {

--- a/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcher.stories.tsx
+++ b/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcher.stories.tsx
@@ -26,7 +26,8 @@ Compose with \`InlineViewSwitcherItem\`. Keyboard: **← →** cycle, **Home / E
 |---------|-------------|
 | \`default\` | Standalone control with clear elevation — inside cards or content areas |
 | \`flat\` | Inside a toolbar or header bar background — blends with the surface |
-| \`round\` | Prominent pill shape for primary view selection in open space |
+| \`round\` | Prominent pill shape with accent active indicator |
+| \`pill\` | Segmented-control style — active item lifted, no accent color (Following tabs) |
 
 ### Guidelines
 - Prefer \`ViewSwitcher\` in a \`HeaderBar\` for top-level navigation.
@@ -46,7 +47,7 @@ Compose with \`InlineViewSwitcherItem\`. Keyboard: **← →** cycle, **Home / E
   argTypes: {
     variant: {
       control: "select",
-      options: ["default", "flat", "round"],
+      options: ["default", "flat", "round", "pill"],
     },
     value: { control: "text" },
   },
@@ -86,6 +87,7 @@ export const AllVariants: Story = {
     const [v1, setV1] = useState("list");
     const [v2, setV2] = useState("list");
     const [v3, setV3] = useState("list");
+    const [v4, setV4] = useState("apps");
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: 20, width: "100%" }}>
         <div>
@@ -122,13 +124,23 @@ export const AllVariants: Story = {
             <InlineViewSwitcherItem name="columns" label="Columns" />
           </InlineViewSwitcher>
         </div>
+
+        <div>
+          <p style={{ margin: "0 0 8px", fontSize: "0.75rem", opacity: 0.6, color: "var(--gnome-window-fg-color)" }}>
+            pill
+          </p>
+          <InlineViewSwitcher variant="pill" value={v4} onValueChange={setV4} aria-label="Following view">
+            <InlineViewSwitcherItem name="apps" label="Apps" />
+            <InlineViewSwitcherItem name="maintainers" label="Maintainers" />
+          </InlineViewSwitcher>
+        </div>
       </div>
     );
   },
   parameters: {
     controls: { disable: true },
     docs: {
-      description: { story: "All three variants side by side in their natural contexts." },
+      description: { story: "All four variants side by side in their natural contexts." },
     },
   },
 };
@@ -245,6 +257,29 @@ export const DisabledItems: Story = {
     controls: { disable: true },
     docs: {
       description: { story: "Individual items can be disabled while leaving others active." },
+    },
+  },
+};
+
+// ─── Pill ──────────────────────────────────────────────────────────────────────
+
+export const Pill: Story = {
+  render: () => {
+    const [tab, setTab] = useState("apps");
+    return (
+      <InlineViewSwitcher variant="pill" value={tab} onValueChange={setTab} aria-label="Following view">
+        <InlineViewSwitcherItem name="apps" label="Apps" />
+        <InlineViewSwitcherItem name="maintainers" label="Maintainers" />
+      </InlineViewSwitcher>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "`pill` variant — segmented-control style. Active item appears lifted with a card background and subtle shadow; no accent color is used. Ideal for tab-like switching in open content areas.",
+      },
     },
   },
 };

--- a/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcher.tsx
+++ b/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcher.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import styles from "./InlineViewSwitcher.module.css";
 
-export type InlineViewSwitcherVariant = "default" | "flat" | "round";
+export type InlineViewSwitcherVariant = "default" | "flat" | "round" | "pill";
 
 // ─── Internal context ──────────────────────────────────────────────────────────
 
@@ -41,6 +41,7 @@ export interface InlineViewSwitcherProps extends HTMLAttributes<HTMLDivElement> 
    * - `default` — card background with border and shadow (same as `ToggleGroup`).
    * - `flat`    — no background or border; active indicator only.
    * - `round`   — pill-shaped container and items.
+   * - `pill`    — segmented-control style; active item appears lifted, no accent color.
    */
   variant?: InlineViewSwitcherVariant;
   /** Accessible label for the group. */


### PR DESCRIPTION
## What
variant=pill
Segmented-control style: muted tray background, active item lifted with card bg + shadow, no accent color. Includes dark mode overrides.

## Changes

- [ ] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
