### PR TITLE
EntityCard / StatusBadge / ApplicationCard

### DIFF
--- a/packages/core/src/tokens.css
+++ b/packages/core/src/tokens.css
@@ -143,6 +143,10 @@
   --gnome-error-bg-color: var(--gnome-red-3);
   --gnome-error-fg-color: #ffffff;
 
+  --gnome-new-color: var(--gnome-purple-3);
+  --gnome-new-bg-color: var(--gnome-purple-3);
+  --gnome-new-fg-color: #ffffff;
+
   /* ─── Window & Surface Colors ───────────────────────────────── */
 
   --gnome-window-bg-color: #fafafa;
@@ -407,6 +411,9 @@
     --gnome-error-color: var(--gnome-red-5);
     --gnome-error-bg-color: var(--gnome-red-5);
 
+    --gnome-new-color: var(--gnome-purple-5);
+    --gnome-new-bg-color: var(--gnome-purple-5);
+
     /* Overlays: solid, not transparent */
     --gnome-hover-overlay: rgba(0, 0, 0, 0.12);
     --gnome-active-overlay: rgba(0, 0, 0, 0.22);
@@ -443,6 +450,9 @@
 
     --gnome-error-color: var(--gnome-red-1);
     --gnome-error-bg-color: var(--gnome-red-2);
+
+    --gnome-new-color: var(--gnome-purple-1);
+    --gnome-new-bg-color: var(--gnome-purple-2);
 
     --gnome-hover-overlay: rgba(255, 255, 255, 0.12);
     --gnome-active-overlay: rgba(255, 255, 255, 0.22);
@@ -588,6 +598,9 @@
   --gnome-error-color: var(--gnome-red-5);
   --gnome-error-bg-color: var(--gnome-red-5);
 
+  --gnome-new-color: var(--gnome-purple-5);
+  --gnome-new-bg-color: var(--gnome-purple-5);
+
   --gnome-hover-overlay: rgba(0, 0, 0, 0.12);
   --gnome-active-overlay: rgba(0, 0, 0, 0.22);
   --gnome-border-subtle: rgba(0, 0, 0, 0.5);
@@ -617,6 +630,9 @@
 
   --gnome-error-color: var(--gnome-red-1);
   --gnome-error-bg-color: var(--gnome-red-2);
+
+  --gnome-new-color: var(--gnome-purple-1);
+  --gnome-new-bg-color: var(--gnome-purple-2);
 
   --gnome-window-bg-color: #242424;
   --gnome-window-fg-color: #ffffff;

--- a/packages/layout/src/components/ApplicationCard/ApplicationCard.module.css
+++ b/packages/layout/src/components/ApplicationCard/ApplicationCard.module.css
@@ -1,0 +1,88 @@
+/* ─── Card override ──────────────────────────────────────────────────────────── */
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px 20px !important;
+}
+
+/* ─── Header row ─────────────────────────────────────────────────────────────── */
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.avatarSlot {
+  flex-shrink: 0;
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* ─── Name row ───────────────────────────────────────────────────────────────── */
+
+.nameRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.name {
+  line-height: 1.2 !important;
+}
+
+.badge {
+  flex-shrink: 0;
+}
+
+/* ─── Description ────────────────────────────────────────────────────────────── */
+
+.description {
+  display: block;
+}
+
+/* ─── Stats row ──────────────────────────────────────────────────────────────── */
+
+.stats {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.statLabel {
+  display: block;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.625rem !important;
+}
+
+.statValue {
+  font-family: var(--gnome-font-family);
+  font-size: var(--gnome-font-size-body, 1rem);
+  font-weight: 600;
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  line-height: 1.2;
+}
+
+/* ─── Actions row ────────────────────────────────────────────────────────────── */
+
+.actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}

--- a/packages/layout/src/components/ApplicationCard/ApplicationCard.stories.tsx
+++ b/packages/layout/src/components/ApplicationCard/ApplicationCard.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button, StatusBadge } from "@gnome-ui/react";
+import { IconBadge } from "../IconBadge";
+import { ApplicationCard } from "./ApplicationCard";
+
+const meta: Meta<typeof ApplicationCard> = {
+  title: "Layout/ApplicationCard",
+  component: ApplicationCard,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+App detail header with avatar, name, badge, description, stat row, and actions.
+Designed for the MyApps \`AppDetail\` view — use \`EntityCard\` for list rows.
+
+\`\`\`tsx
+import { ApplicationCard } from "@gnome-ui/layout";
+
+<ApplicationCard
+  avatar={<IconBadge color="blue" size="xl">⛅</IconBadge>}
+  name="GNOME Weather"
+  badge={<StatusBadge variant="success">published</StatusBadge>}
+  description="The official weather app for the GNOME desktop."
+  stats={[
+    { label: "Version", value: "v4.8.1" },
+    { label: "Builds",  value: "24" },
+  ]}
+  actions={<Button variant="suggested">New Release</Button>}
+/>
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ApplicationCard>;
+
+// ─── Full — MyApps AppDetail ───────────────────────────────────────────────────
+
+const APPS = [
+  { id: "weather",  icon: "⛅", color: "#3584e4", name: "GNOME Weather",  status: "published" as const, desc: "The official weather app for the GNOME desktop.", version: "v4.8.1",  builds: 24, updated: "2 days ago" },
+  { id: "maps",     icon: "🗺",  color: "#33d17a", name: "GNOME Maps",    status: "published" as const, desc: "Explore and navigate the world.",                version: "v3.38.0", builds: 18, updated: "1 week ago" },
+  { id: "podcasts", icon: "🎙",  color: "#9141ac", name: "GNOME Podcasts",status: "beta" as const,      desc: "Listen to podcasts on GNOME.",                  version: "v0.5.1",  builds: 7,  updated: "3 weeks ago" },
+];
+
+export const MyAppsDetail: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16, width: 480 }}>
+      {APPS.map((app) => (
+        <ApplicationCard
+          key={app.id}
+          avatar={<IconBadge color={app.color as "blue"} size="xl">{app.icon}</IconBadge>}
+          name={app.name}
+          badge={
+            <StatusBadge variant={app.status === "published" ? "success" : "warning"}>
+              {app.status}
+            </StatusBadge>
+          }
+          description={app.desc}
+          stats={[
+            { label: "Version",      value: app.version },
+            { label: "Builds",       value: String(app.builds) },
+            { label: "Last updated", value: app.updated },
+          ]}
+          actions={
+            <>
+              <Button variant="flat">Edit</Button>
+              <Button variant="suggested">New Release</Button>
+            </>
+          }
+        />
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "Full MyApps AppDetail variant — all props provided." },
+    },
+  },
+};
+
+// ─── Without stats or actions ──────────────────────────────────────────────────
+
+export const Minimal: Story = {
+  args: {
+    avatar: <IconBadge size="xl">📦</IconBadge>,
+    name: "My Application",
+    description: "A short description of this application.",
+  },
+  parameters: {
+    docs: {
+      description: { story: "Only `avatar`, `name`, and `description` — no stats or actions." },
+    },
+  },
+};
+
+// ─── Stats only, no actions ────────────────────────────────────────────────────
+
+export const WithStats: Story = {
+  args: {
+    avatar: <IconBadge color="green" size="xl">🗺</IconBadge>,
+    name: "GNOME Maps",
+    description: "Explore and navigate the world.",
+    stats: [
+      { label: "Version",      value: "v3.38.0" },
+      { label: "Builds",       value: "18" },
+      { label: "Last updated", value: "1 week ago" },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: { story: "`stats` row without `actions`." },
+    },
+  },
+};

--- a/packages/layout/src/components/ApplicationCard/ApplicationCard.test.tsx
+++ b/packages/layout/src/components/ApplicationCard/ApplicationCard.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ApplicationCard } from "./ApplicationCard";
+
+const avatar = <div data-testid="avatar">A</div>;
+
+describe("ApplicationCard", () => {
+  describe("required props", () => {
+    it("renders the avatar slot", () => {
+      render(<ApplicationCard avatar={avatar} name="GNOME Weather" />);
+      expect(screen.getByTestId("avatar")).toBeInTheDocument();
+    });
+
+    it("renders the name", () => {
+      render(<ApplicationCard avatar={avatar} name="GNOME Weather" />);
+      expect(screen.getByText("GNOME Weather")).toBeInTheDocument();
+    });
+  });
+
+  describe("optional props", () => {
+    it("renders badge when provided", () => {
+      render(<ApplicationCard avatar={avatar} name="T" badge={<span>published</span>} />);
+      expect(screen.getByText("published")).toBeInTheDocument();
+    });
+
+    it("renders description when provided", () => {
+      render(<ApplicationCard avatar={avatar} name="T" description="A weather app." />);
+      expect(screen.getByText("A weather app.")).toBeInTheDocument();
+    });
+
+    it("does not render description when omitted", () => {
+      render(<ApplicationCard avatar={avatar} name="T" />);
+      expect(screen.queryByText("A weather app.")).toBeNull();
+    });
+
+    it("renders action slot when provided", () => {
+      render(<ApplicationCard avatar={avatar} name="T" actions={<button>Edit</button>} />);
+      expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    });
+
+    it("does not render action slot when omitted", () => {
+      render(<ApplicationCard avatar={avatar} name="T" />);
+      expect(screen.queryByRole("button")).toBeNull();
+    });
+  });
+
+  describe("stats", () => {
+    const stats = [
+      { label: "Version", value: "v4.8.1" },
+      { label: "Builds",  value: "24" },
+    ];
+
+    it("renders stat labels and values", () => {
+      render(<ApplicationCard avatar={avatar} name="T" stats={stats} />);
+      expect(screen.getByText("Version")).toBeInTheDocument();
+      expect(screen.getByText("v4.8.1")).toBeInTheDocument();
+      expect(screen.getByText("Builds")).toBeInTheDocument();
+      expect(screen.getByText("24")).toBeInTheDocument();
+    });
+
+    it("omits stats row when stats is undefined", () => {
+      const { container } = render(<ApplicationCard avatar={avatar} name="T" />);
+      expect(container.querySelector("[class*=stats]")).toBeNull();
+    });
+
+    it("omits stats row when stats is empty array", () => {
+      const { container } = render(<ApplicationCard avatar={avatar} name="T" stats={[]} />);
+      expect(container.querySelector("[class*=stats]")).toBeNull();
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards data-testid to root element", () => {
+      render(<ApplicationCard avatar={avatar} name="T" data-testid="appcard" />);
+      expect(screen.getByTestId("appcard")).toBeInTheDocument();
+    });
+
+    it("forwards className to root element", () => {
+      const { container } = render(<ApplicationCard avatar={avatar} name="T" className="custom" />);
+      expect((container.firstChild as HTMLElement).className).toContain("custom");
+    });
+  });
+});

--- a/packages/layout/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/packages/layout/src/components/ApplicationCard/ApplicationCard.tsx
@@ -1,0 +1,73 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { Card, Text } from "@gnome-ui/react";
+import styles from "./ApplicationCard.module.css";
+
+export interface ApplicationCardStat {
+  label: string;
+  value: string;
+}
+
+export interface ApplicationCardProps extends HTMLAttributes<HTMLDivElement> {
+  /** Avatar slot — unconstrained ReactNode. Use `<IconBadge size="xl">` here. */
+  avatar: ReactNode;
+  /** Application name — primary title. */
+  name: string;
+  /** Optional node rendered inline next to the name (e.g. `<StatusBadge>`). */
+  badge?: ReactNode;
+  /** Short description rendered below the name. */
+  description?: string;
+  /** Horizontal row of labeled key/value stat pairs. Omitted when empty. */
+  stats?: ApplicationCardStat[];
+  /** Action buttons rendered below the stats row. Omitted when undefined. */
+  actions?: ReactNode;
+}
+
+export function ApplicationCard({
+  avatar,
+  name,
+  badge,
+  description,
+  stats,
+  actions,
+  className,
+  ...props
+}: ApplicationCardProps) {
+  return (
+    <Card
+      className={[styles.card, className].filter(Boolean).join(" ")}
+      {...props}
+    >
+      <div className={styles.header}>
+        <div className={styles.avatarSlot}>{avatar}</div>
+
+        <div className={styles.body}>
+          <div className={styles.nameRow}>
+            <Text variant="title-2" className={styles.name}>{name}</Text>
+            {badge && <span className={styles.badge}>{badge}</span>}
+          </div>
+
+          {description && (
+            <Text variant="caption" color="dim" className={styles.description}>
+              {description}
+            </Text>
+          )}
+        </div>
+      </div>
+
+      {stats && stats.length > 0 && (
+        <div className={styles.stats}>
+          {stats.map((s) => (
+            <div key={s.label} className={styles.stat}>
+              <Text variant="caption" color="dim" className={styles.statLabel}>
+                {s.label}
+              </Text>
+              <span className={styles.statValue}>{s.value}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {actions && <div className={styles.actions}>{actions}</div>}
+    </Card>
+  );
+}

--- a/packages/layout/src/components/ApplicationCard/index.ts
+++ b/packages/layout/src/components/ApplicationCard/index.ts
@@ -1,0 +1,2 @@
+export { ApplicationCard } from "./ApplicationCard";
+export type { ApplicationCardProps, ApplicationCardStat } from "./ApplicationCard";

--- a/packages/layout/src/components/EntityCard/EntityCard.module.css
+++ b/packages/layout/src/components/EntityCard/EntityCard.module.css
@@ -1,0 +1,78 @@
+/* ─── Card override ──────────────────────────────────────────────────────────── */
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px !important;
+}
+
+/* ─── Avatar + body row ──────────────────────────────────────────────────────── */
+
+.inner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.avatarSlot {
+  flex-shrink: 0;
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* ─── Title row ──────────────────────────────────────────────────────────────── */
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.title {
+  font-family: var(--gnome-font-family);
+  font-size: var(--gnome-font-size-body, 1rem);
+  font-weight: 600;
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1;
+}
+
+.badge {
+  flex-shrink: 0;
+}
+
+.trailing {
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+/* ─── Subtitle / description ─────────────────────────────────────────────────── */
+
+.subtitle {
+  display: block;
+}
+
+.description {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── Footer meta ────────────────────────────────────────────────────────────── */
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/packages/layout/src/components/EntityCard/EntityCard.stories.tsx
+++ b/packages/layout/src/components/EntityCard/EntityCard.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Avatar, StatusBadge } from "@gnome-ui/react";
+import { IconBadge } from "../IconBadge";
+import { EntityCard } from "./EntityCard";
+
+const meta: Meta<typeof EntityCard> = {
+  title: "Layout/EntityCard",
+  component: EntityCard,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+Avatar/icon + title + meta card. Covers both compact grid cards (Following screen)
+and full-width list rows (MyApps screen) via additive optional props.
+
+\`\`\`tsx
+import { EntityCard } from "@gnome-ui/layout";
+import { IconBadge } from "@gnome-ui/layout";
+
+<EntityCard
+  avatar={<IconBadge color="blue" size="md">🌤</IconBadge>}
+  title="GNOME Weather"
+  subtitle="@alice_dev"
+  meta={["v4.8.0", "⭐ 203"]}
+/>
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EntityCard>;
+
+// ─── Following — Apps tab ──────────────────────────────────────────────────────
+
+const FOLLOWING_APPS = [
+  { id: "1", icon: "🌤", name: "GNOME Weather",  maintainer: "@alice_dev",  version: "v4.8.0", watchers: 203 },
+  { id: "2", icon: "📅", name: "GNOME Calendar", maintainer: "@gnome_team", version: "v47.0",  watchers: 891 },
+  { id: "3", icon: "🎵", name: "Rhythmbox",       maintainer: "@rbox_dev",   version: "v3.4.7", watchers: 517 },
+];
+
+export const FollowingApps: Story = {
+  render: () => (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 10, width: 500 }}>
+      {FOLLOWING_APPS.map((app) => (
+        <EntityCard
+          key={app.id}
+          avatar={<IconBadge size="md">{app.icon}</IconBadge>}
+          title={app.name}
+          subtitle={app.maintainer}
+          meta={[app.version, `⭐ ${app.watchers}`]}
+          onClick={() => {}}
+        />
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "Compact grid cards — Following / Apps tab. No `badge`, no `description`." },
+    },
+  },
+};
+
+// ─── Following — Maintainers tab ───────────────────────────────────────────────
+
+const FOLLOWING_MAINTAINERS = [
+  { id: "1", name: "Alice Dev",    handle: "@alice_dev",   apps: 4, followers: 312 },
+  { id: "2", name: "GNOME Team",   handle: "@gnome_team",  apps: 12, followers: 4821 },
+  { id: "3", name: "Rhythmbox Dev",handle: "@rbox_dev",    apps: 1, followers: 95 },
+];
+
+export const FollowingMaintainers: Story = {
+  render: () => (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 10, width: 500 }}>
+      {FOLLOWING_MAINTAINERS.map((m) => (
+        <EntityCard
+          key={m.id}
+          avatar={<Avatar name={m.name} size="sm" />}
+          title={m.name}
+          subtitle={m.handle}
+          meta={[`${m.apps} apps`, `👤 ${m.followers.toLocaleString()}`]}
+          onClick={() => {}}
+        />
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "Compact grid cards — Following / Maintainers tab. Uses `<Avatar>` instead of `<IconBadge>`." },
+    },
+  },
+};
+
+// ─── MyApps — list rows ────────────────────────────────────────────────────────
+
+const APPS = [
+  { id: "weather",  icon: "⛅", color: "#3584e4", name: "GNOME Weather",   status: "published", desc: "The official weather app for GNOME desktop.", version: "v4.8.1", downloads: 12483 },
+  { id: "maps",     icon: "🗺",  color: "#33d17a", name: "GNOME Maps",      status: "published", desc: "Explore and navigate the world.",              version: "v3.38.0", downloads: 9241 },
+  { id: "podcasts", icon: "🎙",  color: "#9141ac", name: "GNOME Podcasts",  status: "beta",      desc: "Listen to podcasts on GNOME.",                 version: "v0.5.1", downloads: 4102 },
+];
+
+export const MyApps: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, width: 480 }}>
+      {APPS.map((app) => (
+        <EntityCard
+          key={app.id}
+          avatar={<IconBadge color={app.color as "blue"} size="lg">{app.icon}</IconBadge>}
+          title={app.name}
+          badge={
+            <StatusBadge variant={app.status === "published" ? "success" : "warning"}>
+              {app.status}
+            </StatusBadge>
+          }
+          trailing={<span style={{ opacity: 0.3, fontSize: "1.2rem" }}>›</span>}
+          description={app.desc}
+          meta={[app.version, `${app.downloads.toLocaleString()} downloads`]}
+          onClick={() => {}}
+        />
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "Full-width list rows — MyApps screen. Uses `badge`, `trailing`, and `description`." },
+    },
+  },
+};
+
+// ─── Minimal (no optional props) ──────────────────────────────────────────────
+
+export const Minimal: Story = {
+  args: {
+    avatar: <IconBadge size="md">📄</IconBadge>,
+    title: "Entity title",
+  },
+  parameters: {
+    docs: {
+      description: { story: "Only `avatar` and `title` — all other props omitted." },
+    },
+  },
+};

--- a/packages/layout/src/components/EntityCard/EntityCard.test.tsx
+++ b/packages/layout/src/components/EntityCard/EntityCard.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EntityCard } from "./EntityCard";
+
+const avatar = <div data-testid="avatar">A</div>;
+
+describe("EntityCard", () => {
+  describe("required props", () => {
+    it("renders the avatar slot", () => {
+      render(<EntityCard avatar={avatar} title="Title" />);
+      expect(screen.getByTestId("avatar")).toBeInTheDocument();
+    });
+
+    it("renders the title", () => {
+      render(<EntityCard avatar={avatar} title="GNOME Weather" />);
+      expect(screen.getByText("GNOME Weather")).toBeInTheDocument();
+    });
+  });
+
+  describe("optional props", () => {
+    it("renders badge when provided", () => {
+      render(<EntityCard avatar={avatar} title="T" badge={<span>beta</span>} />);
+      expect(screen.getByText("beta")).toBeInTheDocument();
+    });
+
+    it("does not render badge slot when omitted", () => {
+      render(<EntityCard avatar={avatar} title="T" />);
+      expect(screen.queryByRole("generic", { name: /beta/i })).toBeNull();
+    });
+
+    it("renders trailing when provided", () => {
+      render(<EntityCard avatar={avatar} title="T" trailing={<span>›</span>} />);
+      expect(screen.getByText("›")).toBeInTheDocument();
+    });
+
+    it("renders subtitle when provided", () => {
+      render(<EntityCard avatar={avatar} title="T" subtitle="@alice_dev" />);
+      expect(screen.getByText("@alice_dev")).toBeInTheDocument();
+    });
+
+    it("does not render subtitle when omitted", () => {
+      render(<EntityCard avatar={avatar} title="T" />);
+      expect(screen.queryByText("@alice_dev")).toBeNull();
+    });
+
+    it("renders description when provided", () => {
+      render(<EntityCard avatar={avatar} title="T" description="A weather app." />);
+      expect(screen.getByText("A weather app.")).toBeInTheDocument();
+    });
+
+    it("does not render description when omitted", () => {
+      render(<EntityCard avatar={avatar} title="T" />);
+      expect(screen.queryByText("A weather app.")).toBeNull();
+    });
+  });
+
+  describe("meta footer", () => {
+    it("renders both meta strings", () => {
+      render(<EntityCard avatar={avatar} title="T" meta={["v4.8.0", "⭐ 203"]} />);
+      expect(screen.getByText("v4.8.0")).toBeInTheDocument();
+      expect(screen.getByText("⭐ 203")).toBeInTheDocument();
+    });
+
+    it("renders only the first meta string when second is omitted", () => {
+      render(<EntityCard avatar={avatar} title="T" meta={["v1.0"]} />);
+      expect(screen.getByText("v1.0")).toBeInTheDocument();
+    });
+
+    it("omits the footer when meta is undefined", () => {
+      const { container } = render(<EntityCard avatar={avatar} title="T" />);
+      expect(container.querySelector("[class*=footer]")).toBeNull();
+    });
+
+    it("omits the footer when meta is an empty tuple", () => {
+      const { container } = render(<EntityCard avatar={avatar} title="T" meta={[]} />);
+      expect(container.querySelector("[class*=footer]")).toBeNull();
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards data-testid to root element", () => {
+      render(<EntityCard avatar={avatar} title="T" data-testid="entity" />);
+      expect(screen.getByTestId("entity")).toBeInTheDocument();
+    });
+
+    it("forwards className to root element", () => {
+      const { container } = render(<EntityCard avatar={avatar} title="T" className="custom" />);
+      expect((container.firstChild as HTMLElement).className).toContain("custom");
+    });
+  });
+});

--- a/packages/layout/src/components/EntityCard/EntityCard.tsx
+++ b/packages/layout/src/components/EntityCard/EntityCard.tsx
@@ -1,0 +1,79 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { Card, Text } from "@gnome-ui/react";
+import styles from "./EntityCard.module.css";
+
+export interface EntityCardProps extends HTMLAttributes<HTMLDivElement> {
+  /** Avatar slot — any ReactNode. Use `<IconBadge>` or `<Avatar>` here. */
+  avatar: ReactNode;
+  /** Primary label — truncated with ellipsis on overflow. */
+  title: string;
+  /** Optional node rendered inline next to the title (e.g. a status badge). */
+  badge?: ReactNode;
+  /** Optional node pinned to the far right of the card. */
+  trailing?: ReactNode;
+  /** Secondary line below the title. */
+  subtitle?: string;
+  /** Third line below subtitle — longer description text. */
+  description?: string;
+  /**
+   * Up to two footer meta strings: first left-aligned, second right-aligned.
+   * Footer row is omitted when undefined or empty.
+   */
+  meta?: [string?, string?];
+  /** Delegates hover/active behavior to Card. Defaults to `true`. */
+  interactive?: boolean;
+}
+
+export function EntityCard({
+  avatar,
+  title,
+  badge,
+  trailing,
+  subtitle,
+  description,
+  meta,
+  interactive = true,
+  className,
+  ...props
+}: EntityCardProps) {
+  const hasMeta = meta && (meta[0] || meta[1]);
+
+  return (
+    <Card
+      interactive={interactive}
+      className={[styles.card, className].filter(Boolean).join(" ")}
+      {...props}
+    >
+      <div className={styles.inner}>
+        <div className={styles.avatarSlot}>{avatar}</div>
+
+        <div className={styles.body}>
+          <div className={styles.titleRow}>
+            <span className={styles.title}>{title}</span>
+            {badge && <span className={styles.badge}>{badge}</span>}
+            {trailing && <span className={styles.trailing}>{trailing}</span>}
+          </div>
+
+          {subtitle && (
+            <Text variant="caption" color="dim" className={styles.subtitle}>
+              {subtitle}
+            </Text>
+          )}
+
+          {description && (
+            <Text variant="caption" color="dim" className={styles.description}>
+              {description}
+            </Text>
+          )}
+        </div>
+      </div>
+
+      {hasMeta && (
+        <div className={styles.footer}>
+          {meta[0] && <Text variant="caption" color="dim">{meta[0]}</Text>}
+          {meta[1] && <Text variant="caption" color="dim">{meta[1]}</Text>}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/packages/layout/src/components/EntityCard/index.ts
+++ b/packages/layout/src/components/EntityCard/index.ts
@@ -1,0 +1,2 @@
+export { EntityCard } from "./EntityCard";
+export type { EntityCardProps } from "./EntityCard";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -19,3 +19,6 @@ export type { AdaptiveLayoutProps, AdaptiveNavItem } from "./components/Adaptive
 
 export { IconBadge } from "./components/IconBadge";
 export type { IconBadgeProps, IconBadgeColor, IconBadgeSize } from "./components/IconBadge";
+
+export { EntityCard } from "./components/EntityCard";
+export type { EntityCardProps } from "./components/EntityCard";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -22,3 +22,6 @@ export type { IconBadgeProps, IconBadgeColor, IconBadgeSize } from "./components
 
 export { EntityCard } from "./components/EntityCard";
 export type { EntityCardProps } from "./components/EntityCard";
+
+export { ApplicationCard } from "./components/ApplicationCard";
+export type { ApplicationCardProps, ApplicationCardStat } from "./components/ApplicationCard";

--- a/packages/react/src/components/StatusBadge/StatusBadge.module.css
+++ b/packages/react/src/components/StatusBadge/StatusBadge.module.css
@@ -1,0 +1,46 @@
+/* ─── Base ────────────────────────────────────────────────────────────────── */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: var(--gnome-radius-pill, 9999px);
+  font-family: var(--gnome-font-family);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+}
+
+/* ─── Variants ────────────────────────────────────────────────────────────── */
+
+.success {
+  background-color: var(--gnome-success-bg-color, #2ec27e);
+  color: var(--gnome-success-fg-color, #ffffff);
+}
+
+.warning {
+  background-color: var(--gnome-warning-bg-color, #f6d32d);
+  color: var(--gnome-warning-fg-color, rgba(0, 0, 0, 0.8));
+}
+
+.error {
+  background-color: var(--gnome-error-bg-color, #e01b24);
+  color: var(--gnome-error-fg-color, #ffffff);
+}
+
+.new {
+  background-color: var(--gnome-new-bg-color, #9141ac);
+  color: var(--gnome-new-fg-color, #ffffff);
+}
+
+.accent {
+  background-color: var(--gnome-accent-bg-color, #3584e4);
+  color: var(--gnome-accent-fg-color, #ffffff);
+}
+
+.neutral {
+  background-color: var(--gnome-hover-overlay, rgba(0, 0, 0, 0.08));
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+}

--- a/packages/react/src/components/StatusBadge/StatusBadge.stories.tsx
+++ b/packages/react/src/components/StatusBadge/StatusBadge.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { StatusBadge } from "./StatusBadge";
+import type { StatusBadgeVariant } from "./StatusBadge";
+
+const meta: Meta<typeof StatusBadge> = {
+  title: "Components/StatusBadge",
+  component: StatusBadge,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+Pill-shaped text label for entity status. Use for human-readable state labels
+like \`published\`, \`beta\`, or \`new\` — not for numeric counts (use \`Badge\` for those).
+
+\`\`\`tsx
+import { StatusBadge } from "@gnome-ui/react";
+
+<StatusBadge variant="success">published</StatusBadge>
+<StatusBadge variant="warning">beta</StatusBadge>
+<StatusBadge variant="new">new</StatusBadge>
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StatusBadge>;
+
+// ─── All variants ──────────────────────────────────────────────────────────────
+
+const VARIANTS: { variant: StatusBadgeVariant; label: string }[] = [
+  { variant: "success", label: "published" },
+  { variant: "warning", label: "beta" },
+  { variant: "error",   label: "failed" },
+  { variant: "new",     label: "new" },
+  { variant: "accent",  label: "featured" },
+  { variant: "neutral", label: "draft" },
+];
+
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+      {VARIANTS.map(({ variant, label }) => (
+        <StatusBadge key={variant} variant={variant}>
+          {label}
+        </StatusBadge>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "All six variants with representative status labels." },
+    },
+  },
+};
+
+export const Success: Story = {
+  args: { variant: "success", children: "published" },
+};
+
+export const Warning: Story = {
+  args: { variant: "warning", children: "beta" },
+};
+
+export const Error: Story = {
+  args: { variant: "error", children: "failed" },
+};
+
+export const New: Story = {
+  args: { variant: "new", children: "new" },
+};
+
+export const Neutral: Story = {
+  args: { variant: "neutral", children: "draft" },
+};

--- a/packages/react/src/components/StatusBadge/StatusBadge.test.tsx
+++ b/packages/react/src/components/StatusBadge/StatusBadge.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatusBadge } from "./StatusBadge";
+
+describe("StatusBadge", () => {
+  it("renders children", () => {
+    render(<StatusBadge>published</StatusBadge>);
+    expect(screen.getByText("published")).toBeInTheDocument();
+  });
+
+  it("defaults to neutral variant", () => {
+    const { container } = render(<StatusBadge>draft</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/neutral/);
+  });
+
+  it("applies the variant class", () => {
+    const { container } = render(<StatusBadge variant="success">published</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/success/);
+  });
+
+  it("applies the new variant class", () => {
+    const { container } = render(<StatusBadge variant="new">new</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/new/);
+  });
+
+  it("forwards className", () => {
+    const { container } = render(<StatusBadge className="custom">x</StatusBadge>);
+    expect((container.firstChild as HTMLElement).className).toContain("custom");
+  });
+
+  it("forwards arbitrary HTML attributes", () => {
+    render(<StatusBadge data-testid="sb">x</StatusBadge>);
+    expect(screen.getByTestId("sb")).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/StatusBadge/StatusBadge.tsx
+++ b/packages/react/src/components/StatusBadge/StatusBadge.tsx
@@ -1,0 +1,54 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import styles from "./StatusBadge.module.css";
+
+export type StatusBadgeVariant =
+  | "success"
+  | "warning"
+  | "error"
+  | "new"
+  | "accent"
+  | "neutral";
+
+export interface StatusBadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  /**
+   * Visual style. Defaults to `"neutral"`.
+   * - `success` — green (`--gnome-success-*`), for published / active states.
+   * - `warning` — yellow (`--gnome-warning-*`), for beta / pending states.
+   * - `error`   — red (`--gnome-error-*`), for failed / rejected states.
+   * - `new`     — purple (`--gnome-new-*`), for newly released / featured items.
+   * - `accent`  — blue (`--gnome-accent-*`), for highlighted / primary states.
+   * - `neutral` — muted overlay, for draft / archived / inactive states.
+   */
+  variant?: StatusBadgeVariant;
+  children: ReactNode;
+}
+
+/**
+ * Pill-shaped text label for entity status — published, beta, new, etc.
+ *
+ * Unlike `Badge` (which is for numeric counts), `StatusBadge` is designed
+ * for short human-readable state labels.
+ *
+ * ```tsx
+ * <StatusBadge variant="success">published</StatusBadge>
+ * <StatusBadge variant="warning">beta</StatusBadge>
+ * <StatusBadge variant="new">new</StatusBadge>
+ * ```
+ */
+export function StatusBadge({
+  variant = "neutral",
+  className,
+  children,
+  ...props
+}: StatusBadgeProps) {
+  return (
+    <span
+      className={[styles.badge, styles[variant], className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/react/src/components/StatusBadge/index.ts
+++ b/packages/react/src/components/StatusBadge/index.ts
@@ -1,0 +1,2 @@
+export { StatusBadge } from "./StatusBadge";
+export type { StatusBadgeProps, StatusBadgeVariant } from "./StatusBadge";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -248,3 +248,6 @@ export type {
 
 export { TerminalView } from "./components/TerminalView";
 export type { TerminalViewProps, TerminalVariant } from "./components/TerminalView";
+
+export { StatusBadge } from "./components/StatusBadge";
+export type { StatusBadgeProps, StatusBadgeVariant } from "./components/StatusBadge";


### PR DESCRIPTION
## What

Add new components Entity Card and Status Badge dependency.
Add new component Application Card.

closes #61 
closes #63

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
