### PR TITLE
feat(@gnome-ui/layout): add StatCard component (closes #83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Live examples and documentation: **[Storybook →](https://eljijuna.github.io/gn
 | `Layout` | Full-page shell with four named zones: `topBar`, `sidebar`, `children`, `bottomBar` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-layout--docs) |
 | `AdaptiveLayout` | Responsive layout that adapts column structure to the available width | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-adaptivelayout--docs) |
 | `CounterCard` | Card displaying a labelled numeric count | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-countercard--docs) |
+| `StatCard` | Key metric card with unit, trend indicator, icon, and skeleton loading state | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-statcard--docs) |
 | `UserCard` | Card displaying user identity (avatar, name, role) | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-usercard--docs) |
 | `PanelCard` | Collapsible card panel with header and body | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-panelcard--docs) |
 | `EntityCard` | Card for displaying a generic named entity with metadata | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-entitycard--docs) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -404,7 +404,7 @@ React hooks that surface every `@gnome-ui/platform` module as idiomatic React st
 | Status | Component | Description |
 |--------|-----------|-------------|
 | ✅ | **`DashboardGrid`** | Responsive CSS Grid container for arranging dashboard widgets; supports column count and per-item span — issue [#82](https://github.com/ElJijuna/gnome-ui/issues/82) |
-| ⬜ | **`StatCard`** | Key metric display with optional trend indicator (direction, percentage, period) and loading skeleton — issue [#83](https://github.com/ElJijuna/gnome-ui/issues/83) |
+| ✅ | **`StatCard`** | Key metric display with optional trend indicator (direction, percentage, period) and loading skeleton — issue [#83](https://github.com/ElJijuna/gnome-ui/issues/83) |
 | ⬜ | **`ProgressCard`** | Resource usage card with labelled progress bar; color thresholds at 75 % (warning) and 90 % (critical) — issue [#84](https://github.com/ElJijuna/gnome-ui/issues/84) |
 | ⬜ | **`ActivityFeed`** | Chronological event list with relative timestamps, icons, and truncation — issue [#85](https://github.com/ElJijuna/gnome-ui/issues/85) |
 | ⬜ | **`QuickActions`** | Grid of shortcut action buttons with keyboard navigation — issue [#86](https://github.com/ElJijuna/gnome-ui/issues/86) |

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -141,6 +141,42 @@ import { CounterCard } from "@gnome-ui/layout";
 
 ---
 
+### `StatCard`
+
+Key metric card with optional unit, trend indicator, icon, and skeleton loading
+state. Use it for dashboard metrics that need context beyond a raw count.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | — | Metric label |
+| `value` | `number \| string` | — | Primary value |
+| `unit` | `string` | — | Optional unit suffix |
+| `trend` | `{ direction: "up" \| "down" \| "neutral"; value: number; period?: string }` | — | Optional trend indicator |
+| `icon` | `ReactNode` | — | Optional visual element. Size and color are controlled by the node you pass in. |
+| `loading` | `boolean` | `false` | Render a skeleton placeholder state |
+
+```tsx
+import { Person } from "@gnome-ui/icons";
+import { Icon } from "@gnome-ui/react";
+import { StatCard } from "@gnome-ui/layout";
+
+<StatCard
+  label="Active Users"
+  value={1284}
+  unit="users"
+  icon={<Icon icon={Person} size="lg" />}
+  trend={{ direction: "up", value: 12, period: "vs last week" }}
+/>
+```
+
+Per-component path:
+
+```tsx
+import { StatCard } from "@gnome-ui/layout/components/StatCard";
+```
+
+---
+
 ### `UserCard`
 
 User identity panel for popovers, sidebar footers, and profile pages. Renders an `Avatar`, a display name, an optional sub-line, and a list of action buttons. A separator is automatically inserted before the first `"destructive"` action when non-destructive actions precede it.

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/components/DashboardGrid.js",
       "require": "./dist/components/DashboardGrid.cjs"
     },
+    "./components/StatCard": {
+      "types": "./dist/components/StatCard.d.ts",
+      "import": "./dist/components/StatCard.js",
+      "require": "./dist/components/StatCard.cjs"
+    },
     "./components/EmptyState": {
       "types": "./dist/components/EmptyState.d.ts",
       "import": "./dist/components/EmptyState.js",

--- a/packages/layout/src/components/StatCard/StatCard.module.css
+++ b/packages/layout/src/components/StatCard/StatCard.module.css
@@ -1,0 +1,85 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  padding: 20px !important;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 30px;
+}
+
+.label {
+  display: block;
+  min-width: 0;
+}
+
+.icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.valueRow {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  line-height: 1;
+}
+
+.value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+  line-height: 1 !important;
+}
+
+.unit {
+  flex-shrink: 0;
+  line-height: 1 !important;
+}
+
+.trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  margin-top: 2px;
+}
+
+.trendValue {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+  font-weight: var(--gnome-font-weight-semibold, 600);
+}
+
+.period {
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+  opacity: var(--gnome-opacity-dim, 0.55);
+  overflow-wrap: anywhere;
+}
+
+.up {
+  color: var(--gnome-success-color, #26a269) !important;
+}
+
+.down {
+  color: var(--gnome-error-color, #e01b24) !important;
+}
+
+.neutral {
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8)) !important;
+  opacity: var(--gnome-opacity-dim, 0.55);
+}
+
+.loading {
+  pointer-events: none;
+}

--- a/packages/layout/src/components/StatCard/StatCard.stories.tsx
+++ b/packages/layout/src/components/StatCard/StatCard.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Icon } from "@gnome-ui/react";
+import { Applications, Error, Person, Refresh } from "@gnome-ui/icons";
+import { StatCard } from "./StatCard";
+
+const meta: Meta<typeof StatCard> = {
+  title: "Layout/StatCard",
+  component: StatCard,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+Metric card for dashboards with optional unit, trend indicator, icon, and loading state.
+
+\`\`\`tsx
+import { StatCard } from "@gnome-ui/layout";
+
+<StatCard
+  label="Active Users"
+  value={1284}
+  unit="users"
+  trend={{ direction: "up", value: 12, period: "vs last week" }}
+/>
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StatCard>;
+
+export const UpTrend: Story = {
+  args: {
+    label: "Active Users",
+    value: 1284,
+    unit: "users",
+    icon: <Icon icon={Person} size="lg" />,
+    trend: { direction: "up", value: 12, period: "vs last week" },
+  },
+};
+
+export const DownTrend: Story = {
+  args: {
+    label: "Error Rate",
+    value: 2.4,
+    unit: "%",
+    icon: <Icon icon={Error} size="lg" />,
+    trend: { direction: "down", value: -8, period: "vs yesterday" },
+  },
+};
+
+export const NeutralTrend: Story = {
+  args: {
+    label: "Latency",
+    value: 42,
+    unit: "ms",
+    icon: <Icon icon={Refresh} size="lg" />,
+    trend: { direction: "neutral", value: 0, period: "stable" },
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    label: "Requests",
+    value: 0,
+    loading: true,
+    icon: <Icon icon={Applications} size="lg" />,
+  },
+};
+
+export const Dashboard: Story = {
+  render: () => (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: 16, width: 880 }}>
+      <StatCard
+        label="Active Users"
+        value={1284}
+        unit="users"
+        icon={<Icon icon={Person} size="lg" />}
+        trend={{ direction: "up", value: 12, period: "vs last week" }}
+      />
+      <StatCard
+        label="Requests"
+        value="24.8k"
+        icon={<Icon icon={Applications} size="lg" />}
+        trend={{ direction: "up", value: 6, period: "today" }}
+      />
+      <StatCard
+        label="Error Rate"
+        value={2.4}
+        unit="%"
+        icon={<Icon icon={Error} size="lg" />}
+        trend={{ direction: "down", value: -8, period: "vs yesterday" }}
+      />
+      <StatCard
+        label="Latency"
+        value={42}
+        unit="ms"
+        icon={<Icon icon={Refresh} size="lg" />}
+        trend={{ direction: "neutral", value: 0, period: "stable" }}
+      />
+    </div>
+  ),
+};

--- a/packages/layout/src/components/StatCard/StatCard.test.tsx
+++ b/packages/layout/src/components/StatCard/StatCard.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatCard } from "./StatCard";
+
+describe("StatCard", () => {
+  it("renders the label and formatted numeric value", () => {
+    render(<StatCard label="Active Users" value={1284} />);
+
+    expect(screen.getByText("Active Users")).toBeInTheDocument();
+    expect(screen.getByText("1,284")).toBeInTheDocument();
+    expect(screen.getByLabelText("Active Users: 1,284")).toBeInTheDocument();
+  });
+
+  it("renders string values and unit suffixes", () => {
+    render(<StatCard label="Uptime" value="99.9" unit="%" />);
+
+    expect(screen.getByText("99.9")).toBeInTheDocument();
+    expect(screen.getByText("%")).toBeInTheDocument();
+    expect(screen.getByLabelText("Uptime: 99.9 %")).toBeInTheDocument();
+  });
+
+  it("renders the optional icon without exposing it as the button label", () => {
+    render(
+      <StatCard
+        label="Projects"
+        value={24}
+        icon={<span data-testid="icon">P</span>}
+      />,
+    );
+
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("renders an upward trend", () => {
+    render(
+      <StatCard
+        label="Active Users"
+        value={1284}
+        trend={{ direction: "up", value: 12, period: "vs last week" }}
+      />,
+    );
+
+    expect(screen.getByText("+12%")).toBeInTheDocument();
+    expect(screen.getByText("vs last week")).toBeInTheDocument();
+  });
+
+  it("renders a downward trend", () => {
+    render(
+      <StatCard
+        label="Errors"
+        value={8}
+        trend={{ direction: "down", value: -4, period: "vs yesterday" }}
+      />,
+    );
+
+    expect(screen.getByText("-4%")).toBeInTheDocument();
+    expect(screen.getByText("vs yesterday")).toBeInTheDocument();
+  });
+
+  it("renders a neutral trend", () => {
+    render(
+      <StatCard
+        label="Latency"
+        value={42}
+        unit="ms"
+        trend={{ direction: "neutral", value: 0 }}
+      />,
+    );
+
+    expect(screen.getByText("0%")).toBeInTheDocument();
+  });
+
+  it("renders a skeleton loading state", () => {
+    const { container } = render(
+      <StatCard label="Active Users" value={1284} loading data-testid="stat" />,
+    );
+
+    expect(screen.getByTestId("stat")).toHaveAttribute("aria-busy", "true");
+    expect(screen.queryByText("Active Users")).toBeNull();
+    expect(container.querySelectorAll("[aria-hidden='true']").length).toBeGreaterThan(0);
+  });
+
+  it("forwards className, style, and data attributes to the root", () => {
+    render(
+      <StatCard
+        label="Revenue"
+        value={9420}
+        className="custom-stat"
+        style={{ width: 240 }}
+        data-testid="stat"
+      />,
+    );
+
+    const root = screen.getByTestId("stat");
+    expect(root).toHaveClass("custom-stat");
+    expect(root).toHaveStyle({ width: "240px" });
+  });
+});

--- a/packages/layout/src/components/StatCard/StatCard.tsx
+++ b/packages/layout/src/components/StatCard/StatCard.tsx
@@ -1,0 +1,121 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { Card, Skeleton, Text } from "@gnome-ui/react";
+import styles from "./StatCard.module.css";
+
+export type StatCardTrendDirection = "up" | "down" | "neutral";
+
+export interface StatCardTrend {
+  direction: StatCardTrendDirection;
+  value: number;
+  period?: string;
+}
+
+export interface StatCardProps extends HTMLAttributes<HTMLDivElement> {
+  /** Metric label. */
+  label: string;
+  /** Primary value. */
+  value: number | string;
+  /** Optional unit suffix shown next to the value. */
+  unit?: string;
+  /** Optional trend indicator. */
+  trend?: StatCardTrend;
+  /** Optional visual element rendered in the top-right corner. */
+  icon?: ReactNode;
+  /** Render a skeleton loading state. */
+  loading?: boolean;
+}
+
+const TREND_SYMBOL: Record<StatCardTrendDirection, string> = {
+  up: "up",
+  down: "down",
+  neutral: "steady",
+};
+
+function formatValue(value: number | string) {
+  return typeof value === "number" ? value.toLocaleString() : value;
+}
+
+function formatTrendValue(value: number) {
+  return `${value > 0 ? "+" : ""}${value.toLocaleString()}%`;
+}
+
+export function StatCard({
+  label,
+  value,
+  unit,
+  trend,
+  icon,
+  loading = false,
+  className,
+  ...props
+}: StatCardProps) {
+  if (loading) {
+    return (
+      <Card
+        className={[styles.card, styles.loading, className]
+          .filter(Boolean)
+          .join(" ")}
+        aria-busy="true"
+        {...props}
+      >
+        <div className={styles.header}>
+          <Skeleton variant="rect" width={110} height={14} />
+          {icon && <Skeleton variant="circle" size={30} />}
+        </div>
+        <Skeleton variant="rect" width={150} height={34} />
+        <Skeleton variant="rect" width={120} height={14} />
+      </Card>
+    );
+  }
+
+  const displayValue = formatValue(value);
+  const accessibleValue = unit ? `${displayValue} ${unit}` : displayValue;
+
+  return (
+    <Card
+      className={[styles.card, className].filter(Boolean).join(" ")}
+      {...props}
+    >
+      <div className={styles.header}>
+        <Text variant="caption" color="dim" className={styles.label}>
+          {label}
+        </Text>
+        {icon && (
+          <span className={styles.icon} aria-hidden="true">
+            {icon}
+          </span>
+        )}
+      </div>
+
+      <div
+        className={styles.valueRow}
+        aria-label={`${label}: ${accessibleValue}`}
+      >
+        <Text variant="title-2" as="span" className={styles.value}>
+          {displayValue}
+        </Text>
+        {unit && (
+          <Text variant="caption" as="span" color="dim" className={styles.unit}>
+            {unit}
+          </Text>
+        )}
+      </div>
+
+      {trend && (
+        <Text
+          variant="caption"
+          as="span"
+          className={[styles.trend, styles[trend.direction]]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          <span aria-hidden="true">{TREND_SYMBOL[trend.direction]}</span>
+          <span className={styles.trendValue}>{formatTrendValue(trend.value)}</span>
+          {trend.period && (
+            <span className={styles.period}>{trend.period}</span>
+          )}
+        </Text>
+      )}
+    </Card>
+  );
+}

--- a/packages/layout/src/components/StatCard/index.ts
+++ b/packages/layout/src/components/StatCard/index.ts
@@ -1,0 +1,6 @@
+export { StatCard } from "./StatCard";
+export type {
+  StatCardProps,
+  StatCardTrend,
+  StatCardTrendDirection,
+} from "./StatCard";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -4,6 +4,13 @@ export type { LayoutProps } from "./components/Layout";
 export { CounterCard } from "./components/CounterCard";
 export type { CounterCardProps } from "./components/CounterCard";
 
+export { StatCard } from "./components/StatCard";
+export type {
+  StatCardProps,
+  StatCardTrend,
+  StatCardTrendDirection,
+} from "./components/StatCard";
+
 export { UserCard } from "./components/UserCard";
 export type { UserCardProps, UserCardAction } from "./components/UserCard";
 


### PR DESCRIPTION
## What

StatCard component

## Why

closes #83

## Changes

- [x] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
