### PR TITLE
feat(@gnome-ui/charts): add TreeMap component (closes #45)

### DIFF
--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -1,12 +1,12 @@
 # @gnome-ui/charts
 
-Chart components for [@gnome-ui/react](../react/README.md), styled with GNOME Adwaita design tokens.
+Chart components for [@gnome-ui/react](../react/README.md), styled with GNOME Adwaita
+design tokens.
 
 [![npm](https://img.shields.io/npm/v/@gnome-ui/charts)](https://www.npmjs.com/package/@gnome-ui/charts)
 [![CI](https://github.com/eljijuna/gnome-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/eljijuna/gnome-ui/actions/workflows/ci.yml)
 [![Storybook](https://img.shields.io/badge/Storybook-live-ff4785?logo=storybook&logoColor=white)](https://eljijuna.github.io/gnome-ui/charts/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
-
 
 ## Installation
 
@@ -33,13 +33,15 @@ import "@gnome-ui/charts/styles";
 | `AreaChart` | Filled area chart with optional stacking, grid, and legend |
 | `BarChart` | Vertical or horizontal bar chart with rounded bars, optional stacking, grid, and legend |
 | `LineChart` | Line chart with dots, grid, and legend |
+| `TreeMap` | Proportional tile chart with optional group coloring and labels |
 
-All components use the Adwaita color palette (`GNOME_CHART_PALETTE`) and CSS custom properties for theming, and adapt automatically to light/dark mode.
+All components use the Adwaita color palette (`GNOME_CHART_PALETTE`) and CSS custom
+properties for theming, and adapt automatically to light/dark mode.
 
 ## Quick example
 
 ```tsx
-import { AreaChart, BarChart, LineChart } from "@gnome-ui/charts";
+import { AreaChart, BarChart, LineChart, TreeMap } from "@gnome-ui/charts";
 
 const data = [
   { month: "Jan", sales: 400, returns: 80 },
@@ -76,6 +78,16 @@ const data = [
   showGrid
   showLegend
 />
+
+// TreeMap
+<TreeMap
+  data={[
+    { label: "React", value: 4200, group: "Frontend" },
+    { label: "Vue", value: 2100, group: "Frontend" },
+    { label: "Node.js", value: 3800, group: "Backend" },
+  ]}
+  height={400}
+/>
 ```
 
 ## Props
@@ -103,8 +115,17 @@ All three components share a common set of props:
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `stacked` | `boolean` | `false` | Stack series on top of each other |
-| `layout` | `"vertical" \| "horizontal"` | `"vertical"` | Bar orientation — `"horizontal"` for a horizontal bar chart |
-| `yAxisFormatter` | `(value: number) => string` | — | Custom formatter for Y-axis tick labels |
+| `layout` | `"vertical" \| "horizontal"` | `"vertical"` | Bar orientation |
+| `yAxisFormatter` | `(value: number) => string` | — | Custom Y-axis tick formatter |
+
+`TreeMap` accepts:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `TreeMapDataItem[]` | — | Array of `{ label, value, group? }` |
+| `height` | `number` | `400` | Chart height in px |
+| `showLabels` | `boolean` | `true` | Show name and value inside each tile |
+| `className` | `string` | — | Extra CSS class on the wrapper |
 
 ## Utilities
 

--- a/packages/charts/src/components/TreeMap/TreeMap.module.css
+++ b/packages/charts/src/components/TreeMap/TreeMap.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/packages/charts/src/components/TreeMap/TreeMap.stories.tsx
+++ b/packages/charts/src/components/TreeMap/TreeMap.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TreeMap } from "./TreeMap";
+
+const meta: Meta<typeof TreeMap> = {
+  title: "Charts/TreeMap",
+  component: TreeMap,
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof TreeMap>;
+
+const FLAT_DATA = [
+  { label: "React", value: 4200 },
+  { label: "Vue", value: 2100 },
+  { label: "Angular", value: 1800 },
+  { label: "Svelte", value: 900 },
+  { label: "Solid", value: 600 },
+];
+
+const GROUPED_DATA = [
+  { label: "React", value: 4200, group: "Frontend" },
+  { label: "Vue", value: 2100, group: "Frontend" },
+  { label: "Node.js", value: 3800, group: "Backend" },
+  { label: "Python", value: 5100, group: "Backend" },
+  { label: "PostgreSQL", value: 2900, group: "Database" },
+];
+
+export const Flat: Story = {
+  args: {
+    data: FLAT_DATA,
+    height: 400,
+  },
+};
+
+export const Grouped: Story = {
+  args: {
+    data: GROUPED_DATA,
+    height: 400,
+  },
+};
+
+export const NoLabels: Story = {
+  args: {
+    data: GROUPED_DATA,
+    height: 400,
+    showLabels: false,
+  },
+};

--- a/packages/charts/src/components/TreeMap/TreeMap.tsx
+++ b/packages/charts/src/components/TreeMap/TreeMap.tsx
@@ -1,0 +1,149 @@
+import { ReactElement } from "react";
+import { Treemap, ResponsiveContainer, Tooltip } from "recharts";
+import { GNOME_CHART_PALETTE } from "../../colors";
+import styles from "./TreeMap.module.css";
+
+export interface TreeMapDataItem {
+  label: string;
+  value: number;
+  group?: string;
+}
+
+export interface TreeMapProps {
+  data: TreeMapDataItem[];
+  height?: number;
+  showLabels?: boolean;
+  className?: string;
+}
+
+const TOOLTIP_CONTENT_STYLE = {
+  backgroundColor: "var(--gnome-popover-bg-color, #fff)",
+  border: "1px solid var(--gnome-light-3, #deddda)",
+  borderRadius: "var(--gnome-radius-md, 8px)",
+  fontFamily: "var(--gnome-font-family, system-ui)",
+  fontSize: 12,
+  boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+};
+
+function buildColorMap(data: TreeMapDataItem[]): Map<string, string> {
+  const keys: string[] = [];
+  for (const item of data) {
+    const key = item.group ?? item.label;
+    if (!keys.includes(key)) keys.push(key);
+  }
+  return new Map(
+    keys.map((k, i) => [k, GNOME_CHART_PALETTE[i % GNOME_CHART_PALETTE.length]])
+  );
+}
+
+interface TileProps {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  name: string;
+  value: number;
+  group?: string;
+  colorMap: Map<string, string>;
+  showLabels: boolean;
+}
+
+function Tile({ x, y, width, height, name, value, group, colorMap, showLabels }: TileProps) {
+  const colorKey = group ?? name;
+  const fill = colorMap.get(colorKey) ?? GNOME_CHART_PALETTE[0];
+  const showText = showLabels && width > 40 && height > 24;
+
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill={fill}
+        stroke="var(--gnome-window-bg-color, #fff)"
+        strokeWidth={2}
+        rx={4}
+        ry={4}
+        role="img"
+        aria-label={`${name}: ${value}`}
+      />
+      {showText && (
+        <>
+          <text
+            x={x + width / 2}
+            y={y + height / 2 - (height > 44 ? 8 : 0)}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fill="var(--gnome-window-fg-color, rgba(255,255,255,0.9))"
+            fontSize={12}
+            fontFamily="var(--gnome-font-family, system-ui)"
+            style={{ pointerEvents: "none", userSelect: "none" }}
+          >
+            {name}
+          </text>
+          {height > 44 && (
+            <text
+              x={x + width / 2}
+              y={y + height / 2 + 10}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fill="var(--gnome-window-fg-color, rgba(255,255,255,0.7))"
+              fontSize={11}
+              fontFamily="var(--gnome-font-family, system-ui)"
+              style={{ pointerEvents: "none", userSelect: "none" }}
+            >
+              {value}
+            </text>
+          )}
+        </>
+      )}
+    </g>
+  );
+}
+
+export function TreeMap({
+  data,
+  height = 400,
+  showLabels = true,
+  className,
+}: TreeMapProps) {
+  const colorMap = buildColorMap(data);
+  const rechartsData = data.map((item) => ({ name: item.label, value: item.value, group: item.group }));
+
+  return (
+    <div
+      className={[styles.container, className].filter(Boolean).join(" ")}
+      style={{ height }}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <Treemap
+          data={rechartsData}
+          dataKey="value"
+          nameKey="name"
+          content={
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ((props: any) => (
+              <Tile
+                x={props.x}
+                y={props.y}
+                width={props.width}
+                height={props.height}
+                name={props.name}
+                value={props.value}
+                group={props.group}
+                colorMap={colorMap}
+                showLabels={showLabels}
+              />
+            )) as unknown as ReactElement
+          }
+        >
+          <Tooltip
+            contentStyle={TOOLTIP_CONTENT_STYLE}
+            formatter={(value: number, name: string) => [value, name]}
+          />
+        </Treemap>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/packages/charts/src/components/TreeMap/index.ts
+++ b/packages/charts/src/components/TreeMap/index.ts
@@ -1,0 +1,2 @@
+export { TreeMap } from "./TreeMap";
+export type { TreeMapProps, TreeMapDataItem } from "./TreeMap";

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -7,4 +7,7 @@ export type { LineChartProps, LineChartSeries } from "./components/LineChart";
 export { AreaChart } from "./components/AreaChart";
 export type { AreaChartProps, AreaChartSeries } from "./components/AreaChart";
 
+export { TreeMap } from "./components/TreeMap";
+export type { TreeMapProps, TreeMapDataItem } from "./components/TreeMap";
+
 export { GNOME_CHART_PALETTE } from "./colors";


### PR DESCRIPTION
## What

add TreeMap component (closes #45)

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
