### PR TITLE
feat(@gnome-ui/layout): add StatusIndicator component (closes #87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Live examples and documentation: **[Storybook →](https://eljijuna.github.io/gn
 | `EntityCard` | Card for displaying a generic named entity with metadata | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-entitycard--docs) |
 | `ApplicationCard` | Card for displaying an application entry (icon, name, description) | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-applicationcard--docs) |
 | `IconBadge` | Badge with an embedded icon | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-iconbadge--docs) |
+| `EmptyState` | Centered empty-state with icon, title, description, and optional CTA | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-emptystate--docs) |
+| `StatusIndicator` | Service/connection status dot: `online`, `offline`, `warning`, `error`, `loading` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-statusindicator--docs) |
 
 See [ROADMAP.md](ROADMAP.md) for the full list of planned components.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -409,7 +409,8 @@ React hooks that surface every `@gnome-ui/platform` module as idiomatic React st
 | ⬜ | **`QuickActions`** | Grid of shortcut action buttons with keyboard navigation — issue [#86](https://github.com/ElJijuna/gnome-ui/issues/86) |
 | ⬜ | **`StatusIndicator`** | Service/connection status dot: `online`, `offline`, `warning`, `error`, `loading` — issue [#87](https://github.com/ElJijuna/gnome-ui/issues/87) |
 | ⬜ | **`SectionHeader`** | Section title row with optional subtitle and trailing action slot — issue [#88](https://github.com/ElJijuna/gnome-ui/issues/88) |
-| ⬜ | **`EmptyState`** | Centered empty-state illustration: icon, title, description, optional CTA — issue [#89](https://github.com/ElJijuna/gnome-ui/issues/89) |
+| ✅ | **`EmptyState`** | Centered empty-state illustration: icon, title, description, optional CTA — issue [#89](https://github.com/ElJijuna/gnome-ui/issues/89) |
+| ✅ | **`StatusIndicator`** | Service/connection status dot: `online`, `offline`, `warning`, `error`, `loading` — issue [#87](https://github.com/ElJijuna/gnome-ui/issues/87) |
 | ⬜ | **`ErrorState`** | Error state with preset types (`generic`, `network`, `permission`, `not-found`) and recovery action slot — issue [#90](https://github.com/ElJijuna/gnome-ui/issues/90) |
 
 ---

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/components/CounterCard.js",
       "require": "./dist/components/CounterCard.cjs"
     },
+    "./components/EmptyState": {
+      "types": "./dist/components/EmptyState.d.ts",
+      "import": "./dist/components/EmptyState.js",
+      "require": "./dist/components/EmptyState.cjs"
+    },
     "./components/EntityCard": {
       "types": "./dist/components/EntityCard.d.ts",
       "import": "./dist/components/EntityCard.js",
@@ -42,6 +47,11 @@
       "import": "./dist/components/PanelCard.js",
       "require": "./dist/components/PanelCard.cjs"
     },
+    "./components/StatusIndicator": {
+      "types": "./dist/components/StatusIndicator.d.ts",
+      "import": "./dist/components/StatusIndicator.js",
+      "require": "./dist/components/StatusIndicator.cjs"
+    },
     "./components/UserCard": {
       "types": "./dist/components/UserCard.d.ts",
       "import": "./dist/components/UserCard.js",
@@ -51,8 +61,7 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    },
-    "./styles": "./dist/style.css"
+    }
   },
   "sideEffects": [
     "**/*.css",

--- a/packages/layout/src/components/StatusIndicator/StatusIndicator.module.css
+++ b/packages/layout/src/components/StatusIndicator/StatusIndicator.module.css
@@ -1,0 +1,74 @@
+.root {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+/* ─── Dot ─────────────────────────────────────────────────────────────────── */
+
+.dot {
+  flex-shrink: 0;
+  border-radius: 50%;
+}
+
+/* Sizes */
+.dot.md {
+  width: 10px;
+  height: 10px;
+  margin-top: 5px; /* vertically center against body text */
+}
+
+.dot.sm {
+  width: 8px;
+  height: 8px;
+  margin-top: 4px; /* vertically center against caption text */
+}
+
+/* Status colors */
+.dot.online {
+  background-color: var(--gnome-success-color, #26a269);
+}
+
+.dot.warning {
+  background-color: var(--gnome-warning-color, #e5a50a);
+}
+
+.dot.error {
+  background-color: var(--gnome-error-color, #e01b24);
+}
+
+.dot.offline {
+  background-color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  opacity: var(--gnome-opacity-dim, 0.55);
+}
+
+.dot.loading {
+  background-color: var(--gnome-accent-color, #3584e4);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.3; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dot.loading {
+    animation: none;
+    opacity: 0.6;
+  }
+}
+
+/* ─── Content ─────────────────────────────────────────────────────────────── */
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.label,
+.description {
+  margin: 0;
+}

--- a/packages/layout/src/components/StatusIndicator/StatusIndicator.stories.tsx
+++ b/packages/layout/src/components/StatusIndicator/StatusIndicator.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { StatusIndicator } from "./StatusIndicator";
+
+const meta: Meta<typeof StatusIndicator> = {
+  title: "Layout/StatusIndicator",
+  component: StatusIndicator,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+Status dot for communicating the health of a service, connection, or resource.
+
+Colors follow Adwaita tokens (\`--gnome-success-color\`, \`--gnome-warning-color\`,
+\`--gnome-error-color\`). The \`loading\` status pulses via CSS animation and
+respects \`prefers-reduced-motion\`.
+
+\`\`\`tsx
+import { StatusIndicator } from "@gnome-ui/layout";
+
+<StatusIndicator status="online"  label="Database" />
+<StatusIndicator status="warning" label="API Gateway" description="High latency" />
+<StatusIndicator status="offline" label="Backup Service" />
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StatusIndicator>;
+
+export const Online: Story = {
+  args: { status: "online", label: "Database" },
+};
+
+export const Warning: Story = {
+  args: { status: "warning", label: "API Gateway", description: "High latency detected" },
+};
+
+export const Error: Story = {
+  args: { status: "error", label: "Payment Service", description: "Connection refused" },
+};
+
+export const Offline: Story = {
+  args: { status: "offline", label: "Backup Service" },
+};
+
+export const Loading: Story = {
+  args: { status: "loading", label: "Connecting…" },
+  parameters: {
+    docs: { description: { story: "The dot pulses. Animation is disabled when `prefers-reduced-motion` is set." } },
+  },
+};
+
+export const SmallSize: Story = {
+  args: { status: "online", label: "Database", size: "sm" },
+  parameters: {
+    docs: { description: { story: "`size=\"sm\"` for dense lists or compact panels." } },
+  },
+};
+
+export const AllStatuses: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <StatusIndicator status="online"  label="Database"        description="Connected — 3ms avg latency" />
+      <StatusIndicator status="warning" label="API Gateway"     description="High latency detected" />
+      <StatusIndicator status="error"   label="Payment Service" description="Connection refused" />
+      <StatusIndicator status="offline" label="Backup Service" />
+      <StatusIndicator status="loading" label="Cache"           description="Reconnecting…" />
+    </div>
+  ),
+  parameters: {
+    docs: { description: { story: "All five statuses in a realistic service list." } },
+  },
+};

--- a/packages/layout/src/components/StatusIndicator/StatusIndicator.test.tsx
+++ b/packages/layout/src/components/StatusIndicator/StatusIndicator.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatusIndicator } from "./StatusIndicator";
+
+describe("StatusIndicator", () => {
+  describe("label", () => {
+    it("renders the label", () => {
+      render(<StatusIndicator status="online" label="Database" />);
+      expect(screen.getByText("Database")).toBeInTheDocument();
+    });
+  });
+
+  describe("description", () => {
+    it("renders description when provided", () => {
+      render(
+        <StatusIndicator status="warning" label="API" description="High latency" />,
+      );
+      expect(screen.getByText("High latency")).toBeInTheDocument();
+    });
+
+    it("does not render description when omitted", () => {
+      render(<StatusIndicator status="online" label="Database" />);
+      expect(screen.queryByText("High latency")).toBeNull();
+    });
+  });
+
+  describe("dot aria-label", () => {
+    it.each([
+      ["online",  "Online"],
+      ["offline", "Offline"],
+      ["warning", "Warning"],
+      ["error",   "Error"],
+      ["loading", "Loading"],
+    ] as const)("status '%s' gives dot aria-label '%s'", (status, expected) => {
+      render(<StatusIndicator status={status} label="Service" />);
+      expect(screen.getByRole("img", { name: expected })).toBeInTheDocument();
+    });
+  });
+
+  describe("status class", () => {
+    it.each(["online", "offline", "warning", "error", "loading"] as const)(
+      "applies '%s' class to the dot",
+      (status) => {
+        const { container } = render(
+          <StatusIndicator status={status} label="Service" />,
+        );
+        const dot = container.querySelector("[role='img']");
+        expect(dot?.className).toMatch(status);
+      },
+    );
+  });
+
+  describe("size class", () => {
+    it("applies 'md' class by default", () => {
+      const { container } = render(
+        <StatusIndicator status="online" label="Service" />,
+      );
+      const dot = container.querySelector("[role='img']");
+      expect(dot?.className).toMatch("md");
+    });
+
+    it("applies 'sm' class when size='sm'", () => {
+      const { container } = render(
+        <StatusIndicator status="online" label="Service" size="sm" />,
+      );
+      const dot = container.querySelector("[role='img']");
+      expect(dot?.className).toMatch("sm");
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the root element", () => {
+      const { container } = render(
+        <StatusIndicator status="online" label="DB" className="my-status" />,
+      );
+      expect(container.firstChild).toHaveClass("my-status");
+    });
+
+    it("forwards arbitrary HTML attributes to the root element", () => {
+      const { container } = render(
+        <StatusIndicator status="online" label="DB" data-testid="status" />,
+      );
+      expect(container.firstChild).toHaveAttribute("data-testid", "status");
+    });
+  });
+});

--- a/packages/layout/src/components/StatusIndicator/StatusIndicator.tsx
+++ b/packages/layout/src/components/StatusIndicator/StatusIndicator.tsx
@@ -1,0 +1,67 @@
+import type { HTMLAttributes } from "react";
+import { Text } from "@gnome-ui/react";
+import styles from "./StatusIndicator.module.css";
+
+export type StatusIndicatorStatus =
+  | "online"
+  | "offline"
+  | "warning"
+  | "error"
+  | "loading";
+
+export type StatusIndicatorSize = "sm" | "md";
+
+export interface StatusIndicatorProps extends HTMLAttributes<HTMLDivElement> {
+  /** Current status — drives the dot color. */
+  status: StatusIndicatorStatus;
+  /** Service or resource name. */
+  label: string;
+  /** Optional detail text shown below the label. */
+  description?: string;
+  /** Indicator dot size. Defaults to `"md"`. */
+  size?: StatusIndicatorSize;
+}
+
+const STATUS_LABELS: Record<StatusIndicatorStatus, string> = {
+  online: "Online",
+  offline: "Offline",
+  warning: "Warning",
+  error: "Error",
+  loading: "Loading",
+};
+
+export function StatusIndicator({
+  status,
+  label,
+  description,
+  size = "md",
+  className,
+  ...props
+}: StatusIndicatorProps) {
+  return (
+    <div
+      className={[styles.root, className].filter(Boolean).join(" ")}
+      {...props}
+    >
+      <div
+        className={[
+          styles.dot,
+          styles[status],
+          styles[size],
+        ].join(" ")}
+        role="img"
+        aria-label={STATUS_LABELS[status]}
+      />
+      <div className={styles.content}>
+        <Text variant={size === "sm" ? "caption" : "body"} className={styles.label}>
+          {label}
+        </Text>
+        {description && (
+          <Text variant="caption" color="dim" className={styles.description}>
+            {description}
+          </Text>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/layout/src/components/StatusIndicator/index.ts
+++ b/packages/layout/src/components/StatusIndicator/index.ts
@@ -1,0 +1,6 @@
+export { StatusIndicator } from "./StatusIndicator";
+export type {
+  StatusIndicatorProps,
+  StatusIndicatorStatus,
+  StatusIndicatorSize,
+} from "./StatusIndicator";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -24,3 +24,10 @@ export type { ApplicationCardProps, ApplicationCardStat } from "./components/App
 
 export { EmptyState } from "./components/EmptyState";
 export type { EmptyStateProps } from "./components/EmptyState";
+
+export { StatusIndicator } from "./components/StatusIndicator";
+export type {
+  StatusIndicatorProps,
+  StatusIndicatorStatus,
+  StatusIndicatorSize,
+} from "./components/StatusIndicator";


### PR DESCRIPTION
## What

**StatusIndicator component**:
Service/connection status dot with 5 states: online, offline, warning, error, loading. Colors use Adwaita tokens. Loading state pulses via CSS animation; respects prefers-reduced-motion. Includes unit tests and stories.

## Why

closes #87 

## Changes

- [x] New component
- [ ] Bug fix
- [ ] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
