### PR TITLE
Charts - tree shaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12387,6 +12387,19 @@
         }
       }
     },
+    "node_modules/vite-magic-tree-shaking": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vite-magic-tree-shaking/-/vite-magic-tree-shaking-1.0.0.tgz",
+      "integrity": "sha512-rpminXGdZep9BnCsRK/4aEmj5QXFuTMnh1gwCi4XxQlGwpOv3nNn9/nGBPIUQupEVLobg0DMS1glphRhyzMh1g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "vite-magic": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "vite": ">=5.0.0"
+      }
+    },
     "node_modules/vite-plugin-dts": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz",
@@ -12976,7 +12989,7 @@
     },
     "packages/charts": {
       "name": "@gnome-ui/charts",
-      "version": "1.13.2",
+      "version": "1.26.0",
       "dependencies": {
         "@gnome-ui/core": "*",
         "recharts": "^2.15.3"
@@ -12993,6 +13006,7 @@
         "react-dom": "^19.0.0",
         "storybook": "^10.3.3",
         "vite": "^8.0.3",
+        "vite-magic-tree-shaking": "^1.0.0",
         "vite-plugin-dts": "^4.5.4"
       },
       "peerDependencies": {
@@ -13002,11 +13016,11 @@
     },
     "packages/core": {
       "name": "@gnome-ui/core",
-      "version": "1.27.0"
+      "version": "1.39.0"
     },
     "packages/hooks": {
       "name": "@gnome-ui/hooks",
-      "version": "1.12.2",
+      "version": "1.25.0",
       "dependencies": {
         "@gnome-ui/platform": "*"
       },
@@ -13028,7 +13042,7 @@
     },
     "packages/icons": {
       "name": "@gnome-ui/icons",
-      "version": "1.24.2",
+      "version": "1.37.0",
       "devDependencies": {
         "@storybook/addon-a11y": "^10.3.3",
         "@storybook/addon-docs": "^10.3.3",
@@ -13046,11 +13060,12 @@
     },
     "packages/layout": {
       "name": "@gnome-ui/layout",
-      "version": "1.2.0",
+      "version": "1.11.0",
       "dependencies": {
         "@gnome-ui/core": "*"
       },
       "devDependencies": {
+        "@gnome-ui/hooks": "*",
         "@gnome-ui/icons": "*",
         "@gnome-ui/react": "*",
         "@storybook/addon-a11y": "^10.3.3",
@@ -13073,6 +13088,7 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
+        "@gnome-ui/hooks": "*",
         "@gnome-ui/react": "*",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -13080,7 +13096,7 @@
     },
     "packages/platform": {
       "name": "@gnome-ui/platform",
-      "version": "1.12.2",
+      "version": "1.25.0",
       "devDependencies": {
         "vite": "^8.0.3",
         "vite-plugin-dts": "^4.5.4"
@@ -13088,7 +13104,7 @@
     },
     "packages/react": {
       "name": "@gnome-ui/react",
-      "version": "1.23.2",
+      "version": "1.36.0",
       "dependencies": {
         "@gnome-ui/core": "*",
         "@gnome-ui/icons": "*"

--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -38,6 +38,33 @@ import "@gnome-ui/charts/styles";
 All components use the Adwaita color palette (`GNOME_CHART_PALETTE`) and CSS custom
 properties for theming, and adapt automatically to light/dark mode.
 
+## Imports
+
+### Standard import (barrel)
+
+Import any component from the package root. Works with every bundler and is
+the simplest option. Modern bundlers that respect the `sideEffects` field in
+`package.json` will still tree-shake unused components automatically.
+
+```tsx
+import { AreaChart, BarChart, LineChart, TreeMap } from "@gnome-ui/charts";
+```
+
+### Per-component import (explicit tree-shaking)
+
+Each component is also exposed as its own sub-path export. Use this form if
+your bundler does not perform tree-shaking, or when you want to be explicit
+about what you pull in.
+
+```tsx
+import { BarChart } from "@gnome-ui/charts/components/BarChart";
+import { LineChart } from "@gnome-ui/charts/components/LineChart";
+import { AreaChart } from "@gnome-ui/charts/components/AreaChart";
+import { TreeMap } from "@gnome-ui/charts/components/TreeMap";
+```
+
+Both forms are fully typed and produce identical runtime behavior.
+
 ## Quick example
 
 ```tsx

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -6,7 +6,33 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "sideEffects": ["**/*.css", "dist/style.css"],
   "exports": {
+    "./colors": {
+      "types": "./dist/colors.d.ts",
+      "import": "./dist/colors.js",
+      "require": "./dist/colors.cjs"
+    },
+    "./components/AreaChart": {
+      "types": "./dist/components/AreaChart.d.ts",
+      "import": "./dist/components/AreaChart.js",
+      "require": "./dist/components/AreaChart.cjs"
+    },
+    "./components/BarChart": {
+      "types": "./dist/components/BarChart.d.ts",
+      "import": "./dist/components/BarChart.js",
+      "require": "./dist/components/BarChart.cjs"
+    },
+    "./components/LineChart": {
+      "types": "./dist/components/LineChart.d.ts",
+      "import": "./dist/components/LineChart.js",
+      "require": "./dist/components/LineChart.cjs"
+    },
+    "./components/TreeMap": {
+      "types": "./dist/components/TreeMap.d.ts",
+      "import": "./dist/components/TreeMap.js",
+      "require": "./dist/components/TreeMap.cjs"
+    },
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
@@ -35,17 +61,18 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@storybook/addon-a11y": "^10.3.3",
+    "@storybook/addon-docs": "^10.3.3",
+    "@storybook/react": "^10.3.3",
+    "@storybook/react-vite": "^10.3.3",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "storybook": "^10.3.3",
     "vite": "^8.0.3",
-    "vite-plugin-dts": "^4.5.4",
-    "@storybook/react": "^10.3.3",
-    "@storybook/react-vite": "^10.3.3",
-    "@storybook/addon-docs": "^10.3.3",
-    "@storybook/addon-a11y": "^10.3.3",
-    "storybook": "^10.3.3"
+    "vite-magic-tree-shaking": "^1.0.0",
+    "vite-plugin-dts": "^4.5.4"
   }
 }

--- a/packages/charts/vite.config.ts
+++ b/packages/charts/vite.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import dts from "vite-plugin-dts";
 import { resolve } from "path";
+import { fileURLToPath } from "node:url";
+import { generateEntries } from "vite-magic-tree-shaking";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig({
   plugins: [
@@ -19,20 +23,15 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: resolve(__dirname, "src/index.ts"),
-      name: "GnomeCharts",
+      entry: generateEntries(__dirname, "src", { warnOnExportsMismatch: true }),
       formats: ["es", "cjs"],
-      fileName: (format) => `index.${format === "es" ? "js" : "cjs"}`,
+      fileName: (_, entryName) => `${entryName}.js`,
     },
     rollupOptions: {
       external: ["react", "react-dom", "react/jsx-runtime", "recharts"],
       output: {
-        globals: {
-          react: "React",
-          "react-dom": "ReactDOM",
-          "react/jsx-runtime": "jsxRuntime",
-          recharts: "Recharts",
-        },
+        preserveModules: true,
+        preserveModulesRoot: "src",
         assetFileNames: "style.css",
       },
     },


### PR DESCRIPTION
## What

fix(@gnome-ui/charts): enable per-component tree-shaking (closes #39)

## Changes

- [ ] New component
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [ ] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [ ] All styles use CSS custom properties from `@gnome-ui/core`
- [ ] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [ ] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
