### PR TITLE
feat(@gnome-ui/layout): add responsive DashboardGrid layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Live examples and documentation: **[Storybook →](https://eljijuna.github.io/gn
 | `EmptyState` | Centered empty-state with icon, title, description, and optional CTA | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-emptystate--docs) |
 | `StatusIndicator` | Service/connection status dot: `online`, `offline`, `warning`, `error`, `loading` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-statusindicator--docs) |
 | `ErrorState` | Error state with presets: `generic`, `network`, `permission`, `not-found` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-errorstate--docs) |
-| `DashboardGrid` | Responsive CSS Grid container for arranging dashboard widgets; `columns` (1–4 or auto) and per-item `span` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-dashboardgrid--docs) |
+| `DashboardGrid` | Responsive dashboard container with fixed, auto, breakpoint-mapped columns, column layout, and per-item `span` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-dashboardgrid--docs) |
 | `QuickActions` | Grid of keyboard-navigable shortcut action buttons for dashboards and control panels | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-quickactions--docs) |
 
 See [ROADMAP.md](ROADMAP.md) for the full list of planned components.

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -281,15 +281,25 @@ Responsive CSS Grid container for arranging dashboard widgets and panels.
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `columns` | `1 \| 2 \| 3 \| 4 \| "auto"` | `"auto"` | Column count. `"auto"` fills columns with `minmax(280px, 1fr)`. |
-| `gap` | `"sm" \| "md" \| "lg"` | `"md"` | Gap between items (8 / 16 / 24 px). |
+| `columns` | `1 \| 2 \| 3 \| 4 \| "auto" \| ResponsiveColumns` | `"auto"` | Column count. `"auto"` fills columns with `minmax(280px, 1fr)`. Objects map breakpoints to explicit counts. |
+| `gap` | `"sm" \| "md" \| "lg"` | `"md"` | Gap between items using core spacing tokens (`--gnome-space-2/3/4`). |
+| `layout` | `"grid" \| "column"` | `"grid"` | Render as a grid or as a vertical stack. |
 | `children` | `ReactNode` | — | `DashboardGrid.Item` elements. |
+
+#### Responsive columns
+
+| Key | Width |
+|-----|-------|
+| `sm` | Base / small screens |
+| `md` | `≥ 550px` |
+| `lg` | `≥ 860px` |
+| `xl` | `≥ 1200px` |
 
 #### `DashboardGrid.Item` props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `span` | `1 \| 2 \| 3 \| 4` | `1` | Number of columns the item spans. |
+| `span` | `1 \| 2 \| 3 \| 4` | `1` | Number of columns the item spans in grid mode. Harmless in column mode. |
 | `children` | `ReactNode` | — | Widget content. |
 
 Both `DashboardGrid` and `DashboardGrid.Item` forward all `<div>` props
@@ -298,12 +308,23 @@ to their root element.
 ```tsx
 import { DashboardGrid } from "@gnome-ui/layout";
 
-<DashboardGrid columns={3} gap="md">
+<DashboardGrid columns={{ sm: 1, md: 2, lg: 3, xl: 4 }} gap="md">
   <DashboardGrid.Item span={2}>
     <StatCard />
   </DashboardGrid.Item>
   <DashboardGrid.Item>
     <ProgressCard />
+  </DashboardGrid.Item>
+</DashboardGrid>
+```
+
+```tsx
+<DashboardGrid layout="column" gap="md">
+  <DashboardGrid.Item>
+    <StatCard />
+  </DashboardGrid.Item>
+  <DashboardGrid.Item>
+    <ActivityFeed />
   </DashboardGrid.Item>
 </DashboardGrid>
 ```

--- a/packages/layout/src/components/DashboardGrid/DashboardGrid.module.css
+++ b/packages/layout/src/components/DashboardGrid/DashboardGrid.module.css
@@ -3,16 +3,54 @@
   width: 100%;
 }
 
+.column {
+  display: flex;
+  flex-direction: column;
+}
+
 /* ─── Gap variants ────────────────────────────────────────────────────────── */
 
-.gapSm { gap: 8px; }
-.gapMd { gap: 16px; }
-.gapLg { gap: 24px; }
+.gapSm { gap: var(--gnome-space-2, 12px); }
+.gapMd { gap: var(--gnome-space-3, 18px); }
+.gapLg { gap: var(--gnome-space-4, 24px); }
 
 /* ─── Auto responsive columns ─────────────────────────────────────────────── */
 
 .auto {
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+/* ─── Explicit responsive columns ─────────────────────────────────────────── */
+
+.responsive {
+  grid-template-columns: repeat(var(--dashboard-grid-columns-sm, 1), minmax(0, 1fr));
+}
+
+@media (min-width: 550px) {
+  .responsive {
+    grid-template-columns: repeat(
+      var(--dashboard-grid-columns-md, var(--dashboard-grid-columns-sm, 1)),
+      minmax(0, 1fr)
+    );
+  }
+}
+
+@media (min-width: 860px) {
+  .responsive {
+    grid-template-columns: repeat(
+      var(--dashboard-grid-columns-lg, var(--dashboard-grid-columns-md, var(--dashboard-grid-columns-sm, 1))),
+      minmax(0, 1fr)
+    );
+  }
+}
+
+@media (min-width: 1200px) {
+  .responsive {
+    grid-template-columns: repeat(
+      var(--dashboard-grid-columns-xl, var(--dashboard-grid-columns-lg, var(--dashboard-grid-columns-md, var(--dashboard-grid-columns-sm, 1)))),
+      minmax(0, 1fr)
+    );
+  }
 }
 
 /* ─── Item ────────────────────────────────────────────────────────────────── */

--- a/packages/layout/src/components/DashboardGrid/DashboardGrid.stories.tsx
+++ b/packages/layout/src/components/DashboardGrid/DashboardGrid.stories.tsx
@@ -37,13 +37,15 @@ const meta: Meta<typeof DashboardGrid> = {
         component: `
 Responsive grid container for arranging dashboard widgets and panels.
 
-Use \`columns\` to fix the column count or let it adapt automatically with \`"auto"\`.
+Use \`columns\` to fix the column count, let it adapt automatically with \`"auto"\`,
+or map explicit column counts to responsive breakpoints.
 Wrap each widget in \`DashboardGrid.Item\` and set \`span\` to make it span multiple columns.
+Set \`layout="column"\` when the same children should stack vertically.
 
 \`\`\`tsx
 import { DashboardGrid } from "@gnome-ui/layout";
 
-<DashboardGrid columns={3} gap="md">
+<DashboardGrid columns={{ sm: 1, md: 2, lg: 3, xl: 4 }} gap="md">
   <DashboardGrid.Item span={2}>
     <StatCard ... />
   </DashboardGrid.Item>
@@ -58,12 +60,15 @@ import { DashboardGrid } from "@gnome-ui/layout";
   },
   argTypes: {
     columns: {
-      control: { type: "select" },
-      options: [1, 2, 3, 4, "auto"],
+      control: false,
     },
     gap: {
       control: { type: "radio" },
       options: ["sm", "md", "lg"],
+    },
+    layout: {
+      control: { type: "radio" },
+      options: ["grid", "column"],
     },
   },
 };
@@ -105,6 +110,56 @@ export const FixedColumns: Story = {
   ),
   parameters: {
     docs: { description: { story: "Fixed 3-column layout." } },
+  },
+};
+
+export const ResponsiveColumns: Story = {
+  args: {
+    columns: { sm: 1, md: 2, lg: 3, xl: 4 },
+    gap: "md",
+  },
+  render: (args) => (
+    <DashboardGrid {...args}>
+      {["Users", "Revenue", "Sessions", "Errors", "Latency", "Uptime", "Jobs", "Storage"].map(
+        (label) => (
+          <DashboardGrid.Item key={label}>
+            <Placeholder label={label} />
+          </DashboardGrid.Item>
+        ),
+      )}
+    </DashboardGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Explicit responsive columns: 1 on small screens, 2 at medium, 3 at large, and 4 at extra-large widths.",
+      },
+    },
+  },
+};
+
+export const ColumnLayout: Story = {
+  args: {
+    layout: "column",
+    gap: "md",
+  },
+  render: (args) => (
+    <DashboardGrid {...args}>
+      {["Queue", "Workers", "Deployments"].map((label) => (
+        <DashboardGrid.Item key={label} span={3}>
+          <Placeholder label={label} height={88} />
+        </DashboardGrid.Item>
+      ))}
+    </DashboardGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`layout=\"column\"` stacks children vertically and keeps using the same gap scale. Item `span` is harmless in this mode.",
+      },
+    },
   },
 };
 

--- a/packages/layout/src/components/DashboardGrid/DashboardGrid.test.tsx
+++ b/packages/layout/src/components/DashboardGrid/DashboardGrid.test.tsx
@@ -47,6 +47,51 @@ describe("DashboardGrid", () => {
       const grid = container.firstChild as HTMLElement;
       expect(grid.style.gridTemplateColumns).toBe("");
     });
+
+    it("sets responsive column CSS variables for object columns", () => {
+      const { container } = render(
+        <DashboardGrid columns={{ sm: 1, md: 2, lg: 3, xl: 4 }} />,
+      );
+      const grid = container.firstChild as HTMLElement;
+
+      expect(grid.style.getPropertyValue("--dashboard-grid-columns-sm")).toBe("1");
+      expect(grid.style.getPropertyValue("--dashboard-grid-columns-md")).toBe("2");
+      expect(grid.style.getPropertyValue("--dashboard-grid-columns-lg")).toBe("3");
+      expect(grid.style.getPropertyValue("--dashboard-grid-columns-xl")).toBe("4");
+      expect(grid.style.gridTemplateColumns).toBe("");
+      expect(grid.className).toMatch(/responsive/);
+    });
+
+    it("preserves user inline styles with responsive columns", () => {
+      const { container } = render(
+        <DashboardGrid columns={{ sm: 1, md: 2 }} style={{ maxWidth: 640 }} />,
+      );
+      const grid = container.firstChild as HTMLElement;
+
+      expect(grid.style.maxWidth).toBe("640px");
+      expect(grid.style.getPropertyValue("--dashboard-grid-columns-md")).toBe("2");
+    });
+  });
+
+  describe("layout prop", () => {
+    it("defaults to grid layout", () => {
+      const { container } = render(<DashboardGrid />);
+      const grid = container.firstChild as HTMLElement;
+      expect(grid.className).not.toMatch(/column/);
+    });
+
+    it("applies column layout class", () => {
+      const { container } = render(<DashboardGrid layout="column" />);
+      const grid = container.firstChild as HTMLElement;
+      expect(grid.className).toMatch(/column/);
+    });
+
+    it("does not apply grid column styles in column layout", () => {
+      const { container } = render(<DashboardGrid layout="column" columns={3} />);
+      const grid = container.firstChild as HTMLElement;
+      expect(grid.style.gridTemplateColumns).toBe("");
+      expect(grid.className).not.toMatch(/auto|responsive/);
+    });
   });
 
   describe("gap prop", () => {

--- a/packages/layout/src/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/layout/src/components/DashboardGrid/DashboardGrid.tsx
@@ -1,14 +1,27 @@
 import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
 import styles from "./DashboardGrid.module.css";
 
-export type DashboardGridColumns = 1 | 2 | 3 | 4 | "auto";
+export type DashboardGridColumnCount = 1 | 2 | 3 | 4;
+export interface DashboardGridResponsiveColumns {
+  sm?: DashboardGridColumnCount;
+  md?: DashboardGridColumnCount;
+  lg?: DashboardGridColumnCount;
+  xl?: DashboardGridColumnCount;
+}
+export type DashboardGridColumns =
+  | DashboardGridColumnCount
+  | "auto"
+  | DashboardGridResponsiveColumns;
 export type DashboardGridGap = "sm" | "md" | "lg";
+export type DashboardGridLayout = "grid" | "column";
 
 export interface DashboardGridProps extends HTMLAttributes<HTMLDivElement> {
-  /** Number of columns. `"auto"` uses responsive breakpoints. Defaults to `"auto"`. */
+  /** Number of columns. `"auto"` uses fluid auto-fill; an object maps breakpoints. Defaults to `"auto"`. */
   columns?: DashboardGridColumns;
   /** Gap between items. Defaults to `"md"`. */
   gap?: DashboardGridGap;
+  /** Layout mode. `"column"` stacks children vertically. Defaults to `"grid"`. */
+  layout?: DashboardGridLayout;
   children?: ReactNode;
 }
 
@@ -23,6 +36,23 @@ const GAP_CLASS: Record<DashboardGridGap, string> = {
   md: styles.gapMd,
   lg: styles.gapLg,
 };
+
+function isResponsiveColumns(
+  columns: DashboardGridColumns,
+): columns is DashboardGridResponsiveColumns {
+  return typeof columns === "object";
+}
+
+function getResponsiveColumnStyle(
+  columns: DashboardGridResponsiveColumns,
+): CSSProperties {
+  return {
+    "--dashboard-grid-columns-sm": columns.sm,
+    "--dashboard-grid-columns-md": columns.md,
+    "--dashboard-grid-columns-lg": columns.lg,
+    "--dashboard-grid-columns-xl": columns.xl,
+  } as CSSProperties;
+}
 
 function DashboardGridItem({
   span = 1,
@@ -50,14 +80,20 @@ function DashboardGridItem({
 export function DashboardGrid({
   columns = "auto",
   gap = "md",
+  layout = "grid",
   children,
   className,
   style,
   ...props
 }: DashboardGridProps) {
+  const responsiveColumns = layout === "grid" && isResponsiveColumns(columns);
+
   const gridStyle: CSSProperties = {
     gridTemplateColumns:
-      columns === "auto" ? undefined : `repeat(${columns}, 1fr)`,
+      layout === "grid" && typeof columns === "number"
+        ? `repeat(${columns}, 1fr)`
+        : undefined,
+    ...(responsiveColumns ? getResponsiveColumnStyle(columns) : null),
     ...style,
   };
 
@@ -65,8 +101,10 @@ export function DashboardGrid({
     <div
       className={[
         styles.grid,
+        layout === "column" && styles.column,
         GAP_CLASS[gap],
-        columns === "auto" && styles.auto,
+        layout === "grid" && columns === "auto" && styles.auto,
+        responsiveColumns && styles.responsive,
         className,
       ]
         .filter(Boolean)

--- a/packages/layout/src/components/DashboardGrid/index.ts
+++ b/packages/layout/src/components/DashboardGrid/index.ts
@@ -3,5 +3,8 @@ export type {
   DashboardGridProps,
   DashboardGridItemProps,
   DashboardGridColumns,
+  DashboardGridColumnCount,
+  DashboardGridResponsiveColumns,
   DashboardGridGap,
+  DashboardGridLayout,
 } from "./DashboardGrid";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -47,7 +47,10 @@ export type {
   DashboardGridProps,
   DashboardGridItemProps,
   DashboardGridColumns,
+  DashboardGridColumnCount,
+  DashboardGridResponsiveColumns,
   DashboardGridGap,
+  DashboardGridLayout,
 } from "./components/DashboardGrid";
 
 export { QuickActions } from "./components/QuickActions";


### PR DESCRIPTION
## What

responsive DashboardGrid

## Why

closes #99 

## Changes

- [ ] New component
- [ ] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
