### PR TITLE
feat(@gnome-ui/layout): add QuickActions component (closes #86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Live examples and documentation: **[Storybook →](https://eljijuna.github.io/gn
 | `StatusIndicator` | Service/connection status dot: `online`, `offline`, `warning`, `error`, `loading` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-statusindicator--docs) |
 | `ErrorState` | Error state with presets: `generic`, `network`, `permission`, `not-found` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-errorstate--docs) |
 | `DashboardGrid` | Responsive CSS Grid container for arranging dashboard widgets; `columns` (1–4 or auto) and per-item `span` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-dashboardgrid--docs) |
+| `QuickActions` | Grid of keyboard-navigable shortcut action buttons for dashboards and control panels | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-quickactions--docs) |
 
 See [ROADMAP.md](ROADMAP.md) for the full list of planned components.
 

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -272,6 +272,60 @@ import { DashboardGrid } from "@gnome-ui/layout";
 </DashboardGrid>
 ```
 
+---
+
+### `QuickActions`
+
+Grid of shortcut action buttons for dashboards, file managers, and control panels.
+Actions are keyboard navigable with arrow keys, and disabled actions are skipped
+and cannot be activated.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `actions` | `QuickAction[]` | — | Shortcut action definitions |
+| `columns` | `number` | `4` | Number of grid columns |
+
+#### `QuickAction`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Stable action id |
+| `label` | `string` | Visible button label |
+| `icon` | `ReactNode` | Icon or visual element. Size and color are controlled by the node you pass in. |
+| `disabled` | `boolean` | Visually disables the action and blocks activation |
+| `onActivate` | `() => void` | Called when the action is clicked or activated from the keyboard |
+
+```tsx
+import { Add, Save, Share } from "@gnome-ui/icons";
+import { Icon } from "@gnome-ui/react";
+import { QuickActions } from "@gnome-ui/layout";
+
+<QuickActions
+  columns={3}
+  actions={[
+    {
+      id: "new-file",
+      label: "New File",
+      icon: <Icon icon={Add} size="lg" />,
+      onActivate: () => {},
+    },
+    {
+      id: "save",
+      label: "Save",
+      icon: <Icon icon={Save} size="lg" />,
+      onActivate: () => {},
+    },
+    {
+      id: "share",
+      label: "Share",
+      icon: <Icon icon={Share} size="lg" />,
+      disabled: true,
+      onActivate: () => {},
+    },
+  ]}
+/>
+```
+
 ## License
 
 [MIT](../../LICENSE)

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -57,6 +57,11 @@
       "import": "./dist/components/PanelCard.js",
       "require": "./dist/components/PanelCard.cjs"
     },
+    "./components/QuickActions": {
+      "types": "./dist/components/QuickActions.d.ts",
+      "import": "./dist/components/QuickActions.js",
+      "require": "./dist/components/QuickActions.cjs"
+    },
     "./components/StatusIndicator": {
       "types": "./dist/components/StatusIndicator.d.ts",
       "import": "./dist/components/StatusIndicator.js",

--- a/packages/layout/src/components/QuickActions/QuickActions.module.css
+++ b/packages/layout/src/components/QuickActions/QuickActions.module.css
@@ -1,0 +1,53 @@
+.root {
+  display: grid;
+  width: 100%;
+  gap: 10px;
+  grid-template-columns: repeat(var(--quick-actions-columns, 4), minmax(0, 1fr));
+}
+
+.action {
+  appearance: none;
+  min-width: 0;
+  min-height: 84px;
+  border: 1px solid var(--gnome-card-shade-color, rgba(0, 0, 0, 0.07));
+  border-radius: 8px;
+  background: var(--gnome-card-bg-color, #ffffff);
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  font: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px 10px;
+  text-align: center;
+  cursor: pointer;
+}
+
+.action:hover:not(:disabled) {
+  background:
+    linear-gradient(var(--gnome-hover-overlay), var(--gnome-hover-overlay)),
+    var(--gnome-card-bg-color, #ffffff);
+}
+
+.action:active:not(:disabled) {
+  background:
+    linear-gradient(var(--gnome-active-overlay), var(--gnome-active-overlay)),
+    var(--gnome-card-bg-color, #ffffff);
+}
+
+.action:focus-visible {
+  outline: var(--gnome-focus-ring-width, 3px) solid var(--gnome-focus-ring-color, #3584e4);
+  outline-offset: var(--gnome-focus-ring-offset, 2px);
+}
+
+.action:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+@media (max-width: 520px) {
+  .root {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/packages/layout/src/components/QuickActions/QuickActions.stories.tsx
+++ b/packages/layout/src/components/QuickActions/QuickActions.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Icon } from "@gnome-ui/react";
+import {
+  Add,
+  Copy,
+  Delete,
+  DocumentOpen,
+  Edit,
+  Printer,
+  Save,
+  Share,
+} from "@gnome-ui/icons";
+import { QuickActions } from "./QuickActions";
+
+const meta: Meta<typeof QuickActions> = {
+  title: "Layout/QuickActions",
+  component: QuickActions,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+Grid of shortcut action buttons for dashboards, file managers, and control panels.
+
+\`\`\`tsx
+import { QuickActions } from "@gnome-ui/layout";
+
+<QuickActions
+  actions={[
+    { id: "new-file", label: "New File", icon: <AddIcon />, onActivate: createFile },
+    { id: "share", label: "Share", icon: <ShareIcon />, onActivate: share },
+  ]}
+/>
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof QuickActions>;
+
+const actions = [
+  { id: "new-file", label: "New File", icon: <Icon icon={Add} size="lg" />, onActivate: () => {} },
+  { id: "open", label: "Open", icon: <Icon icon={DocumentOpen} size="lg" />, onActivate: () => {} },
+  { id: "save", label: "Save", icon: <Icon icon={Save} size="lg" />, onActivate: () => {} },
+  { id: "share", label: "Share", icon: <Icon icon={Share} size="lg" />, onActivate: () => {} },
+  { id: "duplicate", label: "Duplicate", icon: <Icon icon={Copy} size="lg" />, onActivate: () => {} },
+  { id: "rename", label: "Rename", icon: <Icon icon={Edit} size="lg" />, onActivate: () => {} },
+  { id: "print", label: "Print", icon: <Icon icon={Printer} size="lg" />, onActivate: () => {} },
+  { id: "delete", label: "Delete", icon: <Icon icon={Delete} size="lg" />, disabled: true, onActivate: () => {} },
+];
+
+export const DashboardShortcuts: Story = {
+  args: {
+    actions,
+    columns: 4,
+  },
+  render: (args) => (
+    <div style={{ width: 520 }}>
+      <QuickActions {...args} />
+    </div>
+  ),
+};
+
+export const ThreeColumns: Story = {
+  args: {
+    actions: actions.slice(0, 6),
+    columns: 3,
+  },
+  render: (args) => (
+    <div style={{ width: 420 }}>
+      <QuickActions {...args} />
+    </div>
+  ),
+};

--- a/packages/layout/src/components/QuickActions/QuickActions.test.tsx
+++ b/packages/layout/src/components/QuickActions/QuickActions.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QuickActions, type QuickAction } from "./QuickActions";
+
+const makeActions = (
+  overrides: Partial<QuickAction>[] = [],
+): QuickAction[] => [
+  {
+    id: "new-file",
+    label: "New File",
+    icon: <span>+</span>,
+    onActivate: vi.fn(),
+    ...overrides[0],
+  },
+  {
+    id: "share",
+    label: "Share",
+    icon: <span>S</span>,
+    onActivate: vi.fn(),
+    ...overrides[1],
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    icon: <span>*</span>,
+    onActivate: vi.fn(),
+    ...overrides[2],
+  },
+];
+
+describe("QuickActions", () => {
+  it("renders action labels", () => {
+    render(<QuickActions actions={makeActions()} />);
+
+    expect(screen.getByRole("button", { name: "New File" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
+  });
+
+  it("activates an enabled action on click", () => {
+    const onActivate = vi.fn();
+    render(<QuickActions actions={makeActions([{ onActivate }])} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "New File" }));
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks disabled actions and blocks interaction", () => {
+    const onActivate = vi.fn();
+    render(<QuickActions actions={makeActions([{}, { disabled: true, onActivate }])} />);
+
+    const disabledAction = screen.getByRole("button", { name: "Share" });
+    fireEvent.click(disabledAction);
+
+    expect(disabledAction).toBeDisabled();
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it("moves focus with arrow keys between enabled actions", () => {
+    render(<QuickActions actions={makeActions()} />);
+
+    const first = screen.getByRole("button", { name: "New File" });
+    const second = screen.getByRole("button", { name: "Share" });
+    const third = screen.getByRole("button", { name: "Settings" });
+
+    first.focus();
+    fireEvent.keyDown(first, { key: "ArrowRight" });
+    expect(second).toHaveFocus();
+
+    fireEvent.keyDown(second, { key: "ArrowDown" });
+    expect(third).toHaveFocus();
+
+    fireEvent.keyDown(third, { key: "ArrowLeft" });
+    expect(second).toHaveFocus();
+  });
+
+  it("skips disabled actions during keyboard navigation", () => {
+    render(<QuickActions actions={makeActions([{}, { disabled: true }, {}])} />);
+
+    const first = screen.getByRole("button", { name: "New File" });
+    const third = screen.getByRole("button", { name: "Settings" });
+
+    first.focus();
+    fireEvent.keyDown(first, { key: "ArrowRight" });
+
+    expect(third).toHaveFocus();
+  });
+
+  it("forwards className and data attributes to the root", () => {
+    render(
+      <QuickActions
+        actions={makeActions()}
+        className="custom-actions"
+        data-testid="quick-actions"
+      />,
+    );
+
+    expect(screen.getByTestId("quick-actions")).toHaveClass("custom-actions");
+  });
+
+  it("sets the requested column count as a CSS variable", () => {
+    render(
+      <QuickActions
+        actions={makeActions()}
+        columns={5}
+        data-testid="quick-actions"
+      />,
+    );
+
+    expect(screen.getByTestId("quick-actions")).toHaveStyle({
+      "--quick-actions-columns": "5",
+    });
+  });
+
+  it("preserves user inline styles", () => {
+    render(
+      <QuickActions
+        actions={makeActions()}
+        style={{ maxWidth: 320 }}
+        data-testid="quick-actions"
+      />,
+    );
+
+    expect(screen.getByTestId("quick-actions")).toHaveStyle({
+      maxWidth: "320px",
+    });
+  });
+});

--- a/packages/layout/src/components/QuickActions/QuickActions.tsx
+++ b/packages/layout/src/components/QuickActions/QuickActions.tsx
@@ -1,0 +1,135 @@
+import {
+  useMemo,
+  useRef,
+  type ButtonHTMLAttributes,
+  type CSSProperties,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import { Text } from "@gnome-ui/react";
+import styles from "./QuickActions.module.css";
+
+export interface QuickAction {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  disabled?: boolean;
+  onActivate: () => void;
+}
+
+export interface QuickActionsProps extends HTMLAttributes<HTMLDivElement> {
+  /** Action definitions rendered as shortcut buttons. */
+  actions: QuickAction[];
+  /** Number of grid columns. Defaults to `4`. */
+  columns?: number;
+}
+
+function findNextEnabledIndex(
+  actions: QuickAction[],
+  currentIndex: number,
+  direction: 1 | -1,
+) {
+  if (actions.every((action) => action.disabled)) return currentIndex;
+
+  let nextIndex = currentIndex;
+  do {
+    nextIndex = (nextIndex + direction + actions.length) % actions.length;
+  } while (actions[nextIndex]?.disabled);
+
+  return nextIndex;
+}
+
+function findLastEnabledIndex(actions: QuickAction[]) {
+  for (let index = actions.length - 1; index >= 0; index -= 1) {
+    if (!actions[index]?.disabled) return index;
+  }
+
+  return -1;
+}
+
+export function QuickActions({
+  actions,
+  columns = 4,
+  className,
+  style,
+  ...props
+}: QuickActionsProps) {
+  const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const firstEnabledIndex = useMemo(
+    () => actions.findIndex((action) => !action.disabled),
+    [actions],
+  );
+
+  const focusAction = (index: number) => {
+    buttonRefs.current[index]?.focus();
+  };
+
+  const handleKeyDown =
+    (index: number): ButtonHTMLAttributes<HTMLButtonElement>["onKeyDown"] =>
+      (event: KeyboardEvent<HTMLButtonElement>) => {
+        if (actions[index]?.disabled) return;
+
+        let nextIndex: number | null = null;
+
+        switch (event.key) {
+          case "ArrowRight":
+          case "ArrowDown":
+            nextIndex = findNextEnabledIndex(actions, index, 1);
+            break;
+          case "ArrowLeft":
+          case "ArrowUp":
+            nextIndex = findNextEnabledIndex(actions, index, -1);
+            break;
+          case "Home":
+            nextIndex = firstEnabledIndex;
+            break;
+          case "End":
+            nextIndex = findLastEnabledIndex(actions);
+            break;
+          default:
+            return;
+        }
+
+        if (nextIndex !== null && nextIndex >= 0) {
+          event.preventDefault();
+          focusAction(nextIndex);
+        }
+      };
+
+  const rootStyle = {
+    "--quick-actions-columns": columns,
+    ...style,
+  } as CSSProperties;
+
+  return (
+    <div
+      className={[styles.root, className]
+        .filter(Boolean)
+        .join(" ")}
+      style={rootStyle}
+      role="group"
+      {...props}
+    >
+      {actions.map((action, index) => (
+        <button
+          key={action.id}
+          ref={(node) => {
+            buttonRefs.current[index] = node;
+          }}
+          type="button"
+          className={styles.action}
+          disabled={action.disabled}
+          tabIndex={index === firstEnabledIndex ? 0 : -1}
+          onClick={action.onActivate}
+          onKeyDown={handleKeyDown(index)}
+        >
+          <span aria-hidden="true">{action.icon}</span>
+          <Text variant="body">
+            {action.label}
+          </Text>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/layout/src/components/QuickActions/index.ts
+++ b/packages/layout/src/components/QuickActions/index.ts
@@ -1,0 +1,2 @@
+export { QuickActions } from "./QuickActions";
+export type { QuickAction, QuickActionsProps } from "./QuickActions";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -42,3 +42,6 @@ export type {
   DashboardGridColumns,
   DashboardGridGap,
 } from "./components/DashboardGrid";
+
+export { QuickActions } from "./components/QuickActions";
+export type { QuickAction, QuickActionsProps } from "./components/QuickActions";


### PR DESCRIPTION
## What

QuickActions component

## Why

closes #86

## Changes

- [x] New component
- [ ] Bug fix
- [ ] Enhancement
- [ ] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [x] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
