### PR TITLE
feat(@gnome-ui/layout): add EmptyState component (closes #89)

### DIFF
--- a/packages/layout/src/components/EmptyState/EmptyState.module.css
+++ b/packages/layout/src/components/EmptyState/EmptyState.module.css
@@ -1,0 +1,39 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 8px;
+  padding: 48px 24px;
+}
+
+.icon {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.4;
+  margin-bottom: 8px;
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+}
+
+/* Scale any SVG/img child to fill the icon slot */
+.icon > * {
+  width: 100%;
+  height: 100%;
+}
+
+.title {
+  margin: 0;
+}
+
+.description {
+  max-width: 320px;
+  margin: 0;
+}
+
+.action {
+  margin-top: 8px;
+}

--- a/packages/layout/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/layout/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button, Icon } from "@gnome-ui/react";
+import { Folder, Search } from "@gnome-ui/icons";
+import { EmptyState } from "./EmptyState";
+
+const meta: Meta<typeof EmptyState> = {
+  title: "Layout/EmptyState",
+  component: EmptyState,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+Centered empty-state illustration for views with no data.
+
+No card background or border — intended to fill its parent container.
+
+\`\`\`tsx
+import { EmptyState } from "@gnome-ui/layout";
+import { Icon } from "@gnome-ui/react";
+import { Folder } from "@gnome-ui/icons";
+
+<EmptyState
+  icon={<Icon icon={Folder} size="lg" />}
+  title="No files yet"
+  description="Files you add will appear here."
+  action={<Button variant="suggested">Add File</Button>}
+/>
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EmptyState>;
+
+export const Basic: Story = {
+  args: {
+    title: "No files yet",
+    description: "Files you add will appear here.",
+  },
+  parameters: {
+    docs: { description: { story: "Minimal empty state — no icon, no action." } },
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    icon: <Icon icon={Folder} size="lg" />,
+    title: "No files yet",
+    description: "Files you add will appear here.",
+  },
+  parameters: {
+    docs: { description: { story: "Icon is rendered large and muted (40 % opacity) above the title." } },
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    icon: <Icon icon={Folder} size="lg" />,
+    title: "No files yet",
+    description: "Files you add will appear here.",
+    action: <Button variant="suggested">Add File</Button>,
+  },
+  parameters: {
+    docs: { description: { story: "Full empty state with icon, description, and a call-to-action button." } },
+  },
+};
+
+export const NoDescription: Story = {
+  args: {
+    icon: <Icon icon={Search} size="lg" />,
+    title: "No results found",
+    action: <Button variant="flat">Clear filters</Button>,
+  },
+  parameters: {
+    docs: { description: { story: "Empty state without a description — common for search/filter contexts." } },
+  },
+};

--- a/packages/layout/src/components/EmptyState/EmptyState.test.tsx
+++ b/packages/layout/src/components/EmptyState/EmptyState.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Button } from "@gnome-ui/react";
+import { EmptyState } from "./EmptyState";
+
+describe("EmptyState", () => {
+  describe("title", () => {
+    it("renders the title", () => {
+      render(<EmptyState title="No files yet" />);
+      expect(screen.getByText("No files yet")).toBeInTheDocument();
+    });
+  });
+
+  describe("description", () => {
+    it("renders description when provided", () => {
+      render(<EmptyState title="No files yet" description="Files you add will appear here." />);
+      expect(screen.getByText("Files you add will appear here.")).toBeInTheDocument();
+    });
+
+    it("does not render description text when omitted", () => {
+      render(<EmptyState title="No files yet" />);
+      expect(screen.queryByText("Files you add will appear here.")).toBeNull();
+    });
+  });
+
+  describe("icon", () => {
+    it("renders the icon slot when provided", () => {
+      render(
+        <EmptyState
+          title="No files yet"
+          icon={<svg data-testid="folder-icon" />}
+        />,
+      );
+      expect(screen.getByTestId("folder-icon")).toBeInTheDocument();
+    });
+
+    it("does not render the icon slot when omitted", () => {
+      const { container } = render(<EmptyState title="No files yet" />);
+      expect(container.querySelector("[aria-hidden='true']")).toBeNull();
+    });
+  });
+
+  describe("action", () => {
+    it("renders the action slot when provided", () => {
+      render(
+        <EmptyState
+          title="No files yet"
+          action={<Button variant="suggested">Add File</Button>}
+        />,
+      );
+      expect(screen.getByRole("button", { name: "Add File" })).toBeInTheDocument();
+    });
+
+    it("does not render an action slot when omitted", () => {
+      render(<EmptyState title="No files yet" />);
+      expect(screen.queryByRole("button")).toBeNull();
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the root element", () => {
+      const { container } = render(
+        <EmptyState title="No files yet" className="custom-empty" />,
+      );
+      expect(container.firstChild).toHaveClass("custom-empty");
+    });
+
+    it("forwards arbitrary HTML attributes to the root element", () => {
+      const { container } = render(
+        <EmptyState title="No files yet" data-testid="empty-state" />,
+      );
+      expect(container.firstChild).toHaveAttribute("data-testid", "empty-state");
+    });
+  });
+});

--- a/packages/layout/src/components/EmptyState/EmptyState.tsx
+++ b/packages/layout/src/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,45 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { Text } from "@gnome-ui/react";
+import styles from "./EmptyState.module.css";
+
+export interface EmptyStateProps extends HTMLAttributes<HTMLDivElement> {
+  /** Illustrative icon displayed large and muted at the top. */
+  icon?: ReactNode;
+  /** Primary empty state message. */
+  title: string;
+  /** Optional supporting text below the title. */
+  description?: string;
+  /** Optional call-to-action element (button, link…). */
+  action?: ReactNode;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+  ...props
+}: EmptyStateProps) {
+  return (
+    <div
+      className={[styles.root, className].filter(Boolean).join(" ")}
+      {...props}
+    >
+      {icon && (
+        <div className={styles.icon} aria-hidden="true">
+          {icon}
+        </div>
+      )}
+      <Text variant="heading" className={styles.title}>
+        {title}
+      </Text>
+      {description && (
+        <Text variant="body" color="dim" className={styles.description}>
+          {description}
+        </Text>
+      )}
+      {action && <div className={styles.action}>{action}</div>}
+    </div>
+  );
+}

--- a/packages/layout/src/components/EmptyState/index.ts
+++ b/packages/layout/src/components/EmptyState/index.ts
@@ -1,0 +1,2 @@
+export { EmptyState } from "./EmptyState";
+export type { EmptyStateProps } from "./EmptyState";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -21,3 +21,6 @@ export type { EntityCardProps } from "./components/EntityCard";
 
 export { ApplicationCard } from "./components/ApplicationCard";
 export type { ApplicationCardProps, ApplicationCardStat } from "./components/ApplicationCard";
+
+export { EmptyState } from "./components/EmptyState";
+export type { EmptyStateProps } from "./components/EmptyState";


### PR DESCRIPTION
## What
Layout component EmptyState

## Why

Closes #89

## Changes

- [x] New component
- [ ] Bug fix
- [ ] Enhancement
- [ ] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable