### PR TITLE
feat(react): add Skeleton component

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,6 +54,7 @@ Legend: ✅ Done · 🚧 In progress · ⬜ Pending
 |--------|-----------|-------------|
 | ✅ | **Spinner** | Indeterminate loading indicator |
 | ✅ | **Progress Bar** | Determinate and indeterminate progress |
+| ✅ | **Skeleton** | Content-shaped loading placeholder for web-style skeleton screens; pragmatic extension beyond GNOME HIG loading patterns — issue [#95](https://github.com/ElJijuna/gnome-ui/issues/95) |
 | ✅ | **Toast** | Non-blocking temporary notification |
 | ✅ | **Banner** | Persistent message at the top of a view |
 | ✅ | **Dialog** | Blocking modal with title, body, and buttons |

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -86,6 +86,7 @@ import { Button } from "@gnome-ui/react/components/Button";
 | [`Blockquote`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-blockquote--docs) | Styled pull-quote with left-border accent; default, info, warning, error, success variants; optional icon and attribution |
 | [`Spinner`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-spinner--docs) | Indeterminate loading indicator; sm/md/lg sizes |
 | [`ProgressBar`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-progressbar--docs) | Determinate (0–1) and indeterminate progress indicator |
+| [`Skeleton`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-skeleton--docs) | Content-shaped loading placeholder; rectangular, circular, and multi-line text variants with optional shimmer |
 | [`CountDownTimer`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-countdowntimer--docs) | Countdown timer showing remaining time until a specified date; `date`, `time`, or `datetime` formats; executes callback on completion |
 | [`StatusPage`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-statuspage--docs) | Empty-state page with icon, title, description, and optional actions; `compact` prop for sidebars/popovers |
 | [`Separator`](https://eljijuna.github.io/gnome-ui/?path=/docs/components-separator--docs) | Horizontal/vertical dividing line between content groups |

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -267,6 +267,11 @@
       "import": "./dist/components/Sidebar.js",
       "require": "./dist/components/Sidebar.cjs"
     },
+    "./components/Skeleton": {
+      "types": "./dist/components/Skeleton.d.ts",
+      "import": "./dist/components/Skeleton.js",
+      "require": "./dist/components/Skeleton.cjs"
+    },
     "./components/Slider": {
       "types": "./dist/components/Slider.d.ts",
       "import": "./dist/components/Slider.js",

--- a/packages/react/src/components/Skeleton/Skeleton.module.css
+++ b/packages/react/src/components/Skeleton/Skeleton.module.css
@@ -1,0 +1,88 @@
+/* Base */
+
+.skeleton {
+  --skeleton-base: var(--gnome-skeleton-base-color, rgba(0, 0, 0, 0.09));
+  --skeleton-highlight: var(--gnome-skeleton-highlight-color, rgba(255, 255, 255, 0.55));
+
+  position: relative;
+  display: block;
+  flex-shrink: 0;
+  overflow: hidden;
+  background-color: var(--skeleton-base);
+}
+
+.skeleton::after,
+.line::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--skeleton-highlight),
+    transparent
+  );
+}
+
+.animated::after,
+.animated .line::after {
+  animation: shimmer 1.4s var(--gnome-easing-default, ease) infinite;
+}
+
+/* Variants */
+
+.rect {
+  border-radius: var(--gnome-radius-md, 6px);
+}
+
+.circle {
+  border-radius: 50%;
+}
+
+.text {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 8px;
+  background-color: transparent;
+}
+
+.text::after {
+  display: none;
+}
+
+.line {
+  position: relative;
+  width: var(--skeleton-line-width, 100%);
+  height: 12px;
+  overflow: hidden;
+  border-radius: var(--gnome-radius-pill, 999px);
+  background-color: var(--skeleton-base);
+}
+
+/* Keyframes */
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* Dark mode */
+
+@media (prefers-color-scheme: dark) {
+  .skeleton {
+    --skeleton-base: var(--gnome-skeleton-base-color, rgba(255, 255, 255, 0.12));
+    --skeleton-highlight: var(--gnome-skeleton-highlight-color, rgba(255, 255, 255, 0.18));
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  .animated::after,
+  .animated .line::after {
+    animation: none;
+  }
+}

--- a/packages/react/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Skeleton } from "./Skeleton";
+import { Card } from "../Card";
+
+const meta: Meta<typeof Skeleton> = {
+  title: "Components/Skeleton",
+  component: Skeleton,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+Content-shaped loading placeholder for skeleton screens.
+
+GNOME HIG recommends \`Spinner\` and \`ProgressBar\` for loading states. \`Skeleton\`
+is provided as a pragmatic web-style extension for dashboards and data-heavy
+views where placeholders reduce layout shift.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    variant: { control: "select", options: ["rect", "circle", "text"] },
+    width: { control: "text" },
+    height: { control: "text" },
+    size: { control: { type: "number", min: 8, max: 160, step: 1 } },
+    lines: { control: { type: "number", min: 1, max: 8, step: 1 } },
+    animated: { control: "boolean" },
+  },
+  args: {
+    variant: "rect",
+    width: 200,
+    height: 20,
+    size: 40,
+    lines: 3,
+    animated: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+// Rectangular
+
+export const Rectangular: Story = {};
+
+// Circle
+
+export const Circle: Story = {
+  args: {
+    variant: "circle",
+    size: 48,
+  },
+};
+
+// Text
+
+export const Text: Story = {
+  args: {
+    variant: "text",
+    lines: 4,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+// All variants
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: 20, maxWidth: 360 }}>
+      <Skeleton width="100%" height={24} />
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <Skeleton variant="circle" size={48} />
+        <Skeleton variant="text" lines={2} />
+      </div>
+      <Skeleton variant="text" lines={4} />
+    </div>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+// Card skeleton
+
+export const CardSkeleton: Story = {
+  render: () => (
+    <Card style={{ width: 320 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <Skeleton variant="circle" size={44} />
+        <div style={{ flex: 1 }}>
+          <Skeleton variant="text" lines={2} />
+        </div>
+      </div>
+      <div style={{ display: "grid", gap: 10, marginTop: 18 }}>
+        <Skeleton height={72} />
+        <Skeleton variant="text" lines={3} />
+      </div>
+    </Card>
+  ),
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "A realistic card placeholder that mirrors avatar, title, summary, and content regions while data loads.",
+      },
+    },
+  },
+};

--- a/packages/react/src/components/Skeleton/Skeleton.test.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Skeleton } from "./Skeleton";
+
+describe("Skeleton", () => {
+  describe("variants", () => {
+    it("renders a rectangular block with width and height", () => {
+      render(<Skeleton width={200} height={20} data-testid="skeleton" />);
+      const skeleton = screen.getByTestId("skeleton");
+
+      expect(skeleton.className).toMatch(/rect/);
+      expect(skeleton).toHaveStyle({ width: "200px", height: "20px" });
+    });
+
+    it("accepts string dimensions for rectangular blocks", () => {
+      render(<Skeleton width="12rem" height="2em" data-testid="skeleton" />);
+      expect(screen.getByTestId("skeleton")).toHaveStyle({
+        width: "12rem",
+        height: "2em",
+      });
+    });
+
+    it("renders a circular block with size", () => {
+      render(<Skeleton variant="circle" size={40} data-testid="skeleton" />);
+      const skeleton = screen.getByTestId("skeleton");
+
+      expect(skeleton.className).toMatch(/circle/);
+      expect(skeleton).toHaveStyle({ width: "40px", height: "40px" });
+    });
+
+    it("renders text rows and makes the last row shorter", () => {
+      const { container } = render(
+        <Skeleton variant="text" lines={3} data-testid="skeleton" />,
+      );
+      const lines = container.querySelectorAll("[class*='line']");
+
+      expect(screen.getByTestId("skeleton").className).toMatch(/text/);
+      expect(lines).toHaveLength(3);
+      expect(lines[2]).toHaveStyle({ "--skeleton-line-width": "60%" });
+    });
+  });
+
+  describe("animation", () => {
+    it("is animated by default", () => {
+      render(<Skeleton data-testid="skeleton" />);
+      expect(screen.getByTestId("skeleton").className).toMatch(/animated/);
+    });
+
+    it("does not apply the animated class when disabled", () => {
+      render(<Skeleton animated={false} data-testid="skeleton" />);
+      expect(screen.getByTestId("skeleton").className).not.toMatch(/animated/);
+    });
+  });
+
+  describe("HTML attribute forwarding", () => {
+    it("forwards className", () => {
+      render(<Skeleton className="custom" data-testid="skeleton" />);
+      expect(screen.getByTestId("skeleton")).toHaveClass("custom");
+    });
+
+    it("is hidden from assistive technologies by default", () => {
+      render(<Skeleton data-testid="skeleton" />);
+      expect(screen.getByTestId("skeleton")).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+});

--- a/packages/react/src/components/Skeleton/Skeleton.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,92 @@
+import type { CSSProperties, HTMLAttributes } from "react";
+import styles from "./Skeleton.module.css";
+
+export type SkeletonVariant = "rect" | "circle" | "text";
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  /** Shape of the placeholder. Defaults to `"rect"`. */
+  variant?: SkeletonVariant;
+  /** Width for rectangular placeholders. Defaults to `"100%"`. */
+  width?: number | string;
+  /** Height for rectangular placeholders. Defaults to `16`. */
+  height?: number | string;
+  /** Diameter for circular placeholders. Defaults to `40`. */
+  size?: number;
+  /** Number of rows for text placeholders. Defaults to `3`. */
+  lines?: number;
+  /**
+   * Enables the shimmer animation.
+   * Respects `prefers-reduced-motion`. Defaults to `true`.
+   */
+  animated?: boolean;
+}
+
+function toCssSize(value: number | string) {
+  return typeof value === "number" ? `${value}px` : value;
+}
+
+/**
+ * Loading placeholder for content-shaped skeleton screens.
+ *
+ * GNOME HIG recommends `Spinner` or `ProgressBar` for loading states; this is a
+ * pragmatic web-style extension for layouts that benefit from placeholder shape.
+ */
+export function Skeleton({
+  variant = "rect",
+  width = "100%",
+  height = 16,
+  size = 40,
+  lines = 3,
+  animated = true,
+  className,
+  style,
+  ...props
+}: SkeletonProps) {
+  const classes = [
+    styles.skeleton,
+    styles[variant],
+    animated ? styles.animated : null,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  if (variant === "text") {
+    const lineCount = Math.max(1, Math.floor(lines));
+
+    return (
+      <div
+        aria-hidden="true"
+        className={classes}
+        style={style}
+        {...props}
+      >
+        {Array.from({ length: lineCount }, (_, index) => (
+          <div
+            key={index}
+            className={styles.line}
+            style={
+              index === lineCount - 1
+                ? ({ "--skeleton-line-width": "60%" } as CSSProperties)
+                : undefined
+            }
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const shapeStyle: CSSProperties =
+    variant === "circle"
+      ? { width: `${size}px`, height: `${size}px` }
+      : { width: toCssSize(width), height: toCssSize(height) };
+
+  return (
+    <div
+      aria-hidden="true"
+      className={classes}
+      style={{ ...shapeStyle, ...style }}
+      {...props}
+    />
+  );
+}

--- a/packages/react/src/components/Skeleton/index.ts
+++ b/packages/react/src/components/Skeleton/index.ts
@@ -1,0 +1,2 @@
+export { Skeleton } from "./Skeleton";
+export type { SkeletonProps, SkeletonVariant } from "./Skeleton";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,6 +14,9 @@ export type { CardProps, CardPadding } from "./components/Card";
 export { Spinner } from "./components/Spinner";
 export type { SpinnerProps, SpinnerSize } from "./components/Spinner";
 
+export { Skeleton } from "./components/Skeleton";
+export type { SkeletonProps, SkeletonVariant } from "./components/Skeleton";
+
 export { Avatar } from "./components/Avatar";
 export type { AvatarProps, AvatarSize, AvatarColor } from "./components/Avatar";
 


### PR DESCRIPTION
## What

Skeleton:
Add a Skeleton loading placeholder to @gnome-ui/react with rect, circle, and text variants, including shimmer animation support.

## Why

(closes #95)

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
