### PR TITLE
feat: extend CounterCard with icon, color, and trend props

### DIFF
--- a/packages/layout/src/components/CounterCard/CounterCard.module.css
+++ b/packages/layout/src/components/CounterCard/CounterCard.module.css
@@ -7,10 +7,27 @@
   padding: 20px !important; /* override Card .padding-md */
 }
 
-/* ─── Label ───────────────────────────────────────────────────────────────── */
+/* ─── Header row (label + icon badge) ────────────────────────────────────── */
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
 
 .label {
   display: block;
+}
+
+.iconBadge {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* ─── Value row ───────────────────────────────────────────────────────────── */
@@ -35,6 +52,14 @@
   line-height: 1;
   color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
   opacity: 0.7;
+}
+
+/* ─── Trend line ──────────────────────────────────────────────────────────── */
+
+.trend {
+  display: block;
+  color: var(--gnome-success-color, #26a269) !important;
+  margin-top: 2px;
 }
 
 /* ─── Accent variant ─────────────────────────────────────────────────────── */

--- a/packages/layout/src/components/CounterCard/CounterCard.stories.tsx
+++ b/packages/layout/src/components/CounterCard/CounterCard.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@gnome-ui/react";
+import { Applications, Person, Refresh, Heart } from "@gnome-ui/icons";
 import { CounterCard } from "./CounterCard";
 
 const meta: Meta<typeof CounterCard> = {
@@ -163,6 +164,38 @@ export const LiveChange: Story = {
           "When `value` changes while a previous animation is still running, the counter " +
           "re-animates **from its current mid-point** — no jump, no restart from 0.",
       },
+    },
+  },
+};
+
+// ─── Dashboard stats (icon + color + trend) ───────────────────────────────────
+
+const STATS = [
+  { label: "Published Apps",  value: 3,     format: undefined as ((v: number) => string) | undefined, icon: Applications, color: "#3584e4", trend: "↑ 1 this month" },
+  { label: "Total Downloads", value: 25700, format: (v: number) => `${(v / 1000).toFixed(1)}k`,       icon: Person,       color: "#33d17a", trend: "↑ 12% this week" },
+  { label: "API Calls Today", value: 1482,  format: undefined as ((v: number) => string) | undefined, icon: Refresh,      color: "#ff7800", trend: "↑ 340 from yesterday" },
+  { label: "Followers",       value: 128,   format: undefined as ((v: number) => string) | undefined, icon: Heart,        color: "#e01b24", trend: "↑ 8 this week" },
+];
+
+export const DashboardStats: Story = {
+  render: () => (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 180px)", gap: 12 }}>
+      {STATS.map((s) => (
+        <CounterCard
+          key={s.label}
+          label={s.label}
+          value={s.value}
+          format={s.format}
+          icon={s.icon}
+          color={s.color}
+          trend={s.trend}
+        />
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "`icon`, `color`, and `trend` props — mirrors the Developer Portal Dashboard STATS grid." },
     },
   },
 };

--- a/packages/layout/src/components/CounterCard/CounterCard.tsx
+++ b/packages/layout/src/components/CounterCard/CounterCard.tsx
@@ -4,7 +4,8 @@ import {
   useState,
   type HTMLAttributes,
 } from "react";
-import { Card, Text } from "@gnome-ui/react";
+import { Card, Icon, Text } from "@gnome-ui/react";
+import type { IconDefinition } from "@gnome-ui/icons";
 import styles from "./CounterCard.module.css";
 
 // ─── Hook ─────────────────────────────────────────────────────────────────────
@@ -109,20 +110,18 @@ export interface CounterCardProps extends HTMLAttributes<HTMLDivElement> {
   accent?: boolean;
   /** Make the card interactive (clickable). Passed to `Card`. */
   interactive?: boolean;
+  /** Icon rendered in a tinted badge in the top-right corner of the card. */
+  icon?: IconDefinition;
+  /**
+   * Per-card accent color (CSS color string, e.g. `"#3584e4"`).
+   * Drives the icon badge background tint and the value text color.
+   * Takes precedence over the `accent` boolean when provided.
+   */
+  color?: string;
+  /** Short trend line rendered below the value in a muted success color. */
+  trend?: string;
 }
 
-/**
- * Metric card with an animated numeric counter.
- *
- * Wraps `Card` from `@gnome-ui/react` and adds a `useCountUp` animation that
- * counts from `0` (or from the previous value) to `value` using an ease-out
- * cubic curve. Respects `prefers-reduced-motion`.
- *
- * ```tsx
- * <CounterCard label="Documents" value={1248} suffix=" files" />
- * <CounterCard label="Revenue"   value={9420} prefix="$" accent duration={1500} />
- * ```
- */
 export function CounterCard({
   label,
   value,
@@ -134,6 +133,9 @@ export function CounterCard({
   duration = 1000,
   accent = false,
   interactive = false,
+  icon,
+  color,
+  trend,
   className,
   style,
   ...props
@@ -147,6 +149,8 @@ export function CounterCard({
         maximumFractionDigits: decimals,
       });
 
+  const useColor = Boolean(color);
+
   return (
     <Card
       interactive={interactive}
@@ -154,16 +158,32 @@ export function CounterCard({
       style={style}
       {...props}
     >
-      <Text variant="caption" color="dim" className={styles.label}>
-        {label}
-      </Text>
+      <div className={styles.header}>
+        <Text variant="caption" color="dim" className={styles.label}>
+          {label}
+        </Text>
+        {icon && (
+          <div
+            className={styles.iconBadge}
+            style={{
+              background: color
+                ? `color-mix(in srgb, ${color} 15%, transparent)`
+                : "var(--gnome-hover-overlay, rgba(0,0,0,0.06))",
+              color: color ?? undefined,
+            }}
+          >
+            <Icon icon={icon} size="sm" />
+          </div>
+        )}
+      </div>
       <span
         className={[
           styles.value,
-          accent ? styles.accent : null,
+          useColor ? null : accent ? styles.accent : null,
         ]
           .filter(Boolean)
           .join(" ")}
+        style={useColor ? { color } : undefined}
         aria-live="polite"
         aria-atomic="true"
         aria-label={`${label}: ${prefix ?? ""}${value.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}${suffix ?? ""}`}
@@ -174,6 +194,11 @@ export function CounterCard({
         </Text>
         {suffix && <span className={styles.affix}>{suffix}</span>}
       </span>
+      {trend && (
+        <Text variant="caption" className={styles.trend}>
+          {trend}
+        </Text>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
## What

Adds per-card icon badge (tinted with color-mix), custom accent color, and a trend caption line. Updates Developer Portal STATS mock to raw numeric values and replaces the inline Dashboard markup with CounterCard.

(closes #60)

## Changes

- [ ] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
