### PR TITLE
feat(@gnome-ui/layout): add DashboardGrid component (closes #82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Live examples and documentation: **[Storybook →](https://eljijuna.github.io/gn
 | `EmptyState` | Centered empty-state with icon, title, description, and optional CTA | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-emptystate--docs) |
 | `StatusIndicator` | Service/connection status dot: `online`, `offline`, `warning`, `error`, `loading` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-statusindicator--docs) |
 | `ErrorState` | Error state with presets: `generic`, `network`, `permission`, `not-found` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-errorstate--docs) |
+| `DashboardGrid` | Responsive CSS Grid container for arranging dashboard widgets; `columns` (1–4 or auto) and per-item `span` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-dashboardgrid--docs) |
 
 See [ROADMAP.md](ROADMAP.md) for the full list of planned components.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -402,7 +402,7 @@ React hooks that surface every `@gnome-ui/platform` module as idiomatic React st
 
 | Status | Component | Description |
 |--------|-----------|-------------|
-| ⬜ | **`DashboardGrid`** | Responsive CSS Grid container for arranging dashboard widgets; supports column count and per-item span — issue [#82](https://github.com/ElJijuna/gnome-ui/issues/82) |
+| ✅ | **`DashboardGrid`** | Responsive CSS Grid container for arranging dashboard widgets; supports column count and per-item span — issue [#82](https://github.com/ElJijuna/gnome-ui/issues/82) |
 | ⬜ | **`StatCard`** | Key metric display with optional trend indicator (direction, percentage, period) and loading skeleton — issue [#83](https://github.com/ElJijuna/gnome-ui/issues/83) |
 | ⬜ | **`ProgressCard`** | Resource usage card with labelled progress bar; color thresholds at 75 % (warning) and 90 % (critical) — issue [#84](https://github.com/ElJijuna/gnome-ui/issues/84) |
 | ⬜ | **`ActivityFeed`** | Chronological event list with relative timestamps, icons, and truncation — issue [#85](https://github.com/ElJijuna/gnome-ui/issues/85) |

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -237,6 +237,41 @@ const panelRef = useRef<PanelCardHandle>(null);
 </PanelCard>
 ```
 
+---
+
+### `DashboardGrid`
+
+Responsive CSS Grid container for arranging dashboard widgets and panels.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `columns` | `1 \| 2 \| 3 \| 4 \| "auto"` | `"auto"` | Column count. `"auto"` fills columns with `minmax(280px, 1fr)`. |
+| `gap` | `"sm" \| "md" \| "lg"` | `"md"` | Gap between items (8 / 16 / 24 px). |
+| `children` | `ReactNode` | — | `DashboardGrid.Item` elements. |
+
+#### `DashboardGrid.Item` props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `span` | `1 \| 2 \| 3 \| 4` | `1` | Number of columns the item spans. |
+| `children` | `ReactNode` | — | Widget content. |
+
+Both `DashboardGrid` and `DashboardGrid.Item` forward all `<div>` props
+to their root element.
+
+```tsx
+import { DashboardGrid } from "@gnome-ui/layout";
+
+<DashboardGrid columns={3} gap="md">
+  <DashboardGrid.Item span={2}>
+    <StatCard />
+  </DashboardGrid.Item>
+  <DashboardGrid.Item>
+    <ProgressCard />
+  </DashboardGrid.Item>
+</DashboardGrid>
+```
+
 ## License
 
 [MIT](../../LICENSE)

--- a/packages/layout/ROADMAP.md
+++ b/packages/layout/ROADMAP.md
@@ -88,18 +88,9 @@ Colapsa a una sola columna en mobile (patrón `NavigationSplitView` pero al nive
 
 ---
 
-### `DashboardGrid`
+### ~~`DashboardGrid`~~ ✅ Implementado — issue [#82](https://github.com/ElJijuna/gnome-ui/issues/82)
 
 Grid responsivo de tarjetas con columnas fluidas, gap consistente y soporte para celdas de distintos tamaños (`span`).
-
-```tsx
-<DashboardGrid>
-  <DashboardGrid.Cell span={2}><StatsCard /></DashboardGrid.Cell>
-  <DashboardGrid.Cell><ChartCard /></DashboardGrid.Cell>
-</DashboardGrid>
-```
-
-**Por qué en layout:** encapsula el CSS Grid responsivo con los tokens de espaciado de GNOME.
 
 ---
 

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/components/CounterCard.js",
       "require": "./dist/components/CounterCard.cjs"
     },
+    "./components/DashboardGrid": {
+      "types": "./dist/components/DashboardGrid.d.ts",
+      "import": "./dist/components/DashboardGrid.js",
+      "require": "./dist/components/DashboardGrid.cjs"
+    },
     "./components/EmptyState": {
       "types": "./dist/components/EmptyState.d.ts",
       "import": "./dist/components/EmptyState.js",

--- a/packages/layout/src/components/DashboardGrid/DashboardGrid.module.css
+++ b/packages/layout/src/components/DashboardGrid/DashboardGrid.module.css
@@ -1,0 +1,22 @@
+.grid {
+  display: grid;
+  width: 100%;
+}
+
+/* ─── Gap variants ────────────────────────────────────────────────────────── */
+
+.gapSm { gap: 8px; }
+.gapMd { gap: 16px; }
+.gapLg { gap: 24px; }
+
+/* ─── Auto responsive columns ─────────────────────────────────────────────── */
+
+.auto {
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+/* ─── Item ────────────────────────────────────────────────────────────────── */
+
+.item {
+  min-width: 0;
+}

--- a/packages/layout/src/components/DashboardGrid/DashboardGrid.stories.tsx
+++ b/packages/layout/src/components/DashboardGrid/DashboardGrid.stories.tsx
@@ -1,0 +1,210 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DashboardGrid } from "./DashboardGrid";
+
+const Placeholder = ({
+  label,
+  height = 120,
+}: {
+  label: string;
+  height?: number;
+}) => (
+  <div
+    style={{
+      height,
+      background: "var(--gnome-card-bg, #f6f5f4)",
+      border: "1px solid var(--gnome-border-color, #deddda)",
+      borderRadius: 12,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      fontWeight: 500,
+      color: "var(--gnome-dim-label-color, #77767b)",
+      fontSize: 14,
+    }}
+  >
+    {label}
+  </div>
+);
+
+const meta: Meta<typeof DashboardGrid> = {
+  title: "Layout/DashboardGrid",
+  component: DashboardGrid,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+Responsive grid container for arranging dashboard widgets and panels.
+
+Use \`columns\` to fix the column count or let it adapt automatically with \`"auto"\`.
+Wrap each widget in \`DashboardGrid.Item\` and set \`span\` to make it span multiple columns.
+
+\`\`\`tsx
+import { DashboardGrid } from "@gnome-ui/layout";
+
+<DashboardGrid columns={3} gap="md">
+  <DashboardGrid.Item span={2}>
+    <StatCard ... />
+  </DashboardGrid.Item>
+  <DashboardGrid.Item>
+    <ProgressCard ... />
+  </DashboardGrid.Item>
+</DashboardGrid>
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    columns: {
+      control: { type: "select" },
+      options: [1, 2, 3, 4, "auto"],
+    },
+    gap: {
+      control: { type: "radio" },
+      options: ["sm", "md", "lg"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DashboardGrid>;
+
+export const Default: Story = {
+  args: {
+    columns: "auto",
+    gap: "md",
+  },
+  render: (args) => (
+    <DashboardGrid {...args}>
+      {["Widget A", "Widget B", "Widget C", "Widget D"].map((label) => (
+        <DashboardGrid.Item key={label}>
+          <Placeholder label={label} />
+        </DashboardGrid.Item>
+      ))}
+    </DashboardGrid>
+  ),
+};
+
+export const FixedColumns: Story = {
+  args: {
+    columns: 3,
+    gap: "md",
+  },
+  render: (args) => (
+    <DashboardGrid {...args}>
+      {["Stats", "Revenue", "Users", "Sessions", "Errors", "Uptime"].map(
+        (label) => (
+          <DashboardGrid.Item key={label}>
+            <Placeholder label={label} />
+          </DashboardGrid.Item>
+        ),
+      )}
+    </DashboardGrid>
+  ),
+  parameters: {
+    docs: { description: { story: "Fixed 3-column layout." } },
+  },
+};
+
+export const WithSpanning: Story = {
+  args: {
+    columns: 3,
+    gap: "md",
+  },
+  render: (args) => (
+    <DashboardGrid {...args}>
+      <DashboardGrid.Item span={2}>
+        <Placeholder label="Revenue Chart (span 2)" height={200} />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item>
+        <Placeholder label="Quick Stats" height={200} />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item>
+        <Placeholder label="Users" />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item>
+        <Placeholder label="Sessions" />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item>
+        <Placeholder label="Errors" />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item span={3}>
+        <Placeholder label="Activity Feed (span 3)" height={80} />
+      </DashboardGrid.Item>
+    </DashboardGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Items can span multiple columns via the `span` prop on `DashboardGrid.Item`.",
+      },
+    },
+  },
+};
+
+export const GapVariants: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+      {(["sm", "md", "lg"] as const).map((gap) => (
+        <div key={gap}>
+          <p style={{ marginBottom: 8, fontWeight: 600, fontSize: 13 }}>
+            gap="{gap}"
+          </p>
+          <DashboardGrid columns={3} gap={gap}>
+            {["A", "B", "C"].map((l) => (
+              <DashboardGrid.Item key={l}>
+                <Placeholder label={l} height={80} />
+              </DashboardGrid.Item>
+            ))}
+          </DashboardGrid>
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: { description: { story: "All three gap sizes side by side." } },
+  },
+};
+
+export const RealisticDashboard: Story = {
+  render: () => (
+    <DashboardGrid columns={4} gap="md">
+      <DashboardGrid.Item>
+        <Placeholder label="Total Users" height={100} />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item>
+        <Placeholder label="Revenue" height={100} />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item>
+        <Placeholder label="Active Sessions" height={100} />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item>
+        <Placeholder label="Error Rate" height={100} />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item span={3}>
+        <Placeholder label="Traffic Chart (span 3)" height={220} />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item>
+        <Placeholder label="Top Pages" height={220} />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item span={2}>
+        <Placeholder label="Recent Events (span 2)" height={160} />
+      </DashboardGrid.Item>
+      <DashboardGrid.Item span={2}>
+        <Placeholder label="Device Breakdown (span 2)" height={160} />
+      </DashboardGrid.Item>
+    </DashboardGrid>
+  ),
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        story:
+          "Realistic 4-column dashboard mixing full-width, half-width, and single-column panels.",
+      },
+    },
+  },
+};

--- a/packages/layout/src/components/DashboardGrid/DashboardGrid.test.tsx
+++ b/packages/layout/src/components/DashboardGrid/DashboardGrid.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DashboardGrid } from "./DashboardGrid";
+
+describe("DashboardGrid", () => {
+  describe("rendering", () => {
+    it("renders children", () => {
+      render(
+        <DashboardGrid>
+          <DashboardGrid.Item>Widget A</DashboardGrid.Item>
+          <DashboardGrid.Item>Widget B</DashboardGrid.Item>
+        </DashboardGrid>,
+      );
+      expect(screen.getByText("Widget A")).toBeInTheDocument();
+      expect(screen.getByText("Widget B")).toBeInTheDocument();
+    });
+  });
+
+  describe("columns prop", () => {
+    it("applies repeat(N, 1fr) inline style for numeric columns", () => {
+      const { container } = render(
+        <DashboardGrid columns={3}>
+          <DashboardGrid.Item>Item</DashboardGrid.Item>
+        </DashboardGrid>,
+      );
+      const grid = container.firstChild as HTMLElement;
+      expect(grid.style.gridTemplateColumns).toBe("repeat(3, 1fr)");
+    });
+
+    it.each([1, 2, 4] as const)(
+      "applies repeat(%s, 1fr) for columns=%s",
+      (cols) => {
+        const { container } = render(<DashboardGrid columns={cols} />);
+        const grid = container.firstChild as HTMLElement;
+        expect(grid.style.gridTemplateColumns).toBe(`repeat(${cols}, 1fr)`);
+      },
+    );
+
+    it('does not set gridTemplateColumns inline style for columns="auto"', () => {
+      const { container } = render(<DashboardGrid columns="auto" />);
+      const grid = container.firstChild as HTMLElement;
+      expect(grid.style.gridTemplateColumns).toBe("");
+    });
+
+    it("defaults to auto when columns is omitted", () => {
+      const { container } = render(<DashboardGrid />);
+      const grid = container.firstChild as HTMLElement;
+      expect(grid.style.gridTemplateColumns).toBe("");
+    });
+  });
+
+  describe("gap prop", () => {
+    it.each(["sm", "md", "lg"] as const)(
+      "applies gap class for gap='%s'",
+      (gap) => {
+        const { container } = render(<DashboardGrid gap={gap} />);
+        const grid = container.firstChild as HTMLElement;
+        expect(grid.className).toMatch(new RegExp(`gap${gap[0].toUpperCase() + gap.slice(1)}|gap-${gap}`));
+      },
+    );
+
+    it("defaults to md gap when gap is omitted", () => {
+      const { container } = render(<DashboardGrid />);
+      const grid = container.firstChild as HTMLElement;
+      expect(grid.className).toMatch(/gapMd|gap-md/);
+    });
+  });
+
+  describe("DashboardGrid.Item span prop", () => {
+    it("applies gridColumn span style for span > 1", () => {
+      const { container } = render(
+        <DashboardGrid>
+          <DashboardGrid.Item span={2}>Item</DashboardGrid.Item>
+        </DashboardGrid>,
+      );
+      const item = container.querySelector("[class]")
+        ?.nextElementSibling as HTMLElement | null ??
+        container.querySelectorAll("div")[1] as HTMLElement;
+      expect(item.style.gridColumn).toBe("span 2");
+    });
+
+    it.each([2, 3, 4] as const)(
+      "applies span %s to item",
+      (span) => {
+        const { container } = render(
+          <DashboardGrid>
+            <DashboardGrid.Item span={span}>Item</DashboardGrid.Item>
+          </DashboardGrid>,
+        );
+        const item = container.querySelectorAll("div")[1] as HTMLElement;
+        expect(item.style.gridColumn).toBe(`span ${span}`);
+      },
+    );
+
+    it("does not apply gridColumn style for default span (1)", () => {
+      const { container } = render(
+        <DashboardGrid>
+          <DashboardGrid.Item>Item</DashboardGrid.Item>
+        </DashboardGrid>,
+      );
+      const item = container.querySelectorAll("div")[1] as HTMLElement;
+      expect(item.style.gridColumn).toBe("");
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className to the grid root", () => {
+      const { container } = render(<DashboardGrid className="my-grid" />);
+      expect(container.firstChild).toHaveClass("my-grid");
+    });
+
+    it("forwards data attributes to the grid root", () => {
+      const { container } = render(<DashboardGrid data-testid="grid" />);
+      expect(container.firstChild).toHaveAttribute("data-testid", "grid");
+    });
+
+    it("forwards className to DashboardGrid.Item", () => {
+      render(
+        <DashboardGrid>
+          <DashboardGrid.Item className="my-item">Item</DashboardGrid.Item>
+        </DashboardGrid>,
+      );
+      const item = screen.getByText("Item");
+      expect(item).toHaveClass("my-item");
+    });
+
+    it("forwards data attributes to DashboardGrid.Item", () => {
+      render(
+        <DashboardGrid>
+          <DashboardGrid.Item data-testid="item">Item</DashboardGrid.Item>
+        </DashboardGrid>,
+      );
+      expect(screen.getByTestId("item")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/layout/src/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/layout/src/components/DashboardGrid/DashboardGrid.tsx
@@ -1,0 +1,82 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import styles from "./DashboardGrid.module.css";
+
+export type DashboardGridColumns = 1 | 2 | 3 | 4 | "auto";
+export type DashboardGridGap = "sm" | "md" | "lg";
+
+export interface DashboardGridProps extends HTMLAttributes<HTMLDivElement> {
+  /** Number of columns. `"auto"` uses responsive breakpoints. Defaults to `"auto"`. */
+  columns?: DashboardGridColumns;
+  /** Gap between items. Defaults to `"md"`. */
+  gap?: DashboardGridGap;
+  children?: ReactNode;
+}
+
+export interface DashboardGridItemProps extends HTMLAttributes<HTMLDivElement> {
+  /** Column span (1–4). Defaults to `1`. */
+  span?: 1 | 2 | 3 | 4;
+  children?: ReactNode;
+}
+
+const GAP_CLASS: Record<DashboardGridGap, string> = {
+  sm: styles.gapSm,
+  md: styles.gapMd,
+  lg: styles.gapLg,
+};
+
+function DashboardGridItem({
+  span = 1,
+  children,
+  className,
+  style,
+  ...props
+}: DashboardGridItemProps) {
+  const itemStyle: CSSProperties = {
+    gridColumn: span > 1 ? `span ${span}` : undefined,
+    ...style,
+  };
+
+  return (
+    <div
+      className={[styles.item, className].filter(Boolean).join(" ")}
+      style={itemStyle}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DashboardGrid({
+  columns = "auto",
+  gap = "md",
+  children,
+  className,
+  style,
+  ...props
+}: DashboardGridProps) {
+  const gridStyle: CSSProperties = {
+    gridTemplateColumns:
+      columns === "auto" ? undefined : `repeat(${columns}, 1fr)`,
+    ...style,
+  };
+
+  return (
+    <div
+      className={[
+        styles.grid,
+        GAP_CLASS[gap],
+        columns === "auto" && styles.auto,
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={gridStyle}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+DashboardGrid.Item = DashboardGridItem;

--- a/packages/layout/src/components/DashboardGrid/index.ts
+++ b/packages/layout/src/components/DashboardGrid/index.ts
@@ -1,0 +1,7 @@
+export { DashboardGrid } from "./DashboardGrid";
+export type {
+  DashboardGridProps,
+  DashboardGridItemProps,
+  DashboardGridColumns,
+  DashboardGridGap,
+} from "./DashboardGrid";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -34,3 +34,11 @@ export type {
 
 export { ErrorState } from "./components/ErrorState";
 export type { ErrorStateProps, ErrorStateType } from "./components/ErrorState";
+
+export { DashboardGrid } from "./components/DashboardGrid";
+export type {
+  DashboardGridProps,
+  DashboardGridItemProps,
+  DashboardGridColumns,
+  DashboardGridGap,
+} from "./components/DashboardGrid";


### PR DESCRIPTION
## What

DashboardGrid component

## Why

closes #82 

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
