### PR TITLE
Feature/charts extra

### DIFF
--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -34,6 +34,7 @@ import "@gnome-ui/charts/styles";
 | `BarChart` | Vertical or horizontal bar chart with rounded bars, optional stacking, grid, and legend |
 | `LineChart` | Line chart with dots, grid, and legend |
 | `RadialBarChart` | Concentric arc chart with optional labels, legend, and inner radius control |
+| `CloudChart` | Word/tag cloud with linear font-size scaling and per-word color support |
 | `PieChart` | Pie or donut chart with optional slice labels and legend |
 | `RadarChart` | Spider/radar chart with single or multiple series and optional fill |
 | `TreeMap` | Proportional tile chart with optional group coloring and labels |
@@ -50,7 +51,7 @@ the simplest option. Modern bundlers that respect the `sideEffects` field in
 `package.json` will still tree-shake unused components automatically.
 
 ```tsx
-import { AreaChart, BarChart, LineChart, PieChart, RadarChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
+import { AreaChart, BarChart, CloudChart, LineChart, PieChart, RadarChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
 ```
 
 ### Per-component import (explicit tree-shaking)
@@ -64,6 +65,7 @@ import { BarChart } from "@gnome-ui/charts/components/BarChart";
 import { LineChart } from "@gnome-ui/charts/components/LineChart";
 import { AreaChart } from "@gnome-ui/charts/components/AreaChart";
 import { PieChart } from "@gnome-ui/charts/components/PieChart";
+import { CloudChart } from "@gnome-ui/charts/components/CloudChart";
 import { RadarChart } from "@gnome-ui/charts/components/RadarChart";
 import { RadialBarChart } from "@gnome-ui/charts/components/RadialBarChart";
 import { TreeMap } from "@gnome-ui/charts/components/TreeMap";
@@ -74,7 +76,7 @@ Both forms are fully typed and produce identical runtime behavior.
 ## Quick example
 
 ```tsx
-import { AreaChart, BarChart, LineChart, PieChart, RadarChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
+import { AreaChart, BarChart, CloudChart, LineChart, PieChart, RadarChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
 
 const data = [
   { month: "Jan", sales: 400, returns: 80 },
@@ -110,6 +112,16 @@ const data = [
   ]}
   showGrid
   showLegend
+/>
+
+// Word cloud
+<CloudChart
+  data={[
+    { text: "TypeScript", value: 95 },
+    { text: "React", value: 80 },
+    { text: "CSS", value: 60 },
+    { text: "Docker", value: 40 },
+  ]}
 />
 
 // Pie / donut chart
@@ -189,6 +201,17 @@ const data = [
 | `stacked` | `boolean` | `false` | Stack series on top of each other |
 | `layout` | `"vertical" \| "horizontal"` | `"vertical"` | Bar orientation |
 | `yAxisFormatter` | `(value: number) => string` | — | Custom Y-axis tick formatter |
+
+`CloudChart` accepts:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `CloudChartDataItem[]` | — | Array of `{ text, value, color? }` |
+| `height` | `number` | `300` | Minimum height of the cloud container in px |
+| `minFontSize` | `number` | `12` | Font size in px for the lowest-value word |
+| `maxFontSize` | `number` | `48` | Font size in px for the highest-value word |
+| `aria-label` | `string` | auto | Accessible label for the chart |
+| `className` | `string` | — | Extra CSS class on the wrapper |
 
 `PieChart` accepts:
 

--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -180,6 +180,7 @@ const data = [
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `stacked` | `boolean` | `false` | Stack all series on top of each other |
+| `gradient` | `boolean` | `false` | Fill areas with a top-to-transparent gradient |
 
 `BarChart` also accepts:
 

--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -34,6 +34,7 @@ import "@gnome-ui/charts/styles";
 | `BarChart` | Vertical or horizontal bar chart with rounded bars, optional stacking, grid, and legend |
 | `LineChart` | Line chart with dots, grid, and legend |
 | `RadialBarChart` | Concentric arc chart with optional labels, legend, and inner radius control |
+| `PieChart` | Pie or donut chart with optional slice labels and legend |
 | `RadarChart` | Spider/radar chart with single or multiple series and optional fill |
 | `TreeMap` | Proportional tile chart with optional group coloring and labels |
 
@@ -49,7 +50,7 @@ the simplest option. Modern bundlers that respect the `sideEffects` field in
 `package.json` will still tree-shake unused components automatically.
 
 ```tsx
-import { AreaChart, BarChart, LineChart, RadarChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
+import { AreaChart, BarChart, LineChart, PieChart, RadarChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
 ```
 
 ### Per-component import (explicit tree-shaking)
@@ -62,6 +63,7 @@ about what you pull in.
 import { BarChart } from "@gnome-ui/charts/components/BarChart";
 import { LineChart } from "@gnome-ui/charts/components/LineChart";
 import { AreaChart } from "@gnome-ui/charts/components/AreaChart";
+import { PieChart } from "@gnome-ui/charts/components/PieChart";
 import { RadarChart } from "@gnome-ui/charts/components/RadarChart";
 import { RadialBarChart } from "@gnome-ui/charts/components/RadialBarChart";
 import { TreeMap } from "@gnome-ui/charts/components/TreeMap";
@@ -72,7 +74,7 @@ Both forms are fully typed and produce identical runtime behavior.
 ## Quick example
 
 ```tsx
-import { AreaChart, BarChart, LineChart, RadarChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
+import { AreaChart, BarChart, LineChart, PieChart, RadarChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
 
 const data = [
   { month: "Jan", sales: 400, returns: 80 },
@@ -107,6 +109,18 @@ const data = [
     { dataKey: "returns", name: "Returns" },
   ]}
   showGrid
+  showLegend
+/>
+
+// Pie / donut chart
+<PieChart
+  data={[
+    { label: "Chrome", value: 62 },
+    { label: "Firefox", value: 18 },
+    { label: "Safari", value: 11 },
+    { label: "Other", value: 9 },
+  ]}
+  donut
   showLegend
 />
 
@@ -174,6 +188,18 @@ const data = [
 | `stacked` | `boolean` | `false` | Stack series on top of each other |
 | `layout` | `"vertical" \| "horizontal"` | `"vertical"` | Bar orientation |
 | `yAxisFormatter` | `(value: number) => string` | — | Custom Y-axis tick formatter |
+
+`PieChart` accepts:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `PieChartDataItem[]` | — | Array of `{ label, value, color? }` |
+| `height` | `number` | `400` | Chart height in px |
+| `donut` | `boolean` | `false` | Render as a donut chart with a center hole |
+| `showLabels` | `boolean` | `false` | Show slice labels outside the chart |
+| `showLegend` | `boolean` | `false` | Show legend below chart |
+| `aria-label` | `string` | auto | Accessible label for the chart |
+| `className` | `string` | — | Extra CSS class on the wrapper |
 
 `RadarChart` accepts:
 

--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -34,6 +34,7 @@ import "@gnome-ui/charts/styles";
 | `BarChart` | Vertical or horizontal bar chart with rounded bars, optional stacking, grid, and legend |
 | `LineChart` | Line chart with dots, grid, and legend |
 | `RadialBarChart` | Concentric arc chart with optional labels, legend, and inner radius control |
+| `RadarChart` | Spider/radar chart with single or multiple series and optional fill |
 | `TreeMap` | Proportional tile chart with optional group coloring and labels |
 
 All components use the Adwaita color palette (`GNOME_CHART_PALETTE`) and CSS custom
@@ -48,7 +49,7 @@ the simplest option. Modern bundlers that respect the `sideEffects` field in
 `package.json` will still tree-shake unused components automatically.
 
 ```tsx
-import { AreaChart, BarChart, LineChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
+import { AreaChart, BarChart, LineChart, RadarChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
 ```
 
 ### Per-component import (explicit tree-shaking)
@@ -61,6 +62,7 @@ about what you pull in.
 import { BarChart } from "@gnome-ui/charts/components/BarChart";
 import { LineChart } from "@gnome-ui/charts/components/LineChart";
 import { AreaChart } from "@gnome-ui/charts/components/AreaChart";
+import { RadarChart } from "@gnome-ui/charts/components/RadarChart";
 import { RadialBarChart } from "@gnome-ui/charts/components/RadialBarChart";
 import { TreeMap } from "@gnome-ui/charts/components/TreeMap";
 ```
@@ -70,7 +72,7 @@ Both forms are fully typed and produce identical runtime behavior.
 ## Quick example
 
 ```tsx
-import { AreaChart, BarChart, LineChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
+import { AreaChart, BarChart, LineChart, RadarChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
 
 const data = [
   { month: "Jan", sales: 400, returns: 80 },
@@ -105,6 +107,22 @@ const data = [
     { dataKey: "returns", name: "Returns" },
   ]}
   showGrid
+  showLegend
+/>
+
+// Radar chart
+<RadarChart
+  data={[
+    { skill: "TypeScript", alice: 90, bob: 70 },
+    { skill: "React", alice: 85, bob: 80 },
+    { skill: "CSS", alice: 60, bob: 75 },
+  ]}
+  angleKey="skill"
+  series={[
+    { dataKey: "alice", name: "Alice" },
+    { dataKey: "bob", name: "Bob" },
+  ]}
+  filled
   showLegend
 />
 
@@ -156,6 +174,19 @@ const data = [
 | `stacked` | `boolean` | `false` | Stack series on top of each other |
 | `layout` | `"vertical" \| "horizontal"` | `"vertical"` | Bar orientation |
 | `yAxisFormatter` | `(value: number) => string` | — | Custom Y-axis tick formatter |
+
+`RadarChart` accepts:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `Record<string, unknown>[]` | — | Array of data objects |
+| `series` | `{ dataKey, name?, color? }[]` | — | Series definitions |
+| `angleKey` | `string` | `"name"` | Key used for the angle axis labels |
+| `height` | `number` | `400` | Chart height in px |
+| `filled` | `boolean` | `false` | Fill radar polygons with a semi-transparent color |
+| `showLegend` | `boolean` | `false` | Show legend below chart |
+| `aria-label` | `string` | auto | Accessible label for the chart |
+| `className` | `string` | — | Extra CSS class on the wrapper |
 
 `RadialBarChart` accepts:
 

--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -33,6 +33,7 @@ import "@gnome-ui/charts/styles";
 | `AreaChart` | Filled area chart with optional stacking, grid, and legend |
 | `BarChart` | Vertical or horizontal bar chart with rounded bars, optional stacking, grid, and legend |
 | `LineChart` | Line chart with dots, grid, and legend |
+| `RadialBarChart` | Concentric arc chart with optional labels, legend, and inner radius control |
 | `TreeMap` | Proportional tile chart with optional group coloring and labels |
 
 All components use the Adwaita color palette (`GNOME_CHART_PALETTE`) and CSS custom
@@ -47,7 +48,7 @@ the simplest option. Modern bundlers that respect the `sideEffects` field in
 `package.json` will still tree-shake unused components automatically.
 
 ```tsx
-import { AreaChart, BarChart, LineChart, TreeMap } from "@gnome-ui/charts";
+import { AreaChart, BarChart, LineChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
 ```
 
 ### Per-component import (explicit tree-shaking)
@@ -60,6 +61,7 @@ about what you pull in.
 import { BarChart } from "@gnome-ui/charts/components/BarChart";
 import { LineChart } from "@gnome-ui/charts/components/LineChart";
 import { AreaChart } from "@gnome-ui/charts/components/AreaChart";
+import { RadialBarChart } from "@gnome-ui/charts/components/RadialBarChart";
 import { TreeMap } from "@gnome-ui/charts/components/TreeMap";
 ```
 
@@ -68,7 +70,7 @@ Both forms are fully typed and produce identical runtime behavior.
 ## Quick example
 
 ```tsx
-import { AreaChart, BarChart, LineChart, TreeMap } from "@gnome-ui/charts";
+import { AreaChart, BarChart, LineChart, RadialBarChart, TreeMap } from "@gnome-ui/charts";
 
 const data = [
   { month: "Jan", sales: 400, returns: 80 },
@@ -106,6 +108,16 @@ const data = [
   showLegend
 />
 
+// Radial bar chart
+<RadialBarChart
+  data={[
+    { label: "CPU", value: 72 },
+    { label: "Memory", value: 58 },
+    { label: "Disk", value: 41 },
+  ]}
+  showLegend
+/>
+
 // TreeMap
 <TreeMap
   data={[
@@ -119,7 +131,7 @@ const data = [
 
 ## Props
 
-All three components share a common set of props:
+`AreaChart`, `BarChart`, and `LineChart` share a common set of props:
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
@@ -144,6 +156,18 @@ All three components share a common set of props:
 | `stacked` | `boolean` | `false` | Stack series on top of each other |
 | `layout` | `"vertical" \| "horizontal"` | `"vertical"` | Bar orientation |
 | `yAxisFormatter` | `(value: number) => string` | — | Custom Y-axis tick formatter |
+
+`RadialBarChart` accepts:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `RadialBarChartDataItem[]` | — | Array of `{ label, value, color? }` |
+| `height` | `number` | `400` | Chart height in px |
+| `innerRadius` | `number \| string` | `"20%"` | Inner radius of the donut gap |
+| `showLabels` | `boolean` | `false` | Show category name inside each arc |
+| `showLegend` | `boolean` | `false` | Show legend below chart |
+| `aria-label` | `string` | auto | Accessible label for the chart |
+| `className` | `string` | — | Extra CSS class on the wrapper |
 
 `TreeMap` accepts:
 

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -49,6 +49,9 @@
   "scripts": {
     "build": "tsc && vite build",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build"
   },
@@ -68,14 +71,19 @@
     "@storybook/addon-docs": "^10.3.3",
     "@storybook/react": "^10.3.3",
     "@storybook/react-vite": "^10.3.3",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.4",
+    "jsdom": "^29.0.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "storybook": "^10.3.3",
     "vite": "^8.0.3",
     "vite-magic-tree-shaking": "^1.0.0",
-    "vite-plugin-dts": "^4.5.4"
+    "vite-plugin-dts": "^4.5.4",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/charts/src/components/AreaChart/AreaChart.stories.tsx
+++ b/packages/charts/src/components/AreaChart/AreaChart.stories.tsx
@@ -51,3 +51,30 @@ export const Stacked: Story = {
     stacked: true,
   },
 };
+
+export const Gradient: Story = {
+  args: {
+    data: TRAFFIC_DATA,
+    series: [
+      { dataKey: "downloads", name: "Downloads" },
+      { dataKey: "installs", name: "Installs" },
+    ],
+    xAxisKey: "week",
+    showLegend: true,
+    gradient: true,
+  },
+};
+
+export const GradientStacked: Story = {
+  args: {
+    data: TRAFFIC_DATA,
+    series: [
+      { dataKey: "downloads", name: "Downloads" },
+      { dataKey: "installs", name: "Installs" },
+    ],
+    xAxisKey: "week",
+    showLegend: true,
+    gradient: true,
+    stacked: true,
+  },
+};

--- a/packages/charts/src/components/AreaChart/AreaChart.test.tsx
+++ b/packages/charts/src/components/AreaChart/AreaChart.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { AreaChart } from "./AreaChart";
+
+const DATA = [
+  { week: "W1", downloads: 320, installs: 210 },
+  { week: "W2", downloads: 480, installs: 310 },
+];
+const SERIES = [{ dataKey: "downloads", name: "Downloads" }];
+
+describe("AreaChart", () => {
+  describe("rendering", () => {
+    it("renders without crashing", () => {
+      const { container } = render(
+        <AreaChart data={DATA} series={SERIES} xAxisKey="week" />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("applies height to the wrapper div", () => {
+      const { container } = render(
+        <AreaChart data={DATA} series={SERIES} height={350} />,
+      );
+      expect(container.querySelector("div")).toHaveStyle({ height: "350px" });
+    });
+
+    it("uses 300px as default height", () => {
+      const { container } = render(<AreaChart data={DATA} series={SERIES} />);
+      expect(container.querySelector("div")).toHaveStyle({ height: "300px" });
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the wrapper div", () => {
+      const { container } = render(
+        <AreaChart data={DATA} series={SERIES} className="area-custom" />,
+      );
+      expect(container.querySelector("div")).toHaveClass("area-custom");
+    });
+  });
+
+  describe("stacked", () => {
+    it("renders without crashing when stacked", () => {
+      const { container } = render(
+        <AreaChart
+          data={DATA}
+          series={[
+            { dataKey: "downloads", name: "Downloads" },
+            { dataKey: "installs", name: "Installs" },
+          ]}
+          xAxisKey="week"
+          stacked
+          showLegend
+        />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+
+  describe("gradient", () => {
+    it("renders without crashing when gradient is enabled", () => {
+      const { container } = render(
+        <AreaChart data={DATA} series={SERIES} gradient />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/charts/src/components/AreaChart/AreaChart.tsx
+++ b/packages/charts/src/components/AreaChart/AreaChart.tsx
@@ -25,6 +25,7 @@ export interface AreaChartProps {
   showGrid?: boolean;
   showLegend?: boolean;
   stacked?: boolean;
+  gradient?: boolean;
   className?: string;
 }
 
@@ -51,8 +52,15 @@ export function AreaChart({
   showGrid = true,
   showLegend = false,
   stacked = false,
+  gradient = false,
   className,
 }: AreaChartProps) {
+  const seriesWithColors = series.map((s, i) => ({
+    ...s,
+    resolvedColor:
+      s.color ?? GNOME_CHART_PALETTE[i % GNOME_CHART_PALETTE.length],
+  }));
+
   return (
     <div
       className={[styles.container, className].filter(Boolean).join(" ")}
@@ -63,6 +71,29 @@ export function AreaChart({
           data={data}
           margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
         >
+          {gradient && (
+            <defs>
+              {seriesWithColors.map((s) => (
+                <linearGradient
+                  key={s.dataKey}
+                  id={`grad-${s.dataKey}`}
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop
+                    offset="5%"
+                    style={{ stopColor: s.resolvedColor, stopOpacity: 0.4 }}
+                  />
+                  <stop
+                    offset="95%"
+                    style={{ stopColor: s.resolvedColor, stopOpacity: 0 }}
+                  />
+                </linearGradient>
+              ))}
+            </defs>
+          )}
           {showGrid && (
             <CartesianGrid
               strokeDasharray="3 3"
@@ -91,23 +122,19 @@ export function AreaChart({
               }}
             />
           )}
-          {series.map((s, i) => {
-            const color =
-              s.color ?? GNOME_CHART_PALETTE[i % GNOME_CHART_PALETTE.length];
-            return (
-              <Area
-                key={s.dataKey}
-                type="monotone"
-                dataKey={s.dataKey}
-                name={s.name ?? s.dataKey}
-                stroke={color}
-                fill={color}
-                fillOpacity={0.15}
-                strokeWidth={2}
-                stackId={stacked ? "stack" : undefined}
-              />
-            );
-          })}
+          {seriesWithColors.map((s) => (
+            <Area
+              key={s.dataKey}
+              type="monotone"
+              dataKey={s.dataKey}
+              name={s.name ?? s.dataKey}
+              stroke={s.resolvedColor}
+              fill={gradient ? `url(#grad-${s.dataKey})` : s.resolvedColor}
+              fillOpacity={gradient ? 1 : 0.15}
+              strokeWidth={2}
+              stackId={stacked ? "stack" : undefined}
+            />
+          ))}
         </RechartsAreaChart>
       </ResponsiveContainer>
     </div>

--- a/packages/charts/src/components/BarChart/BarChart.test.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { BarChart } from "./BarChart";
+
+const DATA = [
+  { month: "Jan", sales: 100, returns: 20 },
+  { month: "Feb", sales: 150, returns: 30 },
+];
+const SERIES = [{ dataKey: "sales", name: "Sales" }];
+
+describe("BarChart", () => {
+  describe("rendering", () => {
+    it("renders without crashing", () => {
+      const { container } = render(<BarChart data={DATA} series={SERIES} xAxisKey="month" />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("applies height to the wrapper div", () => {
+      const { container } = render(
+        <BarChart data={DATA} series={SERIES} height={500} />,
+      );
+      const div = container.querySelector("div");
+      expect(div).toHaveStyle({ height: "500px" });
+    });
+
+    it("uses 300px as default height", () => {
+      const { container } = render(<BarChart data={DATA} series={SERIES} />);
+      const div = container.querySelector("div");
+      expect(div).toHaveStyle({ height: "300px" });
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the wrapper div", () => {
+      const { container } = render(
+        <BarChart data={DATA} series={SERIES} className="custom-bar" />,
+      );
+      expect(container.querySelector("div")).toHaveClass("custom-bar");
+    });
+  });
+
+  describe("multi-series", () => {
+    it("renders without crashing with multiple series", () => {
+      const { container } = render(
+        <BarChart
+          data={DATA}
+          series={[
+            { dataKey: "sales", name: "Sales" },
+            { dataKey: "returns", name: "Returns" },
+          ]}
+          xAxisKey="month"
+          showLegend
+        />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/charts/src/components/CloudChart/CloudChart.module.css
+++ b/packages/charts/src/components/CloudChart/CloudChart.module.css
@@ -1,0 +1,23 @@
+.cloud {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--gnome-space-2, 12px);
+  padding: var(--gnome-space-2, 12px);
+  box-sizing: border-box;
+}
+
+.word {
+  font-family: var(--gnome-font-family, system-ui);
+  line-height: 1.2;
+  white-space: nowrap;
+  cursor: default;
+  transition: opacity 0.15s ease;
+  user-select: none;
+}
+
+.word:hover {
+  opacity: 0.7;
+}

--- a/packages/charts/src/components/CloudChart/CloudChart.stories.tsx
+++ b/packages/charts/src/components/CloudChart/CloudChart.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CloudChart } from "./CloudChart";
+
+const meta: Meta<typeof CloudChart> = {
+  title: "Charts/CloudChart",
+  component: CloudChart,
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof CloudChart>;
+
+const TECH_DATA = [
+  { text: "TypeScript", value: 95 },
+  { text: "React", value: 88 },
+  { text: "Node.js", value: 76 },
+  { text: "CSS", value: 70 },
+  { text: "GraphQL", value: 55 },
+  { text: "Docker", value: 52 },
+  { text: "PostgreSQL", value: 48 },
+  { text: "Rust", value: 42 },
+  { text: "Python", value: 38 },
+  { text: "Go", value: 30 },
+  { text: "Kubernetes", value: 25 },
+  { text: "WebAssembly", value: 18 },
+];
+
+export const Default: Story = {
+  args: {
+    data: TECH_DATA,
+  },
+};
+
+export const NarrowFontRange: Story = {
+  args: {
+    data: TECH_DATA,
+    minFontSize: 14,
+    maxFontSize: 28,
+  },
+};
+
+export const WideFontRange: Story = {
+  args: {
+    data: TECH_DATA,
+    minFontSize: 10,
+    maxFontSize: 64,
+  },
+};
+
+export const CustomColors: Story = {
+  args: {
+    data: [
+      { text: "Accessibility", value: 90, color: "var(--gnome-blue-3, #3584e4)" },
+      { text: "Performance", value: 75, color: "var(--gnome-green-4, #2ec27e)" },
+      { text: "Security", value: 68, color: "var(--gnome-red-3, #e01b24)" },
+      { text: "Usability", value: 82, color: "var(--gnome-purple-3, #9141ac)" },
+      { text: "Reliability", value: 60, color: "var(--gnome-orange-3, #ff7800)" },
+      { text: "Scalability", value: 55, color: "var(--gnome-yellow-5, #e5a50a)" },
+    ],
+  },
+};
+
+export const EqualWeights: Story = {
+  args: {
+    data: [
+      { text: "Alpha", value: 1 },
+      { text: "Beta", value: 1 },
+      { text: "Gamma", value: 1 },
+      { text: "Delta", value: 1 },
+      { text: "Epsilon", value: 1 },
+    ],
+  },
+};

--- a/packages/charts/src/components/CloudChart/CloudChart.test.tsx
+++ b/packages/charts/src/components/CloudChart/CloudChart.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CloudChart } from "./CloudChart";
+
+const DATA = [
+  { text: "TypeScript", value: 95 },
+  { text: "React", value: 60 },
+  { text: "CSS", value: 30 },
+];
+
+describe("CloudChart", () => {
+  describe("rendering", () => {
+    it("renders without crashing", () => {
+      const { container } = render(<CloudChart data={DATA} />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("renders a span for each data item", () => {
+      render(<CloudChart data={DATA} />);
+      expect(screen.getByText("TypeScript")).toBeInTheDocument();
+      expect(screen.getByText("React")).toBeInTheDocument();
+      expect(screen.getByText("CSS")).toBeInTheDocument();
+    });
+
+    it("applies minHeight to the wrapper", () => {
+      const { container } = render(<CloudChart data={DATA} height={400} />);
+      expect(container.querySelector("[role='img']")).toHaveStyle({
+        minHeight: "400px",
+      });
+    });
+
+    it("uses 300px as default minHeight", () => {
+      const { container } = render(<CloudChart data={DATA} />);
+      expect(container.querySelector("[role='img']")).toHaveStyle({
+        minHeight: "300px",
+      });
+    });
+  });
+
+  describe("font size scaling", () => {
+    it("gives the highest-value word the largest font size", () => {
+      render(<CloudChart data={DATA} minFontSize={12} maxFontSize={48} />);
+      const top = screen.getByText("TypeScript");
+      const bottom = screen.getByText("CSS");
+      const topSize = parseFloat(top.style.fontSize);
+      const bottomSize = parseFloat(bottom.style.fontSize);
+      expect(topSize).toBeGreaterThan(bottomSize);
+    });
+
+    it("applies the max font size to the highest-value word", () => {
+      render(<CloudChart data={DATA} minFontSize={12} maxFontSize={48} />);
+      expect(parseFloat(screen.getByText("TypeScript").style.fontSize)).toBe(48);
+    });
+
+    it("applies the min font size to the lowest-value word", () => {
+      render(<CloudChart data={DATA} minFontSize={12} maxFontSize={48} />);
+      expect(parseFloat(screen.getByText("CSS").style.fontSize)).toBe(12);
+    });
+
+    it("applies the midpoint font size when all values are equal", () => {
+      const equalData = [
+        { text: "A", value: 5 },
+        { text: "B", value: 5 },
+      ];
+      render(<CloudChart data={equalData} minFontSize={10} maxFontSize={50} />);
+      expect(parseFloat(screen.getByText("A").style.fontSize)).toBe(30);
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has role=img on the wrapper", () => {
+      const { container } = render(<CloudChart data={DATA} />);
+      expect(container.querySelector("[role='img']")).toBeInTheDocument();
+    });
+
+    it("generates a default aria-label with item count", () => {
+      const { container } = render(<CloudChart data={DATA} />);
+      expect(container.querySelector("[role='img']")).toHaveAttribute(
+        "aria-label",
+        "Word cloud with 3 terms",
+      );
+    });
+
+    it("uses a custom aria-label when provided", () => {
+      const { container } = render(
+        <CloudChart data={DATA} aria-label="Technology popularity" />,
+      );
+      expect(container.querySelector("[role='img']")).toHaveAttribute(
+        "aria-label",
+        "Technology popularity",
+      );
+    });
+
+    it("adds aria-label with value to each word span", () => {
+      render(<CloudChart data={DATA} />);
+      expect(screen.getByText("TypeScript")).toHaveAttribute(
+        "aria-label",
+        "TypeScript 95",
+      );
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the wrapper", () => {
+      const { container } = render(<CloudChart data={DATA} className="my-cloud" />);
+      expect(container.querySelector("[role='img']")).toHaveClass("my-cloud");
+    });
+  });
+
+  describe("custom colors", () => {
+    it("applies per-item color override", () => {
+      render(
+        <CloudChart
+          data={[{ text: "Rust", value: 50, color: "#ff0000" }]}
+        />,
+      );
+      expect(screen.getByText("Rust")).toHaveStyle({ color: "#ff0000" });
+    });
+  });
+});

--- a/packages/charts/src/components/CloudChart/CloudChart.tsx
+++ b/packages/charts/src/components/CloudChart/CloudChart.tsx
@@ -1,0 +1,64 @@
+import { GNOME_CHART_PALETTE } from "../../colors";
+import styles from "./CloudChart.module.css";
+
+export interface CloudChartDataItem {
+  text: string;
+  value: number;
+  color?: string;
+}
+
+export interface CloudChartProps {
+  data: CloudChartDataItem[];
+  height?: number;
+  minFontSize?: number;
+  maxFontSize?: number;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function CloudChart({
+  data,
+  height = 300,
+  minFontSize = 12,
+  maxFontSize = 48,
+  className,
+  "aria-label": ariaLabel,
+}: CloudChartProps) {
+  const values = data.map((d) => d.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+
+  const words = data.map((item, i) => ({
+    ...item,
+    fontSize:
+      min === max
+        ? (minFontSize + maxFontSize) / 2
+        : minFontSize + ((item.value - min) / range) * (maxFontSize - minFontSize),
+    resolvedColor:
+      item.color ?? GNOME_CHART_PALETTE[i % GNOME_CHART_PALETTE.length],
+  }));
+
+  return (
+    <div
+      role="img"
+      aria-label={ariaLabel ?? `Word cloud with ${data.length} terms`}
+      className={[styles.cloud, className].filter(Boolean).join(" ")}
+      style={{ minHeight: height }}
+    >
+      {words.map((word) => (
+        <span
+          key={word.text}
+          className={styles.word}
+          style={{
+            fontSize: word.fontSize,
+            color: word.resolvedColor,
+          }}
+          aria-label={`${word.text} ${word.value}`}
+        >
+          {word.text}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/packages/charts/src/components/CloudChart/index.ts
+++ b/packages/charts/src/components/CloudChart/index.ts
@@ -1,0 +1,2 @@
+export { CloudChart } from "./CloudChart";
+export type { CloudChartProps, CloudChartDataItem } from "./CloudChart";

--- a/packages/charts/src/components/LineChart/LineChart.test.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { LineChart } from "./LineChart";
+
+const DATA = [
+  { day: "Mon", cpu: 42, memory: 68 },
+  { day: "Tue", cpu: 55, memory: 72 },
+];
+const SERIES = [{ dataKey: "cpu", name: "CPU" }];
+
+describe("LineChart", () => {
+  describe("rendering", () => {
+    it("renders without crashing", () => {
+      const { container } = render(
+        <LineChart data={DATA} series={SERIES} xAxisKey="day" />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("applies height to the wrapper div", () => {
+      const { container } = render(
+        <LineChart data={DATA} series={SERIES} height={450} />,
+      );
+      expect(container.querySelector("div")).toHaveStyle({ height: "450px" });
+    });
+
+    it("uses 300px as default height", () => {
+      const { container } = render(<LineChart data={DATA} series={SERIES} />);
+      expect(container.querySelector("div")).toHaveStyle({ height: "300px" });
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the wrapper div", () => {
+      const { container } = render(
+        <LineChart data={DATA} series={SERIES} className="my-line" />,
+      );
+      expect(container.querySelector("div")).toHaveClass("my-line");
+    });
+  });
+
+  describe("multi-series", () => {
+    it("renders without crashing with multiple series and legend", () => {
+      const { container } = render(
+        <LineChart
+          data={DATA}
+          series={[
+            { dataKey: "cpu", name: "CPU" },
+            { dataKey: "memory", name: "Memory" },
+          ]}
+          xAxisKey="day"
+          showLegend
+        />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/charts/src/components/PieChart/PieChart.module.css
+++ b/packages/charts/src/components/PieChart/PieChart.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/packages/charts/src/components/PieChart/PieChart.stories.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PieChart } from "./PieChart";
+
+const meta: Meta<typeof PieChart> = {
+  title: "Charts/PieChart",
+  component: PieChart,
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof PieChart>;
+
+const BROWSER_DATA = [
+  { label: "Chrome", value: 62 },
+  { label: "Firefox", value: 18 },
+  { label: "Safari", value: 11 },
+  { label: "Edge", value: 6 },
+  { label: "Other", value: 3 },
+];
+
+export const Default: Story = {
+  args: {
+    data: BROWSER_DATA,
+  },
+};
+
+export const WithLabels: Story = {
+  args: {
+    data: BROWSER_DATA,
+    showLabels: true,
+  },
+};
+
+export const WithLegend: Story = {
+  args: {
+    data: BROWSER_DATA,
+    showLegend: true,
+  },
+};
+
+export const Donut: Story = {
+  args: {
+    data: BROWSER_DATA,
+    donut: true,
+    showLegend: true,
+  },
+};
+
+export const DonutWithLabels: Story = {
+  args: {
+    data: BROWSER_DATA,
+    donut: true,
+    showLabels: true,
+    showLegend: true,
+  },
+};
+
+export const CustomColors: Story = {
+  args: {
+    data: [
+      { label: "Passed", value: 74, color: "var(--gnome-green-4, #2ec27e)" },
+      { label: "Failed", value: 12, color: "var(--gnome-red-3, #e01b24)" },
+      { label: "Skipped", value: 14, color: "var(--gnome-yellow-5, #e5a50a)" },
+    ],
+    donut: true,
+    showLegend: true,
+  },
+};

--- a/packages/charts/src/components/PieChart/PieChart.test.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { PieChart } from "./PieChart";
+
+const DATA = [
+  { label: "Chrome", value: 62 },
+  { label: "Firefox", value: 18 },
+  { label: "Safari", value: 11 },
+];
+
+describe("PieChart", () => {
+  describe("rendering", () => {
+    it("renders without crashing", () => {
+      const { container } = render(<PieChart data={DATA} />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("applies height to the wrapper div", () => {
+      const { container } = render(<PieChart data={DATA} height={300} />);
+      expect(container.querySelector("[role='img']")).toHaveStyle({ height: "300px" });
+    });
+
+    it("uses 400px as default height", () => {
+      const { container } = render(<PieChart data={DATA} />);
+      expect(container.querySelector("[role='img']")).toHaveStyle({ height: "400px" });
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has role=img on the wrapper", () => {
+      const { container } = render(<PieChart data={DATA} />);
+      expect(container.querySelector("[role='img']")).toBeInTheDocument();
+    });
+
+    it("generates an aria-label that includes each item's label and value", () => {
+      const { container } = render(<PieChart data={DATA} />);
+      const el = container.querySelector("[role='img']");
+      expect(el).toHaveAttribute("aria-label", expect.stringContaining("Chrome"));
+      expect(el).toHaveAttribute("aria-label", expect.stringContaining("62"));
+      expect(el).toHaveAttribute("aria-label", expect.stringContaining("Firefox"));
+    });
+
+    it("uses the custom aria-label when provided", () => {
+      const { container } = render(
+        <PieChart data={DATA} aria-label="Browser market share" />,
+      );
+      expect(container.querySelector("[role='img']")).toHaveAttribute(
+        "aria-label",
+        "Browser market share",
+      );
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the wrapper div", () => {
+      const { container } = render(<PieChart data={DATA} className="pie-cls" />);
+      expect(container.querySelector("[role='img']")).toHaveClass("pie-cls");
+    });
+  });
+
+  describe("props", () => {
+    it("renders without crashing in donut mode", () => {
+      const { container } = render(<PieChart data={DATA} donut />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("renders without crashing with showLabels and showLegend", () => {
+      const { container } = render(
+        <PieChart data={DATA} showLabels showLegend />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -1,0 +1,139 @@
+import {
+  PieChart as RechartsPieChart,
+  Pie,
+  Cell,
+  Legend,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { GNOME_CHART_PALETTE } from "../../colors";
+import styles from "./PieChart.module.css";
+
+export interface PieChartDataItem {
+  label: string;
+  value: number;
+  color?: string;
+}
+
+export interface PieChartProps {
+  data: PieChartDataItem[];
+  height?: number;
+  donut?: boolean;
+  showLabels?: boolean;
+  showLegend?: boolean;
+  className?: string;
+  "aria-label"?: string;
+}
+
+const TOOLTIP_CONTENT_STYLE = {
+  backgroundColor: "var(--gnome-popover-bg-color, #fff)",
+  border: "1px solid var(--gnome-light-3, #deddda)",
+  borderRadius: "var(--gnome-radius-md, 8px)",
+  fontFamily: "var(--gnome-font-family, system-ui)",
+  fontSize: 12,
+  boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+};
+
+const RADIAN = Math.PI / 180;
+
+function SliceLabel(props: {
+  cx?: number;
+  cy?: number;
+  midAngle?: number;
+  outerRadius?: number;
+  name?: string;
+  percent?: number;
+}) {
+  const { cx, cy, midAngle, outerRadius, name, percent } = props;
+  if (
+    cx == null ||
+    cy == null ||
+    midAngle == null ||
+    outerRadius == null ||
+    percent == null ||
+    percent < 0.04
+  ) {
+    return <g />;
+  }
+  const radius = outerRadius + 20;
+  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+  return (
+    <text
+      x={x}
+      y={y}
+      fill="var(--gnome-window-fg-color, rgba(0,0,0,0.8))"
+      textAnchor={x > cx ? "start" : "end"}
+      dominantBaseline="central"
+      fontSize={11}
+      fontFamily="var(--gnome-font-family, system-ui)"
+    >
+      {name}
+    </text>
+  );
+}
+
+export function PieChart({
+  data,
+  height = 400,
+  donut = false,
+  showLabels = false,
+  showLegend = false,
+  className,
+  "aria-label": ariaLabel,
+}: PieChartProps) {
+  const chartData = data.map((item, i) => ({
+    name: item.label,
+    value: item.value,
+    fill: item.color ?? GNOME_CHART_PALETTE[i % GNOME_CHART_PALETTE.length],
+  }));
+
+  return (
+    <div
+      role="img"
+      aria-label={
+        ariaLabel ??
+        `Pie chart: ${data.map((d) => `${d.label} ${d.value}`).join(", ")}`
+      }
+      className={[styles.container, className].filter(Boolean).join(" ")}
+      style={{ height }}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsPieChart margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+          <Tooltip
+            contentStyle={TOOLTIP_CONTENT_STYLE}
+            formatter={(value: number, name: string) => [value, name]}
+          />
+          {showLegend && (
+            <Legend
+              iconSize={10}
+              wrapperStyle={{
+                fontFamily: "var(--gnome-font-family, system-ui)",
+                fontSize: 12,
+              }}
+            />
+          )}
+          <Pie
+            data={chartData}
+            dataKey="value"
+            nameKey="name"
+            innerRadius={donut ? "45%" : 0}
+            outerRadius="80%"
+            paddingAngle={2}
+            label={showLabels ? SliceLabel : false}
+            labelLine={showLabels}
+          >
+            {chartData.map((entry, i) => (
+              <Cell
+                key={`cell-${i}`}
+                fill={entry.fill}
+                stroke="var(--gnome-window-bg-color, #fff)"
+                strokeWidth={2}
+              />
+            ))}
+          </Pie>
+        </RechartsPieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/packages/charts/src/components/PieChart/index.ts
+++ b/packages/charts/src/components/PieChart/index.ts
@@ -1,0 +1,2 @@
+export { PieChart } from "./PieChart";
+export type { PieChartProps, PieChartDataItem } from "./PieChart";

--- a/packages/charts/src/components/RadarChart/RadarChart.module.css
+++ b/packages/charts/src/components/RadarChart/RadarChart.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/packages/charts/src/components/RadarChart/RadarChart.stories.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { RadarChart } from "./RadarChart";
+
+const meta: Meta<typeof RadarChart> = {
+  title: "Charts/RadarChart",
+  component: RadarChart,
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadarChart>;
+
+const SKILLS_DATA = [
+  { skill: "TypeScript", alice: 90, bob: 70 },
+  { skill: "React", alice: 85, bob: 80 },
+  { skill: "CSS", alice: 60, bob: 75 },
+  { skill: "Testing", alice: 75, bob: 55 },
+  { skill: "DevOps", alice: 50, bob: 65 },
+  { skill: "Accessibility", alice: 80, bob: 45 },
+];
+
+export const Default: Story = {
+  args: {
+    data: SKILLS_DATA,
+    series: [{ dataKey: "alice", name: "Alice" }],
+    angleKey: "skill",
+  },
+};
+
+export const MultiSeries: Story = {
+  args: {
+    data: SKILLS_DATA,
+    series: [
+      { dataKey: "alice", name: "Alice" },
+      { dataKey: "bob", name: "Bob" },
+    ],
+    angleKey: "skill",
+    showLegend: true,
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    data: SKILLS_DATA,
+    series: [
+      { dataKey: "alice", name: "Alice" },
+      { dataKey: "bob", name: "Bob" },
+    ],
+    angleKey: "skill",
+    filled: true,
+    showLegend: true,
+  },
+};
+
+export const SingleFilled: Story = {
+  args: {
+    data: SKILLS_DATA,
+    series: [{ dataKey: "alice", name: "Alice" }],
+    angleKey: "skill",
+    filled: true,
+  },
+};

--- a/packages/charts/src/components/RadarChart/RadarChart.test.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { RadarChart } from "./RadarChart";
+
+const DATA = [
+  { skill: "TypeScript", alice: 90, bob: 70 },
+  { skill: "React", alice: 85, bob: 80 },
+  { skill: "CSS", alice: 60, bob: 75 },
+];
+const SERIES = [{ dataKey: "alice", name: "Alice" }];
+
+describe("RadarChart", () => {
+  describe("rendering", () => {
+    it("renders without crashing", () => {
+      const { container } = render(
+        <RadarChart data={DATA} series={SERIES} angleKey="skill" />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("applies height to the wrapper div", () => {
+      const { container } = render(
+        <RadarChart data={DATA} series={SERIES} height={350} />,
+      );
+      expect(container.querySelector("[role='img']")).toHaveStyle({ height: "350px" });
+    });
+
+    it("uses 400px as default height", () => {
+      const { container } = render(<RadarChart data={DATA} series={SERIES} />);
+      expect(container.querySelector("[role='img']")).toHaveStyle({ height: "400px" });
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has role=img on the wrapper", () => {
+      const { container } = render(<RadarChart data={DATA} series={SERIES} />);
+      expect(container.querySelector("[role='img']")).toBeInTheDocument();
+    });
+
+    it("generates an aria-label that includes each series name", () => {
+      const { container } = render(
+        <RadarChart
+          data={DATA}
+          series={[
+            { dataKey: "alice", name: "Alice" },
+            { dataKey: "bob", name: "Bob" },
+          ]}
+        />,
+      );
+      const el = container.querySelector("[role='img']");
+      expect(el).toHaveAttribute("aria-label", expect.stringContaining("Alice"));
+      expect(el).toHaveAttribute("aria-label", expect.stringContaining("Bob"));
+    });
+
+    it("falls back to dataKey in aria-label when name is omitted", () => {
+      const { container } = render(
+        <RadarChart data={DATA} series={[{ dataKey: "alice" }]} />,
+      );
+      expect(container.querySelector("[role='img']")).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("alice"),
+      );
+    });
+
+    it("uses the custom aria-label when provided", () => {
+      const { container } = render(
+        <RadarChart data={DATA} series={SERIES} aria-label="Skill radar" />,
+      );
+      expect(container.querySelector("[role='img']")).toHaveAttribute(
+        "aria-label",
+        "Skill radar",
+      );
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the wrapper div", () => {
+      const { container } = render(
+        <RadarChart data={DATA} series={SERIES} className="radar-cls" />,
+      );
+      expect(container.querySelector("[role='img']")).toHaveClass("radar-cls");
+    });
+  });
+
+  describe("props", () => {
+    it("renders without crashing with filled and showLegend", () => {
+      const { container } = render(
+        <RadarChart
+          data={DATA}
+          series={[
+            { dataKey: "alice", name: "Alice" },
+            { dataKey: "bob", name: "Bob" },
+          ]}
+          filled
+          showLegend
+        />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -1,0 +1,106 @@
+import {
+  RadarChart as RechartsRadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Legend,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { GNOME_CHART_PALETTE } from "../../colors";
+import styles from "./RadarChart.module.css";
+
+export interface RadarChartSeries {
+  dataKey: string;
+  name?: string;
+  color?: string;
+}
+
+export interface RadarChartProps {
+  data: Record<string, unknown>[];
+  series: RadarChartSeries[];
+  angleKey?: string;
+  height?: number;
+  filled?: boolean;
+  showLegend?: boolean;
+  className?: string;
+  "aria-label"?: string;
+}
+
+const AXIS_STYLE = {
+  fontSize: 12,
+  fill: "var(--gnome-window-fg-color, rgba(0,0,0,0.8))",
+  fontFamily: "var(--gnome-font-family, system-ui)",
+};
+
+const TOOLTIP_CONTENT_STYLE = {
+  backgroundColor: "var(--gnome-popover-bg-color, #fff)",
+  border: "1px solid var(--gnome-light-3, #deddda)",
+  borderRadius: "var(--gnome-radius-md, 8px)",
+  fontFamily: "var(--gnome-font-family, system-ui)",
+  fontSize: 12,
+  boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+};
+
+export function RadarChart({
+  data,
+  series,
+  angleKey = "name",
+  height = 400,
+  filled = false,
+  showLegend = false,
+  className,
+  "aria-label": ariaLabel,
+}: RadarChartProps) {
+  return (
+    <div
+      role="img"
+      aria-label={
+        ariaLabel ??
+        `Radar chart with ${series.map((s) => s.name ?? s.dataKey).join(", ")}`
+      }
+      className={[styles.container, className].filter(Boolean).join(" ")}
+      style={{ height }}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsRadarChart
+          data={data}
+          margin={{ top: 8, right: 24, left: 24, bottom: 8 }}
+        >
+          <PolarGrid stroke="var(--gnome-light-3, #deddda)" />
+          <PolarAngleAxis dataKey={angleKey} tick={AXIS_STYLE} />
+          <PolarRadiusAxis
+            tick={AXIS_STYLE}
+            axisLine={false}
+            tickLine={false}
+          />
+          <Tooltip contentStyle={TOOLTIP_CONTENT_STYLE} />
+          {showLegend && (
+            <Legend
+              wrapperStyle={{
+                fontFamily: "var(--gnome-font-family, system-ui)",
+                fontSize: 12,
+              }}
+            />
+          )}
+          {series.map((s, i) => {
+            const color =
+              s.color ?? GNOME_CHART_PALETTE[i % GNOME_CHART_PALETTE.length];
+            return (
+              <Radar
+                key={s.dataKey}
+                dataKey={s.dataKey}
+                name={s.name ?? s.dataKey}
+                stroke={color}
+                fill={color}
+                fillOpacity={filled ? 0.35 : 0}
+                dot={false}
+              />
+            );
+          })}
+        </RechartsRadarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/packages/charts/src/components/RadarChart/index.ts
+++ b/packages/charts/src/components/RadarChart/index.ts
@@ -1,0 +1,2 @@
+export { RadarChart } from "./RadarChart";
+export type { RadarChartProps, RadarChartSeries } from "./RadarChart";

--- a/packages/charts/src/components/RadialBarChart/RadialBarChart.module.css
+++ b/packages/charts/src/components/RadialBarChart/RadialBarChart.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/packages/charts/src/components/RadialBarChart/RadialBarChart.stories.tsx
+++ b/packages/charts/src/components/RadialBarChart/RadialBarChart.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { RadialBarChart } from "./RadialBarChart";
+
+const meta: Meta<typeof RadialBarChart> = {
+  title: "Charts/RadialBarChart",
+  component: RadialBarChart,
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadialBarChart>;
+
+const RESOURCE_DATA = [
+  { label: "CPU", value: 72 },
+  { label: "Memory", value: 58 },
+  { label: "Disk", value: 41 },
+  { label: "Network", value: 85 },
+];
+
+export const Default: Story = {
+  args: {
+    data: RESOURCE_DATA,
+  },
+};
+
+export const WithLabels: Story = {
+  args: {
+    data: RESOURCE_DATA,
+    showLabels: true,
+  },
+};
+
+export const WithLegend: Story = {
+  args: {
+    data: RESOURCE_DATA,
+    showLegend: true,
+  },
+};
+
+export const DonutGap: Story = {
+  args: {
+    data: RESOURCE_DATA,
+    innerRadius: "40%",
+    showLegend: true,
+  },
+};
+
+export const CustomColors: Story = {
+  args: {
+    data: [
+      { label: "Completed", value: 90, color: "var(--gnome-green-4, #2ec27e)" },
+      { label: "In Progress", value: 60, color: "var(--gnome-blue-3, #3584e4)" },
+      { label: "Blocked", value: 25, color: "var(--gnome-red-3, #e01b24)" },
+    ],
+    showLabels: true,
+    showLegend: true,
+  },
+};

--- a/packages/charts/src/components/RadialBarChart/RadialBarChart.test.tsx
+++ b/packages/charts/src/components/RadialBarChart/RadialBarChart.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { RadialBarChart } from "./RadialBarChart";
+
+const DATA = [
+  { label: "CPU", value: 72 },
+  { label: "Memory", value: 58 },
+  { label: "Disk", value: 41 },
+];
+
+describe("RadialBarChart", () => {
+  describe("rendering", () => {
+    it("renders without crashing", () => {
+      const { container } = render(<RadialBarChart data={DATA} />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("applies height to the wrapper div", () => {
+      const { container } = render(<RadialBarChart data={DATA} height={300} />);
+      expect(container.querySelector("[role='img']")).toHaveStyle({ height: "300px" });
+    });
+
+    it("uses 400px as default height", () => {
+      const { container } = render(<RadialBarChart data={DATA} />);
+      expect(container.querySelector("[role='img']")).toHaveStyle({ height: "400px" });
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has role=img on the wrapper", () => {
+      const { container } = render(<RadialBarChart data={DATA} />);
+      expect(container.querySelector("[role='img']")).toBeInTheDocument();
+    });
+
+    it("generates an aria-label that includes each item's label and value", () => {
+      const { container } = render(<RadialBarChart data={DATA} />);
+      const el = container.querySelector("[role='img']");
+      expect(el).toHaveAttribute("aria-label", expect.stringContaining("CPU"));
+      expect(el).toHaveAttribute("aria-label", expect.stringContaining("72"));
+      expect(el).toHaveAttribute("aria-label", expect.stringContaining("Memory"));
+    });
+
+    it("uses the custom aria-label when provided", () => {
+      const { container } = render(
+        <RadialBarChart data={DATA} aria-label="System resource usage" />,
+      );
+      expect(container.querySelector("[role='img']")).toHaveAttribute(
+        "aria-label",
+        "System resource usage",
+      );
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the wrapper div", () => {
+      const { container } = render(
+        <RadialBarChart data={DATA} className="radial-cls" />,
+      );
+      expect(container.querySelector("[role='img']")).toHaveClass("radial-cls");
+    });
+  });
+
+  describe("props", () => {
+    it("renders without crashing with showLabels and showLegend", () => {
+      const { container } = render(
+        <RadialBarChart data={DATA} showLabels showLegend />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("renders without crashing with custom innerRadius", () => {
+      const { container } = render(
+        <RadialBarChart data={DATA} innerRadius="40%" />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("renders without crashing with per-item custom colors", () => {
+      const { container } = render(
+        <RadialBarChart
+          data={[
+            { label: "A", value: 80, color: "#3584e4" },
+            { label: "B", value: 50, color: "#2ec27e" },
+          ]}
+        />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/charts/src/components/RadialBarChart/RadialBarChart.tsx
+++ b/packages/charts/src/components/RadialBarChart/RadialBarChart.tsx
@@ -1,0 +1,126 @@
+import {
+  RadialBarChart as RechartsRadialBarChart,
+  RadialBar,
+  Legend,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { GNOME_CHART_PALETTE } from "../../colors";
+import styles from "./RadialBarChart.module.css";
+
+export interface RadialBarChartDataItem {
+  label: string;
+  value: number;
+  color?: string;
+}
+
+export interface RadialBarChartProps {
+  data: RadialBarChartDataItem[];
+  height?: number;
+  innerRadius?: number | string;
+  showLabels?: boolean;
+  showLegend?: boolean;
+  className?: string;
+  "aria-label"?: string;
+}
+
+const TOOLTIP_CONTENT_STYLE = {
+  backgroundColor: "var(--gnome-popover-bg-color, #fff)",
+  border: "1px solid var(--gnome-light-3, #deddda)",
+  borderRadius: "var(--gnome-radius-md, 8px)",
+  fontFamily: "var(--gnome-font-family, system-ui)",
+  fontSize: 12,
+  boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+};
+
+function ArcLabel(props: {
+  cx?: number;
+  cy?: number;
+  midAngle?: number;
+  innerRadius?: number;
+  outerRadius?: number;
+  name?: string;
+}) {
+  const { cx, cy, midAngle, innerRadius, outerRadius, name } = props;
+  if (
+    cx == null ||
+    cy == null ||
+    midAngle == null ||
+    innerRadius == null ||
+    outerRadius == null
+  ) {
+    return <g />;
+  }
+  const RADIAN = Math.PI / 180;
+  const r = innerRadius + (outerRadius - innerRadius) / 2;
+  const x = cx + r * Math.cos(-midAngle * RADIAN);
+  const y = cy + r * Math.sin(-midAngle * RADIAN);
+  return (
+    <text
+      x={x}
+      y={y}
+      fill="var(--gnome-window-fg-color, rgba(0,0,0,0.8))"
+      textAnchor="middle"
+      dominantBaseline="central"
+      fontSize={11}
+      fontFamily="var(--gnome-font-family, system-ui)"
+    >
+      {name}
+    </text>
+  );
+}
+
+export function RadialBarChart({
+  data,
+  height = 400,
+  innerRadius = "20%",
+  showLabels = false,
+  showLegend = false,
+  className,
+  "aria-label": ariaLabel,
+}: RadialBarChartProps) {
+  const chartData = data.map((item, i) => ({
+    name: item.label,
+    value: item.value,
+    fill: item.color ?? GNOME_CHART_PALETTE[i % GNOME_CHART_PALETTE.length],
+  }));
+
+  return (
+    <div
+      role="img"
+      aria-label={
+        ariaLabel ??
+        `Radial bar chart: ${data.map((d) => `${d.label} ${d.value}`).join(", ")}`
+      }
+      className={[styles.container, className].filter(Boolean).join(" ")}
+      style={{ height }}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsRadialBarChart
+          data={chartData}
+          innerRadius={innerRadius}
+          outerRadius="90%"
+          startAngle={180}
+          endAngle={0}
+          margin={{ top: 8, right: 8, left: 8, bottom: 8 }}
+        >
+          <RadialBar
+            dataKey="value"
+            background={{ fill: "var(--gnome-light-3, #deddda)" }}
+            label={showLabels ? ArcLabel : undefined}
+          />
+          <Tooltip contentStyle={TOOLTIP_CONTENT_STYLE} />
+          {showLegend && (
+            <Legend
+              iconSize={10}
+              wrapperStyle={{
+                fontFamily: "var(--gnome-font-family, system-ui)",
+                fontSize: 12,
+              }}
+            />
+          )}
+        </RechartsRadialBarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/packages/charts/src/components/RadialBarChart/index.ts
+++ b/packages/charts/src/components/RadialBarChart/index.ts
@@ -1,0 +1,2 @@
+export { RadialBarChart } from "./RadialBarChart";
+export type { RadialBarChartProps, RadialBarChartDataItem } from "./RadialBarChart";

--- a/packages/charts/src/components/TreeMap/TreeMap.test.tsx
+++ b/packages/charts/src/components/TreeMap/TreeMap.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { TreeMap } from "./TreeMap";
+
+const DATA = [
+  { label: "React", value: 4200, group: "Frontend" },
+  { label: "Vue", value: 2100, group: "Frontend" },
+  { label: "Node.js", value: 3800, group: "Backend" },
+];
+
+describe("TreeMap", () => {
+  describe("rendering", () => {
+    it("renders without crashing", () => {
+      const { container } = render(<TreeMap data={DATA} />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("applies height to the wrapper div", () => {
+      const { container } = render(<TreeMap data={DATA} height={500} />);
+      expect(container.querySelector("div")).toHaveStyle({ height: "500px" });
+    });
+
+    it("uses 400px as default height", () => {
+      const { container } = render(<TreeMap data={DATA} />);
+      expect(container.querySelector("div")).toHaveStyle({ height: "400px" });
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the wrapper div", () => {
+      const { container } = render(
+        <TreeMap data={DATA} className="treemap-cls" />,
+      );
+      expect(container.querySelector("div")).toHaveClass("treemap-cls");
+    });
+  });
+
+  describe("props", () => {
+    it("renders without crashing with showLabels disabled", () => {
+      const { container } = render(<TreeMap data={DATA} showLabels={false} />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("renders without crashing with ungrouped data", () => {
+      const { container } = render(
+        <TreeMap data={[{ label: "A", value: 100 }, { label: "B", value: 200 }]} />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -16,4 +16,7 @@ export type { RadialBarChartProps, RadialBarChartDataItem } from "./components/R
 export { RadarChart } from "./components/RadarChart";
 export type { RadarChartProps, RadarChartSeries } from "./components/RadarChart";
 
+export { PieChart } from "./components/PieChart";
+export type { PieChartProps, PieChartDataItem } from "./components/PieChart";
+
 export { GNOME_CHART_PALETTE } from "./colors";

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -13,4 +13,7 @@ export type { TreeMapProps, TreeMapDataItem } from "./components/TreeMap";
 export { RadialBarChart } from "./components/RadialBarChart";
 export type { RadialBarChartProps, RadialBarChartDataItem } from "./components/RadialBarChart";
 
+export { RadarChart } from "./components/RadarChart";
+export type { RadarChartProps, RadarChartSeries } from "./components/RadarChart";
+
 export { GNOME_CHART_PALETTE } from "./colors";

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -19,4 +19,7 @@ export type { RadarChartProps, RadarChartSeries } from "./components/RadarChart"
 export { PieChart } from "./components/PieChart";
 export type { PieChartProps, PieChartDataItem } from "./components/PieChart";
 
+export { CloudChart } from "./components/CloudChart";
+export type { CloudChartProps, CloudChartDataItem } from "./components/CloudChart";
+
 export { GNOME_CHART_PALETTE } from "./colors";

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -10,4 +10,7 @@ export type { AreaChartProps, AreaChartSeries } from "./components/AreaChart";
 export { TreeMap } from "./components/TreeMap";
 export type { TreeMapProps, TreeMapDataItem } from "./components/TreeMap";
 
+export { RadialBarChart } from "./components/RadialBarChart";
+export type { RadialBarChartProps, RadialBarChartDataItem } from "./components/RadialBarChart";
+
 export { GNOME_CHART_PALETTE } from "./colors";

--- a/packages/charts/test/setup.ts
+++ b/packages/charts/test/setup.ts
@@ -1,0 +1,12 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import "@testing-library/jest-dom/vitest";
+
+// Recharts' ResponsiveContainer uses ResizeObserver, which is not available in jsdom
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserverMock;

--- a/packages/charts/tsconfig.json
+++ b/packages/charts/tsconfig.json
@@ -7,5 +7,6 @@
     }
   },
   "include": ["src"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/charts/tsconfig.test.json
+++ b/packages/charts/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "types": ["@testing-library/jest-dom"]
+  },
+  "include": [
+    "src/**/*.test.tsx",
+    "src/**/*.test.ts",
+    "test/**/*"
+  ]
+}

--- a/packages/charts/vitest.config.ts
+++ b/packages/charts/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./test/setup.ts"],
+    globals: true,
+    css: true,
+    passWithNoTests: true,
+    typecheck: {
+      tsconfig: "./tsconfig.test.json",
+    },
+  },
+});


### PR DESCRIPTION
## What

Adds five new chart components to @gnome-ui/charts, extends an existing one, and ships a full unit-test suite:

RadialBarChart — concentric arc chart; accepts data: { label, value, color? }[], innerRadius, showLabels, showLegend, and aria-label. Closes #44.
RadarChart — spider/radar chart supporting multiple series, filled polygon mode, and showLegend. Closes #43.
PieChart — pie and donut chart (donut prop) with external slice labels and legend. Closes #42.
CloudChart — word/tag cloud with linear font-size scaling (minFontSize/maxFontSize), per-word color overrides, and no external dependencies. Closes #73.
AreaChart — gradient prop — adds an SVG linearGradient fill option (top-to-transparent) alongside the existing flat-fill. Closes #41.
Vitest test suite — sets up Vitest + jsdom + Testing Library for the package; 64 tests across all 8 components covering render, props, height, className forwarding, and accessibility attributes (role, aria-label). Closes #47.
All components follow the existing API and styling conventions (Adwaita CSS tokens, GNOME_CHART_PALETTE, Recharts ResponsiveContainer wrapper). Each includes a co-located Storybook story file and TypeScript types exported from the package barrel.

## Why

The @gnome-ui/charts package only had four basic cartesian/tree charts. These additions round out the most common visualization patterns — radial, polar, proportional, and text-frequency — so consumers don't need to reach for a second charting library. The gradient fill on AreaChart closes a gap the issue flagged explicitly. The test suite provides a regression baseline now that the component count has doubled.


## Changes

- [x] New component
- [x] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [x] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
