### PR TITLE
Faeture/new layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Live examples and documentation: **[Storybook →](https://eljijuna.github.io/gn
 | `Layout` | Full-page shell with named zones: `header`/`topBar`, `sidebar`, `children`, `footer`/`bottomBar`; supports sidebar overlay, rail collapse, placement, and scroll modes | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-layout--docs) |
 | `AppHeader` | GNOME application header for `Layout.header` with leading, title/subtitle, navigation, search, and action slots | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-appheader--docs) |
 | `SidebarShell` | Full-height sidebar composition with fixed header/footer and scrollable `Sidebar` navigation | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-sidebarshell--docs) |
+| `SidebarTrigger` | Header button that toggles sidebar overlay on narrow screens and rail collapse on wider screens | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-sidebartrigger--docs) |
 | `PageContent` | Scroll-safe content container with GNOME page padding and optional Adwaita clamp widths | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-pagecontent--docs) |
 | `StatusBar` | Compact footer/status bar for `Layout.footer` with optional trailing status/actions | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-statusbar--docs) |
 | `AdaptiveLayout` | Responsive layout that adapts column structure to the available width | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-adaptivelayout--docs) |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,11 @@ Live examples and documentation: **[Storybook →](https://eljijuna.github.io/gn
 
 | Component | Description | Story |
 |-----------|-------------|-------|
-| `Layout` | Full-page shell with four named zones: `topBar`, `sidebar`, `children`, `bottomBar` | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-layout--docs) |
+| `Layout` | Full-page shell with named zones: `header`/`topBar`, `sidebar`, `children`, `footer`/`bottomBar`; supports sidebar overlay, rail collapse, placement, and scroll modes | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-layout--docs) |
+| `AppHeader` | GNOME application header for `Layout.header` with leading, title/subtitle, navigation, search, and action slots | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-appheader--docs) |
+| `SidebarShell` | Full-height sidebar composition with fixed header/footer and scrollable `Sidebar` navigation | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-sidebarshell--docs) |
+| `PageContent` | Scroll-safe content container with GNOME page padding and optional Adwaita clamp widths | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-pagecontent--docs) |
+| `StatusBar` | Compact footer/status bar for `Layout.footer` with optional trailing status/actions | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-statusbar--docs) |
 | `AdaptiveLayout` | Responsive layout that adapts column structure to the available width | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-adaptivelayout--docs) |
 | `CounterCard` | Card displaying a labelled numeric count | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-countercard--docs) |
 | `StatCard` | Key metric card with unit, trend indicator, icon, and skeleton loading state | [Docs](https://eljijuna.github.io/gnome-ui/?path=/docs/layout-statcard--docs) |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -118,6 +118,27 @@ Dark mode is handled automatically via `@media (prefers-color-scheme: dark)`.
 | `--gnome-shadow-md` | Popovers, dropdowns |
 | `--gnome-shadow-lg` | Dialogs, modals |
 
+### Layout
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--gnome-layout-sidebar-min-width` | `180px` | Minimum GNOME sidebar width |
+| `--gnome-layout-sidebar-default-width` | `240px` | Default standalone sidebar width |
+| `--gnome-layout-sidebar-max-width` | `280px` | Maximum GNOME sidebar width |
+| `--gnome-layout-sidebar-width` | `clamp(180px, 25%, 280px)` | Standard in-flow sidebar width |
+| `--gnome-layout-sidebar-overlay-width` | `clamp(180px, 75%, 280px)` | Overlay sidebar width on narrow screens |
+| `--gnome-layout-sidebar-rail-width` | `56px` | Collapsed icon-only sidebar rail |
+| `--gnome-layout-breakpoint-narrow` | `400px` | Split-view collapse threshold |
+| `--gnome-layout-breakpoint-medium` | `550px` | Bottom-navigation / compact shell threshold |
+| `--gnome-layout-breakpoint-wide` | `860px` | Nested-layout outer-pane threshold |
+| `--gnome-layout-content-padding` | `var(--gnome-space-4)` | Default page content padding |
+| `--gnome-layout-content-padding-compact` | `var(--gnome-space-2)` | Compact page content padding |
+| `--gnome-layout-content-padding-spacious` | `var(--gnome-space-5)` | Spacious page content padding |
+
+The breakpoint tokens document the shared GNOME thresholds. CSS media queries
+still use literal pixel values because custom properties are not valid in
+standard `@media` conditions.
+
 ### Misc
 
 | Token | Value |

--- a/packages/core/src/tokens.css
+++ b/packages/core/src/tokens.css
@@ -217,6 +217,29 @@
 
   --gnome-blockquote-border-width: 3px;
 
+  /* ─── Layout tokens ─────────────────────────────────────────── */
+
+  --gnome-layout-sidebar-min-width: 180px;
+  --gnome-layout-sidebar-default-width: 240px;
+  --gnome-layout-sidebar-max-width: 280px;
+  --gnome-layout-sidebar-width: clamp(
+    var(--gnome-layout-sidebar-min-width),
+    25%,
+    var(--gnome-layout-sidebar-max-width)
+  );
+  --gnome-layout-sidebar-overlay-width: clamp(
+    var(--gnome-layout-sidebar-min-width),
+    75%,
+    var(--gnome-layout-sidebar-max-width)
+  );
+  --gnome-layout-sidebar-rail-width: 56px;
+  --gnome-layout-breakpoint-narrow: 400px;
+  --gnome-layout-breakpoint-medium: 550px;
+  --gnome-layout-breakpoint-wide: 860px;
+  --gnome-layout-content-padding: var(--gnome-space-4);
+  --gnome-layout-content-padding-compact: var(--gnome-space-2);
+  --gnome-layout-content-padding-spacious: var(--gnome-space-5);
+
   /* ─── Shadows ────────────────────────────────────────────────── */
 
   --gnome-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.12);

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -85,14 +85,22 @@ when both are provided.
 
 #### Mobile sidebar overlay
 
-On viewports narrower than **640 px** the sidebar becomes a slide-in overlay panel. Two additional props control its visibility:
+On narrow viewports the sidebar becomes a slide-in overlay panel. The default
+breakpoint is **400 px**, matching GNOME split-view behaviour.
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `sidebarOpen` | `boolean` | `false` | Whether the sidebar overlay is visible on mobile |
 | `onSidebarClose` | `() => void` | — | Called when the user taps the backdrop — use it to set `sidebarOpen` back to `false` |
+| `onSidebarOpenChange` | `(open, reason) => void` | — | Called for shell-driven open changes such as backdrop and Escape |
+| `sidebarPlacement` | `"start" \| "end"` | `"start"` | Places the sidebar on the leading or trailing edge |
+| `sidebarBreakpoint` | `"narrow" \| "medium" \| "wide"` | `"narrow"` | Overlay threshold: `400`, `550`, or `860` px |
+| `sidebarCollapseMode` | `"none" \| "rail" \| "overlay"` | `"none"` | Wide-layout collapse behaviour |
+| `sidebarCollapsed` | `boolean` | `false` | Applies shell-level collapsed sidebar styling |
+| `sidebarCollapsedWidth` | `number` | `56` | Rail width in pixels |
 
-On wider (desktop) viewports the sidebar is always visible in the layout flow and these props are ignored.
+On wider viewports the sidebar stays in layout flow unless
+`sidebarCollapseMode="overlay"` and `sidebarCollapsed` are both set.
 
 ```tsx
 import { useState } from "react";
@@ -140,6 +148,35 @@ export default function App() {
     </Layout>
   );
 }
+```
+
+---
+
+### `SidebarShell`
+
+Full-height sidebar composition for `Layout.sidebar`. It wraps the GNOME
+`Sidebar` with optional fixed header/footer areas and a scrollable navigation
+middle.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `header` | `ReactNode` | Fixed content above the navigation list. |
+| `children` | `ReactNode` | Navigation content, usually `SidebarSection` children. |
+| `footer` | `ReactNode` | Fixed content below the navigation list. |
+
+All `Sidebar` props such as `collapsed`, `searchable`, `filter`, `mode`, and
+`variant` pass through.
+
+```tsx
+import { SidebarShell } from "@gnome-ui/layout";
+import { SidebarSection, SidebarItem, Text } from "@gnome-ui/react";
+
+<SidebarShell header={<Text variant="heading">Files</Text>} searchable>
+  <SidebarSection>
+    <SidebarItem label="Home" active />
+    <SidebarItem label="Starred" />
+  </SidebarSection>
+</SidebarShell>
 ```
 
 ---

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -115,13 +115,15 @@ import {
   Layout,
   PageContent,
   SidebarShell,
+  SidebarTrigger,
   StatusBar,
 } from "@gnome-ui/layout";
 import "@gnome-ui/layout/styles";
-import { Button, SidebarSection, SidebarItem, Text } from "@gnome-ui/react";
+import { SidebarSection, SidebarItem, Text } from "@gnome-ui/react";
 
 export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   return (
     <Layout
@@ -129,18 +131,20 @@ export default function App() {
         <AppHeader
           title="My App"
           leading={
-            <Button
-              variant="flat"
-              aria-label="Toggle sidebar"
-              onClick={() => setSidebarOpen((v) => !v)}
-            >
-              ☰
-            </Button>
+            <SidebarTrigger
+              sidebarOpen={sidebarOpen}
+              sidebarCollapsed={sidebarCollapsed}
+              onSidebarOpenChange={setSidebarOpen}
+              onSidebarCollapsedChange={setSidebarCollapsed}
+            />
           }
         />
       }
       sidebar={
-        <SidebarShell header={<Text variant="heading">My App</Text>}>
+        <SidebarShell
+          header={<Text variant="heading">My App</Text>}
+          collapsed={sidebarCollapsed}
+        >
           <SidebarSection>
             <SidebarItem label="Home" active onClick={() => setSidebarOpen(false)} />
             <SidebarItem label="Settings" onClick={() => setSidebarOpen(false)} />
@@ -148,6 +152,8 @@ export default function App() {
         </SidebarShell>
       }
       sidebarOpen={sidebarOpen}
+      sidebarCollapsed={sidebarCollapsed}
+      sidebarCollapseMode="rail"
       onSidebarClose={() => setSidebarOpen(false)}
       footer={
         <StatusBar>
@@ -176,6 +182,8 @@ The current shell API adds a few improvements over the original
   scrolls.
 - `sidebarBreakpoint`, `sidebarPlacement`, and `sidebarCollapseMode` cover
   narrow overlays, right-side panels, and icon-only rail sidebars.
+- `SidebarTrigger` coordinates the same button with overlay open state on
+  narrow screens and rail collapse on wider screens.
 - Overlay sidebars move focus inside, trap `Tab`/`Shift+Tab`, close with
   `Escape`, and restore focus to the previous trigger.
 
@@ -206,6 +214,33 @@ import { SidebarSection, SidebarItem, Text } from "@gnome-ui/react";
     <SidebarItem label="Starred" />
   </SidebarSection>
 </SidebarShell>
+```
+
+---
+
+### `SidebarTrigger`
+
+Header button that toggles the sidebar using the current layout mode. On
+overlay breakpoints it opens or closes the panel; on wider screens it toggles
+rail collapse.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `sidebarOpen` | `boolean` | Current overlay-open state. |
+| `sidebarCollapsed` | `boolean` | Current rail-collapsed state. |
+| `sidebarBreakpoint` | `"narrow" \| "medium" \| "wide"` | Same breakpoint used by `Layout`. |
+| `onSidebarOpenChange` | `(open, reason) => void` | Called when the trigger changes overlay state. |
+| `onSidebarCollapsedChange` | `(collapsed) => void` | Called when the trigger changes rail collapse. |
+
+```tsx
+import { SidebarTrigger } from "@gnome-ui/layout";
+
+<SidebarTrigger
+  sidebarOpen={sidebarOpen}
+  sidebarCollapsed={sidebarCollapsed}
+  onSidebarOpenChange={setSidebarOpen}
+  onSidebarCollapsedChange={setSidebarCollapsed}
+/>
 ```
 
 ---

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -144,6 +144,76 @@ export default function App() {
 
 ---
 
+### `AppHeader`
+
+Opinionated application header for `Layout.header`. It keeps the GNOME
+`HeaderBar` shape while exposing shell-friendly slots.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `title` | `ReactNode` | Header title. String titles render with `WindowTitle`. |
+| `subtitle` | `string` | Optional subtitle for string titles. |
+| `leading` | `ReactNode` | Leading controls, usually sidebar/back buttons. |
+| `navigation` | `ReactNode` | Optional top-level navigation such as `ViewSwitcher`. |
+| `search` | `ReactNode` | Optional search control. |
+| `actions` | `ReactNode` | Trailing actions, usually flat icon buttons or menus. |
+| `flat` | `boolean` | Blend the header into the window chrome. |
+
+```tsx
+import { AppHeader } from "@gnome-ui/layout";
+import { Button, SearchBar } from "@gnome-ui/react";
+
+<AppHeader
+  title="Files"
+  subtitle="Home"
+  leading={<Button variant="flat" aria-label="Toggle sidebar">☰</Button>}
+  search={<SearchBar inline open aria-label="Search files" />}
+  actions={<Button variant="flat">New Folder</Button>}
+/>
+```
+
+---
+
+### `PageContent`
+
+Scrollable page body for `Layout.children`. It provides GNOME page padding and
+optional Adwaita `Clamp` behaviour for readable widths.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `as` | `ElementType` | `"main"` | Element to render. Use `section` when nested inside another `main`. |
+| `maxWidth` | `"none" \| "sm" \| "md" \| "lg" \| "xl" \| number` | `"none"` | Optional content clamp. |
+| `padding` | `"none" \| "compact" \| "normal" \| "spacious"` | `"normal"` | Responsive page padding. |
+
+```tsx
+import { PageContent } from "@gnome-ui/layout";
+
+<PageContent as="section" maxWidth="lg">
+  ...
+</PageContent>
+```
+
+---
+
+### `StatusBar`
+
+Compact footer/status bar for `Layout.footer`.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `children` | `ReactNode` | Leading status content. |
+| `trailing` | `ReactNode` | Optional trailing status or actions. |
+
+```tsx
+import { StatusBar } from "@gnome-ui/layout";
+
+<StatusBar trailing="GNOME Files 48.0">
+  1,248 items
+</StatusBar>
+```
+
+---
+
 ### `IconBadge`
 
 Rounded-square tinted icon container. Accepts the seven gnome-ui named colors or any hex value (`#rgb` / `#rrggbb`). In both cases the background is rendered at 15% opacity.

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -94,6 +94,7 @@ breakpoint is **400 px**, matching GNOME split-view behaviour.
 | `onSidebarClose` | `() => void` | — | Called when the user taps the backdrop — use it to set `sidebarOpen` back to `false` |
 | `onSidebarOpenChange` | `(open, reason) => void` | — | Called for shell-driven open changes such as backdrop and Escape |
 | `sidebarPlacement` | `"start" \| "end"` | `"start"` | Places the sidebar on the leading or trailing edge |
+| `sidebarLabel` | `string` | — | Accessible label for the sidebar landmark wrapper |
 | `sidebarBreakpoint` | `"narrow" \| "medium" \| "wide"` | `"narrow"` | Overlay threshold: `400`, `550`, or `860` px |
 | `sidebarCollapseMode` | `"none" \| "rail" \| "overlay"` | `"none"` | Wide-layout collapse behaviour |
 | `sidebarCollapsed` | `boolean` | `false` | Applies shell-level collapsed sidebar styling |
@@ -101,6 +102,11 @@ breakpoint is **400 px**, matching GNOME split-view behaviour.
 
 On wider viewports the sidebar stays in layout flow unless
 `sidebarCollapseMode="overlay"` and `sidebarCollapsed` are both set.
+
+When the sidebar overlay is open, focus moves into the sidebar, `Tab` and
+`Shift+Tab` remain inside it, and `Escape` requests close through
+`onSidebarOpenChange(false, "escape")`. Add `sidebarLabel` when the sidebar
+content does not provide a labelled `nav`.
 
 ```tsx
 import { useState } from "react";

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -65,12 +65,23 @@ Full-page application shell with four named, optional zones:
 
 | Zone | Prop | Description |
 |------|------|-------------|
-| Top bar | `topBar` | Pinned header — typically a `Toolbar` or `HeaderBar`. Never scrolls. |
+| Header | `header` / `topBar` | Pinned header — typically a `Toolbar`, `HeaderBar`, or app header composition. Never scrolls when `scroll="content"`. |
 | Sidebar | `sidebar` | Fixed-width lateral navigation — typically a `Sidebar`. |
 | Content | `children` | Scrollable main area. Fills remaining space. |
-| Bottom bar | `bottomBar` | Pinned footer — typically a status `Toolbar`. Never scrolls. |
+| Footer | `footer` / `bottomBar` | Pinned footer — typically a status `Toolbar`. Never scrolls when `scroll="content"`. |
 
 All props of `<div>` are forwarded to the root element.
+
+`topBar` and `bottomBar` remain supported for existing apps. New code can use
+the shell-style aliases `header` and `footer`; the legacy names take precedence
+when both are provided.
+
+#### Height and scroll modes
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `height` | `"viewport" \| "parent"` | `"viewport"` | `viewport` fills the browser viewport (`100vh`); `parent` fills the containing element (`100%`) for nested layouts. |
+| `scroll` | `"content" \| "page" \| "none"` | `"content"` | `content` scrolls only the main area; `page` lets the whole shell scroll; `none` disables internal scrolling. |
 
 #### Mobile sidebar overlay
 
@@ -94,7 +105,7 @@ export default function App() {
 
   return (
     <Layout
-      topBar={
+      header={
         <Toolbar style={{ minHeight: 48, padding: "0 8px" }}>
           <Button
             variant="flat"
@@ -117,7 +128,7 @@ export default function App() {
       }
       sidebarOpen={sidebarOpen}
       onSidebarClose={() => setSidebarOpen(false)}
-      bottomBar={
+      footer={
         <Toolbar style={{ minHeight: 36, padding: "0 16px" }}>
           <Text variant="caption" color="dim">Ready</Text>
         </Toolbar>

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -110,9 +110,15 @@ content does not provide a labelled `nav`.
 
 ```tsx
 import { useState } from "react";
-import { Layout } from "@gnome-ui/layout";
+import {
+  AppHeader,
+  Layout,
+  PageContent,
+  SidebarShell,
+  StatusBar,
+} from "@gnome-ui/layout";
 import "@gnome-ui/layout/styles";
-import { Toolbar, Spacer, Button, Sidebar, SidebarSection, SidebarItem, Text } from "@gnome-ui/react";
+import { Button, SidebarSection, SidebarItem, Text } from "@gnome-ui/react";
 
 export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -120,41 +126,58 @@ export default function App() {
   return (
     <Layout
       header={
-        <Toolbar style={{ minHeight: 48, padding: "0 8px" }}>
-          <Button
-            variant="flat"
-            aria-label="Toggle sidebar"
-            onClick={() => setSidebarOpen((v) => !v)}
-          >
-            ☰
-          </Button>
-          <Text variant="heading">My App</Text>
-          <Spacer />
-        </Toolbar>
+        <AppHeader
+          title="My App"
+          leading={
+            <Button
+              variant="flat"
+              aria-label="Toggle sidebar"
+              onClick={() => setSidebarOpen((v) => !v)}
+            >
+              ☰
+            </Button>
+          }
+        />
       }
       sidebar={
-        <Sidebar>
+        <SidebarShell header={<Text variant="heading">My App</Text>}>
           <SidebarSection>
             <SidebarItem label="Home" active onClick={() => setSidebarOpen(false)} />
             <SidebarItem label="Settings" onClick={() => setSidebarOpen(false)} />
           </SidebarSection>
-        </Sidebar>
+        </SidebarShell>
       }
       sidebarOpen={sidebarOpen}
       onSidebarClose={() => setSidebarOpen(false)}
       footer={
-        <Toolbar style={{ minHeight: 36, padding: "0 16px" }}>
+        <StatusBar>
           <Text variant="caption" color="dim">Ready</Text>
-        </Toolbar>
+        </StatusBar>
       }
     >
-      <main style={{ padding: 24 }}>
+      <PageContent as="section" maxWidth="lg">
         <Text variant="title-2">Welcome</Text>
-      </main>
+      </PageContent>
     </Layout>
   );
 }
 ```
+
+#### Shell API improvements
+
+The current shell API adds a few improvements over the original
+`topBar`/`bottomBar` composition:
+
+- `header` and `footer` aliases make shell regions read naturally while keeping
+  `topBar` and `bottomBar` compatible with existing apps.
+- `height="parent"` makes nested shells possible without accidental double
+  `100vh` layouts.
+- `scroll="content"` keeps header/footer/sidebar fixed while only the main area
+  scrolls.
+- `sidebarBreakpoint`, `sidebarPlacement`, and `sidebarCollapseMode` cover
+  narrow overlays, right-side panels, and icon-only rail sidebars.
+- Overlay sidebars move focus inside, trap `Tab`/`Shift+Tab`, close with
+  `Escape`, and restore focus to the previous trigger.
 
 ---
 

--- a/packages/layout/ROADMAP.md
+++ b/packages/layout/ROADMAP.md
@@ -32,6 +32,12 @@ Sidebar vertical lista para usar: encabezado fijo, área de navegación
 scrollable basada en `Sidebar`, pie fijo y passthrough de props como
 `collapsed`, `searchable`, `filter`, `mode` y `variant`.
 
+### `SidebarTrigger`
+
+Botón de encabezado para controlar la sidebar con el mismo gesto en todos los
+tamaños: abre/cierra overlay en pantallas estrechas y alterna el rail colapsado
+en pantallas amplias.
+
 ### `StatusBar`
 
 Barra inferior compacta basada en `Toolbar`, pensada para estado, contadores,

--- a/packages/layout/ROADMAP.md
+++ b/packages/layout/ROADMAP.md
@@ -1,80 +1,66 @@
 # @gnome-ui/layout — Roadmap
 
-Componentes de layout de nivel de aplicación que componen primitivos de `@gnome-ui/react`
-siguiendo las GNOME Human Interface Guidelines y el patrón Adwaita.
+Componentes de layout de nivel de aplicación que componen primitivos de
+`@gnome-ui/react` siguiendo las GNOME Human Interface Guidelines y el patrón
+Adwaita.
 
 ---
 
-## En desarrollo
+## Implementado
+
+### `Layout`
+
+Shell de aplicación con zonas nombradas `header`/`topBar`, `sidebar`,
+`children`, `footer`/`bottomBar`. Soporta altura `viewport`/`parent`, modelos
+de scroll, sidebar overlay, rail collapse, placement `start`/`end`, foco
+contenido dentro del overlay y cierre por `Escape`/backdrop.
+
+### `AppHeader`
+
+Barra superior lista para usar con título/subtítulo, controles leading,
+navegación, búsqueda y acciones. Envuelve patrones de `HeaderBar` y
+`WindowTitle` en una pieza de layout opinionada.
+
+### `PageContent`
+
+Contenedor de página con padding GNOME, `as`, max-width opcional mediante
+`Clamp`, y tamaños `sm`/`md`/`lg`/`xl`/numérico.
+
+### `SidebarShell`
+
+Sidebar vertical lista para usar: encabezado fijo, área de navegación
+scrollable basada en `Sidebar`, pie fijo y passthrough de props como
+`collapsed`, `searchable`, `filter`, `mode` y `variant`.
+
+### `StatusBar`
+
+Barra inferior compacta basada en `Toolbar`, pensada para estado, contadores,
+acciones secundarias o metadata de aplicación.
 
 ### `UserCard`
 
 Panel de identidad de usuario para sidebars, popovers o páginas de perfil.
 
-```tsx
-<UserCard
-  name="Ada Lovelace"
-  email="ada@gnome.org"
-  avatarSrc="/avatar.jpg"
-  actions={[
-    { label: "View Profile",     onClick: () => {} },
-    { label: "Account Settings", onClick: () => {} },
-    { label: "Sign Out",         onClick: () => {}, variant: "destructive" },
-  ]}
-/>
-```
+### `DashboardGrid`
 
-**Composición interna:** `Avatar` + `Text` + lista de `Button` planos.  
-**Referencia Adwaita:** patrón de usuario en `AdwPreferencesGroup`.
+Grid responsivo de tarjetas con columnas fluidas, gap consistente y soporte
+para celdas de distintos tamaños (`span`).
 
 ---
 
 ## Backlog
 
-### `AppHeader`
-
-Barra superior lista para usar: logo, título de app, `SearchBar`, acciones y un `UserCard` en popover.
-Envuelve `HeaderBar` + `Toolbar` en una sola pieza de layout.
-
-**Por qué en layout:** combina primitivos de `@gnome-ui/react` con lógica de disposición (responsive collapse, avatar popover).
-
----
-
-### `PageContent`
-
-Contenedor de página con max-width centrado, padding horizontal responsivo y título opcional de sección.
-
-```tsx
-<PageContent title="Settings" maxWidth="md">
-  …
-</PageContent>
-```
-
-**Por qué en layout:** codifica las reglas de márgenes y anchos de la HIG en un solo componente.
-
----
-
-### `SidebarShell`
-
-Sidebar vertical lista para usar: encabezado con logo/título, área de navegación con scroll, pie de página fijo con `UserCard` y sección de acción.
-
-**Por qué en layout:** es un patrón de composición recurrente que va más allá de un componente primitivo.
-
----
-
 ### `EmptyState`
 
-Pantalla de estado vacío con ilustración SVG, título, descripción y CTA principal/secundario.  
-Versión más opinionada de `StatusPage` adaptada para paneles de contenido.
-
-**Por qué en layout:** ocupa el espacio de contenido (`children` de `Layout`) y su tamaño/centrado depende del contexto de layout.
-
----
+Pantalla de estado vacío con ilustración SVG, título, descripción y CTA
+principal/secundario. Versión más opinionada de `StatusPage` adaptada para
+paneles de contenido.
 
 ### `SplitLayout`
 
-Shell de dos columnas: lista/maestro en la izquierda, detalle en la derecha.  
-Colapsa a una sola columna en mobile (patrón `NavigationSplitView` pero al nivel de página).
+Shell de dos columnas: lista/maestro en la izquierda, detalle en la derecha.
+Colapsa a una sola columna en mobile (patrón `NavigationSplitView` pero al
+nivel de página).
 
 ```tsx
 <SplitLayout
@@ -84,30 +70,16 @@ Colapsa a una sola columna en mobile (patrón `NavigationSplitView` pero al nive
 />
 ```
 
-**Por qué en layout:** combina `NavigationSplitView` con lógica de breakpoint y transiciones.
-
----
-
-### ~~`DashboardGrid`~~ ✅ Implementado — issue [#82](https://github.com/ElJijuna/gnome-ui/issues/82)
-
-Grid responsivo de tarjetas con columnas fluidas, gap consistente y soporte para celdas de distintos tamaños (`span`).
-
----
-
 ### `DialogLayout`
 
-Shell interno para `Dialog`s grandes (preferencias, wizards): sección de navegación lateral + área de contenido scrollable + barra de acciones fija en el pie.
-
-**Por qué en layout:** es el mismo patrón que `Layout` pero scoped dentro de un modal; reutiliza las mismas zonas (`sidebar`, `content`, `bottomBar`).
-
----
+Shell interno para `Dialog`s grandes (preferencias, wizards): sección de
+navegación lateral + área de contenido scrollable + barra de acciones fija en
+el pie.
 
 ### `NotificationCenter`
 
-Panel lateral deslizable (right drawer) que lista notificaciones agrupadas por app.  
-Usa `OverlaySplitView` internamente.
-
-**Por qué en layout:** es un patrón de overlay de nivel de app, no un widget atómico.
+Panel lateral deslizable (right drawer) que lista notificaciones agrupadas por
+app. Usa `OverlaySplitView` internamente.
 
 ---
 

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -82,6 +82,11 @@
       "import": "./dist/components/SidebarShell.js",
       "require": "./dist/components/SidebarShell.cjs"
     },
+    "./components/SidebarTrigger": {
+      "types": "./dist/components/SidebarTrigger.d.ts",
+      "import": "./dist/components/SidebarTrigger.js",
+      "require": "./dist/components/SidebarTrigger.cjs"
+    },
     "./components/StatusBar": {
       "types": "./dist/components/StatusBar.d.ts",
       "import": "./dist/components/StatusBar.js",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -7,6 +7,11 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    "./components/AppHeader": {
+      "types": "./dist/components/AppHeader.d.ts",
+      "import": "./dist/components/AppHeader.js",
+      "require": "./dist/components/AppHeader.cjs"
+    },
     "./components/AdaptiveLayout": {
       "types": "./dist/components/AdaptiveLayout.d.ts",
       "import": "./dist/components/AdaptiveLayout.js",
@@ -62,10 +67,20 @@
       "import": "./dist/components/PanelCard.js",
       "require": "./dist/components/PanelCard.cjs"
     },
+    "./components/PageContent": {
+      "types": "./dist/components/PageContent.d.ts",
+      "import": "./dist/components/PageContent.js",
+      "require": "./dist/components/PageContent.cjs"
+    },
     "./components/QuickActions": {
       "types": "./dist/components/QuickActions.d.ts",
       "import": "./dist/components/QuickActions.js",
       "require": "./dist/components/QuickActions.cjs"
+    },
+    "./components/StatusBar": {
+      "types": "./dist/components/StatusBar.d.ts",
+      "import": "./dist/components/StatusBar.js",
+      "require": "./dist/components/StatusBar.cjs"
     },
     "./components/StatusIndicator": {
       "types": "./dist/components/StatusIndicator.d.ts",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -77,6 +77,11 @@
       "import": "./dist/components/QuickActions.js",
       "require": "./dist/components/QuickActions.cjs"
     },
+    "./components/SidebarShell": {
+      "types": "./dist/components/SidebarShell.d.ts",
+      "import": "./dist/components/SidebarShell.js",
+      "require": "./dist/components/SidebarShell.cjs"
+    },
     "./components/StatusBar": {
       "types": "./dist/components/StatusBar.d.ts",
       "import": "./dist/components/StatusBar.js",

--- a/packages/layout/src/components/AppHeader/AppHeader.module.css
+++ b/packages/layout/src/components/AppHeader/AppHeader.module.css
@@ -1,0 +1,54 @@
+.appHeader {
+  width: 100%;
+}
+
+.center,
+.end,
+.actions {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.center {
+  justify-content: center;
+  gap: var(--gnome-space-2, 12px);
+}
+
+.title {
+  min-width: 0;
+}
+
+.navigation {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.end {
+  justify-content: flex-end;
+  gap: var(--gnome-space-1, 6px);
+  min-width: 0;
+}
+
+.search {
+  flex: 1 1 220px;
+  min-width: 120px;
+  max-width: 360px;
+}
+
+.actions {
+  gap: var(--gnome-space-1, 6px);
+  flex-shrink: 0;
+}
+
+@media (max-width: 550px) {
+  .center {
+    gap: var(--gnome-space-1, 6px);
+  }
+
+  .navigation,
+  .search {
+    display: none;
+  }
+}

--- a/packages/layout/src/components/AppHeader/AppHeader.stories.tsx
+++ b/packages/layout/src/components/AppHeader/AppHeader.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button, SearchBar, Text, ViewSwitcher, ViewSwitcherItem } from "@gnome-ui/react";
+import { AppHeader } from "./AppHeader";
+import { Layout } from "../Layout";
+import { PageContent } from "../PageContent";
+import { StatusBar } from "../StatusBar";
+
+const meta: Meta<typeof AppHeader> = {
+  title: "Layout/AppHeader",
+  component: AppHeader,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: "GNOME application header with named shell slots.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AppHeader>;
+
+export const Basic: Story = {
+  args: {
+    title: "Files",
+    subtitle: "Home",
+    leading: <Button variant="flat" aria-label="Toggle sidebar">☰</Button>,
+    actions: <Button variant="flat">New Folder</Button>,
+  },
+};
+
+export const WithNavigationAndSearch: Story = {
+  args: {
+    title: "Documents",
+    leading: <Button variant="flat" aria-label="Back">‹</Button>,
+    navigation: (
+      <ViewSwitcher aria-label="Document view">
+        <ViewSwitcherItem label="Recent" active />
+        <ViewSwitcherItem label="Starred" />
+      </ViewSwitcher>
+    ),
+    search: <SearchBar inline open placeholder="Search documents" aria-label="Search documents" />,
+    actions: <Button variant="flat" aria-label="Open menu">⋮</Button>,
+  },
+};
+
+export const InLayout: Story = {
+  render: () => (
+    <Layout
+      header={
+        <AppHeader
+          title="Files"
+          subtitle="Home"
+          leading={<Button variant="flat" aria-label="Toggle sidebar">☰</Button>}
+          actions={<Button variant="flat">New Folder</Button>}
+        />
+      }
+      footer={
+        <StatusBar trailing={<Text variant="caption" color="dim">GNOME Files 48.0</Text>}>
+          <Text variant="caption" color="dim">1,248 items</Text>
+        </StatusBar>
+      }
+    >
+      <PageContent as="section" maxWidth="md">
+        <Text variant="title-2">Home</Text>
+        <Text variant="body" color="dim" style={{ marginTop: 12 }}>
+          Application shell using the phase 2 layout primitives.
+        </Text>
+      </PageContent>
+    </Layout>
+  ),
+};

--- a/packages/layout/src/components/AppHeader/AppHeader.test.tsx
+++ b/packages/layout/src/components/AppHeader/AppHeader.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AppHeader } from "./AppHeader";
+
+describe("AppHeader", () => {
+  it("renders a string title", () => {
+    render(<AppHeader title="Files" />);
+    expect(screen.getByText("Files")).toBeInTheDocument();
+  });
+
+  it("renders a subtitle with a string title", () => {
+    render(<AppHeader title="Files" subtitle="Home" />);
+    expect(screen.getByText("Home")).toBeInTheDocument();
+  });
+
+  it("renders a custom title node", () => {
+    render(<AppHeader title={<strong>Custom Title</strong>} />);
+    expect(screen.getByText("Custom Title")).toBeInTheDocument();
+  });
+
+  it("renders leading, navigation, search, and actions slots", () => {
+    render(
+      <AppHeader
+        leading={<button type="button">Menu</button>}
+        navigation={<div>Views</div>}
+        search={<input aria-label="Search" />}
+        actions={<button type="button">More</button>}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Menu" })).toBeInTheDocument();
+    expect(screen.getByText("Views")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Search" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "More" })).toBeInTheDocument();
+  });
+
+  it("forwards HTML attributes to the header element", () => {
+    render(<AppHeader title="Files" data-testid="app-header" />);
+    expect(screen.getByTestId("app-header").tagName).toBe("HEADER");
+  });
+});

--- a/packages/layout/src/components/AppHeader/AppHeader.tsx
+++ b/packages/layout/src/components/AppHeader/AppHeader.tsx
@@ -23,8 +23,8 @@ export interface AppHeaderProps extends Omit<HTMLAttributes<HTMLElement>, "title
  * Opinionated application header for `Layout` / shell compositions.
  *
  * It keeps the GNOME header-bar shape while giving app shells named slots that
- * map cleanly from Ant-style layout thinking: leading controls, title,
- * navigation, search, and trailing actions.
+ * map cleanly to application structure: leading controls, title, navigation,
+ * search, and trailing actions.
  */
 export function AppHeader({
   title,

--- a/packages/layout/src/components/AppHeader/AppHeader.tsx
+++ b/packages/layout/src/components/AppHeader/AppHeader.tsx
@@ -1,0 +1,75 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { HeaderBar, WindowTitle } from "@gnome-ui/react";
+import styles from "./AppHeader.module.css";
+
+export interface AppHeaderProps extends Omit<HTMLAttributes<HTMLElement>, "title"> {
+  /** Primary title shown in the header. */
+  title?: ReactNode;
+  /** Optional subtitle shown below a string title. */
+  subtitle?: string;
+  /** Leading controls, usually back/sidebar buttons. */
+  leading?: ReactNode;
+  /** Optional top-level navigation, usually a `ViewSwitcher`. */
+  navigation?: ReactNode;
+  /** Optional search control. */
+  search?: ReactNode;
+  /** Trailing actions, usually flat icon buttons or menus. */
+  actions?: ReactNode;
+  /** Blend the header into the window chrome. */
+  flat?: boolean;
+}
+
+/**
+ * Opinionated application header for `Layout` / shell compositions.
+ *
+ * It keeps the GNOME header-bar shape while giving app shells named slots that
+ * map cleanly from Ant-style layout thinking: leading controls, title,
+ * navigation, search, and trailing actions.
+ */
+export function AppHeader({
+  title,
+  subtitle,
+  leading,
+  navigation,
+  search,
+  actions,
+  flat = false,
+  className,
+  ...props
+}: AppHeaderProps) {
+  const titleNode =
+    typeof title === "string" ? (
+      <WindowTitle title={title} subtitle={subtitle} />
+    ) : (
+      title
+    );
+
+  const center = titleNode || navigation
+    ? (
+        <div className={styles.center}>
+          {titleNode && <div className={styles.title}>{titleNode}</div>}
+          {navigation && <div className={styles.navigation}>{navigation}</div>}
+        </div>
+      )
+    : undefined;
+
+  const end = search || actions
+    ? (
+        <div className={styles.end}>
+          {search && <div className={styles.search}>{search}</div>}
+          {actions && <div className={styles.actions}>{actions}</div>}
+        </div>
+      )
+    : undefined;
+
+  return (
+    <HeaderBar
+      className={[styles.appHeader, className].filter(Boolean).join(" ")}
+      start={leading}
+      title={center}
+      end={end}
+      flat={flat}
+      {...props}
+    />
+  );
+}

--- a/packages/layout/src/components/AppHeader/index.ts
+++ b/packages/layout/src/components/AppHeader/index.ts
@@ -1,0 +1,2 @@
+export { AppHeader } from "./AppHeader";
+export type { AppHeaderProps } from "./AppHeader";

--- a/packages/layout/src/components/Layout/Layout.module.css
+++ b/packages/layout/src/components/Layout/Layout.module.css
@@ -249,3 +249,14 @@
     transition: none;
   }
 }
+
+@media (prefers-contrast: more) {
+  .topBar,
+  .bottomBar {
+    border-block-width: 2px;
+  }
+
+  .backdrop {
+    background: rgba(0, 0, 0, 0.55);
+  }
+}

--- a/packages/layout/src/components/Layout/Layout.module.css
+++ b/packages/layout/src/components/Layout/Layout.module.css
@@ -63,7 +63,10 @@
 }
 
 .collapseRail.sidebarCollapsed .sidebar > * {
-  width: var(--layout-sidebar-collapsed-width, 56px);
+  width: var(
+    --layout-sidebar-collapsed-width,
+    var(--gnome-layout-sidebar-rail-width, 56px)
+  );
 }
 
 .collapseOverlay.sidebarCollapsed:not(.bodySidebarOpen) .sidebar {

--- a/packages/layout/src/components/Layout/Layout.module.css
+++ b/packages/layout/src/components/Layout/Layout.module.css
@@ -8,17 +8,37 @@
 .layout {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  overflow: hidden;
   background: var(--gnome-window-bg-color, #fafafa);
   font-family: var(--gnome-font-family, sans-serif);
   color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+}
+
+.heightViewport {
+  height: 100vh;
+}
+
+.heightParent {
+  height: 100%;
+}
+
+.scrollContent {
+  overflow: hidden;
+}
+
+.scrollPage {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.scrollNone {
+  overflow: hidden;
 }
 
 /* ── Top bar ──────────────────────────────────────────────────────────────── */
 
 .topBar {
   flex-shrink: 0;
+  display: block;
   background: var(--gnome-headerbar-bg-color, #ebebeb);
   border-bottom: 1px solid var(--gnome-headerbar-border-color, rgba(0, 0, 0, 0.12));
 }
@@ -48,8 +68,26 @@
 
 .content {
   flex: 1;
-  overflow-y: auto;
   min-width: 0;
+}
+
+.scrollContent .content {
+  overflow-y: auto;
+}
+
+.scrollPage .body {
+  flex: 0 0 auto;
+  min-height: 0;
+  overflow: visible;
+}
+
+.scrollPage .content,
+.scrollNone .content {
+  overflow: visible;
+}
+
+.scrollNone .body {
+  overflow: hidden;
 }
 
 /* ── Mobile overlay behaviour (< 640 px) ──────────────────────────────────── */

--- a/packages/layout/src/components/Layout/Layout.module.css
+++ b/packages/layout/src/components/Layout/Layout.module.css
@@ -52,10 +52,22 @@
   min-height: 0;
 }
 
+.bodySidebarEnd {
+  flex-direction: row;
+}
+
 /* ── Sidebar slot ─────────────────────────────────────────────────────────── */
 
 .sidebar {
   flex-shrink: 0;
+}
+
+.collapseRail.sidebarCollapsed .sidebar > * {
+  width: var(--layout-sidebar-collapsed-width, 56px);
+}
+
+.collapseOverlay.sidebarCollapsed:not(.bodySidebarOpen) .sidebar {
+  display: none;
 }
 
 /* ── Backdrop (mobile only) ───────────────────────────────────────────────── */
@@ -90,32 +102,118 @@
   overflow: hidden;
 }
 
-/* ── Mobile overlay behaviour (< 640 px) ──────────────────────────────────── */
+/* ── Mobile overlay behaviour (GNOME breakpoints) ─────────────────────────── */
 
-@media (max-width: 639px) {
-  .body {
+.breakpointNarrow,
+.breakpointMedium,
+.breakpointWide {
+  --layout-sidebar-closed-transform: translateX(-100%);
+  --layout-sidebar-open-transform: translateX(0);
+}
+
+.bodySidebarEnd {
+  --layout-sidebar-closed-transform: translateX(100%);
+}
+
+@media (max-width: 400px) {
+  .breakpointNarrow {
     position: relative;  /* stacking context for absolute sidebar + backdrop */
     overflow-x: clip;    /* clip the sliding sidebar without creating a new scroll context */
   }
 
-  .sidebar {
+  .breakpointNarrow .sidebar {
     position: absolute;
     inset-block: 0;
     inset-inline-start: 0;
     z-index: 10;
-    transform: translateX(-100%);
+    transform: var(--layout-sidebar-closed-transform);
     transition: transform 0.25s ease;
     /* Make sure sidebar background is opaque so content doesn't bleed through */
     background: var(--gnome-sidebar-bg-color, var(--gnome-window-bg-color, #fafafa));
   }
 
+  .breakpointNarrow.bodySidebarEnd .sidebar {
+    inset-inline-start: auto;
+    inset-inline-end: 0;
+  }
+
   /* When open: slide in */
-  .bodySidebarOpen .sidebar {
-    transform: translateX(0);
+  .breakpointNarrow.bodySidebarOpen .sidebar {
+    transform: var(--layout-sidebar-open-transform);
   }
 
   /* Backdrop: covers the content area behind the sidebar */
-  .bodySidebarOpen .backdrop {
+  .breakpointNarrow.bodySidebarOpen .backdrop {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 9;
+    background: rgba(0, 0, 0, 0.35);
+    cursor: pointer;
+  }
+}
+
+@media (max-width: 550px) {
+  .breakpointMedium {
+    position: relative;
+    overflow-x: clip;
+  }
+
+  .breakpointMedium .sidebar {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 0;
+    z-index: 10;
+    transform: var(--layout-sidebar-closed-transform);
+    transition: transform 0.25s ease;
+    background: var(--gnome-sidebar-bg-color, var(--gnome-window-bg-color, #fafafa));
+  }
+
+  .breakpointMedium.bodySidebarEnd .sidebar {
+    inset-inline-start: auto;
+    inset-inline-end: 0;
+  }
+
+  .breakpointMedium.bodySidebarOpen .sidebar {
+    transform: var(--layout-sidebar-open-transform);
+  }
+
+  .breakpointMedium.bodySidebarOpen .backdrop {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 9;
+    background: rgba(0, 0, 0, 0.35);
+    cursor: pointer;
+  }
+}
+
+@media (max-width: 860px) {
+  .breakpointWide {
+    position: relative;
+    overflow-x: clip;
+  }
+
+  .breakpointWide .sidebar {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 0;
+    z-index: 10;
+    transform: var(--layout-sidebar-closed-transform);
+    transition: transform 0.25s ease;
+    background: var(--gnome-sidebar-bg-color, var(--gnome-window-bg-color, #fafafa));
+  }
+
+  .breakpointWide.bodySidebarEnd .sidebar {
+    inset-inline-start: auto;
+    inset-inline-end: 0;
+  }
+
+  .breakpointWide.bodySidebarOpen .sidebar {
+    transform: var(--layout-sidebar-open-transform);
+  }
+
+  .breakpointWide.bodySidebarOpen .backdrop {
     display: block;
     position: absolute;
     inset: 0;
@@ -137,6 +235,14 @@
 
 @media (max-width: 639px) and (prefers-reduced-motion: reduce) {
   .sidebar {
+    transition: none;
+  }
+}
+
+@media (max-width: 860px) and (prefers-reduced-motion: reduce) {
+  .breakpointNarrow .sidebar,
+  .breakpointMedium .sidebar,
+  .breakpointWide .sidebar {
     transition: none;
   }
 }

--- a/packages/layout/src/components/Layout/Layout.stories.tsx
+++ b/packages/layout/src/components/Layout/Layout.stories.tsx
@@ -24,7 +24,11 @@ import {
   WrapBox,
 } from "@gnome-ui/react";
 import { Layout } from "./Layout";
+import { AppHeader as ShellAppHeader } from "../AppHeader";
 import { CounterCard } from "../CounterCard";
+import { PageContent } from "../PageContent";
+import { SidebarShell } from "../SidebarShell";
+import { StatusBar } from "../StatusBar";
 import { UserCard } from "../UserCard";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
@@ -256,6 +260,82 @@ function AppStatusBar() {
   );
 }
 
+function CookbookHeader({
+  title = "Documents",
+  subtitle,
+  onToggleSidebar,
+}: {
+  title?: string;
+  subtitle?: string;
+  onToggleSidebar?: () => void;
+}) {
+  return (
+    <ShellAppHeader
+      title={title}
+      subtitle={subtitle}
+      leading={
+        onToggleSidebar ? (
+          <Button variant="flat" aria-label="Toggle sidebar" onClick={onToggleSidebar}>
+            ☰
+          </Button>
+        ) : undefined
+      }
+      actions={<Button variant="flat">New</Button>}
+    />
+  );
+}
+
+function CookbookSidebar({
+  collapsed = false,
+  onNavigate,
+}: {
+  collapsed?: boolean;
+  onNavigate?: () => void;
+}) {
+  return (
+    <SidebarShell
+      collapsed={collapsed}
+      header={<Text variant="heading">Workspace</Text>}
+      footer={<Button variant="flat" style={{ width: "100%" }}>Preferences</Button>}
+      aria-label="Workspace navigation"
+    >
+      <SidebarSection>
+        <SidebarItem label="Home" icon={GoHome} active onClick={onNavigate} />
+        <SidebarItem label="Starred" icon={Star} onClick={onNavigate} />
+        <SidebarItem label="Shared" icon={Share} onClick={onNavigate} />
+        <SidebarItem label="Settings" icon={Settings} onClick={onNavigate} />
+      </SidebarSection>
+    </SidebarShell>
+  );
+}
+
+function CookbookContent({
+  title = "Overview",
+  rows = 12,
+}: {
+  title?: string;
+  rows?: number;
+}) {
+  return (
+    <PageContent as="section" maxWidth="lg">
+      <Text variant="title-2">{title}</Text>
+      <Text variant="body" color="dim" style={{ marginTop: 8 }}>
+        A GNOME UI application shell pattern equivalent to an Ant Design layout example.
+      </Text>
+      <BoxedList style={{ marginTop: 24 }}>
+        {Array.from({ length: rows }, (_, index) => (
+          <ActionRow
+            key={index}
+            title={`Document ${index + 1}`}
+            subtitle="Updated recently"
+            interactive
+          />
+        ))}
+      </BoxedList>
+    </PageContent>
+  );
+}
+
 // ─── Full app composition ──────────────────────────────────────────────────────
 
 function FilesApp({ startMobileOpen = false }: { startMobileOpen?: boolean }) {
@@ -418,4 +498,244 @@ export const ContentOnly: StoryObj<typeof Layout> = {
     </Layout>
   ),
   parameters: { controls: { disable: true } },
+};
+
+// ─── Ant Design Layout parity cookbook ────────────────────────────────────────
+
+export const BasicStructure: StoryObj<typeof Layout> = {
+  name: "Basic structure",
+  render: () => (
+    <Layout
+      header={<CookbookHeader title="Basic Shell" />}
+      footer={
+        <StatusBar trailing={<Text variant="caption" color="dim">Ready</Text>}>
+          <Text variant="caption" color="dim">Footer</Text>
+        </StatusBar>
+      }
+    >
+      <CookbookContent title="Content" rows={6} />
+    </Layout>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+export const HeaderContentFooter: StoryObj<typeof Layout> = {
+  name: "Header content footer",
+  render: () => (
+    <Layout
+      header={<CookbookHeader title="Reports" subtitle="Q2 activity" />}
+      footer={
+        <StatusBar trailing={<Text variant="caption" color="dim">Synced</Text>}>
+          <Text variant="caption" color="dim">24 reports</Text>
+        </StatusBar>
+      }
+    >
+      <CookbookContent title="Reports" rows={10} />
+    </Layout>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+export const HeaderSidebar: StoryObj<typeof Layout> = {
+  name: "Header sidebar",
+  render: function HeaderSidebarStory() {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <Layout
+        header={<CookbookHeader title="Workspace" onToggleSidebar={() => setOpen((v) => !v)} />}
+        sidebar={<CookbookSidebar onNavigate={() => setOpen(false)} />}
+        sidebarOpen={open}
+        onSidebarOpenChange={setOpen}
+        footer={<StatusBar><Text variant="caption" color="dim">Connected</Text></StatusBar>}
+      >
+        <CookbookContent title="Home" rows={10} />
+      </Layout>
+    );
+  },
+  parameters: { controls: { disable: true } },
+};
+
+export const HeaderSidebarNested: StoryObj<typeof Layout> = {
+  name: "Header sidebar 2",
+  render: function HeaderSidebarNestedStory() {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <Layout
+        header={<CookbookHeader title="Projects" subtitle="Planning" onToggleSidebar={() => setOpen((v) => !v)} />}
+        sidebar={<CookbookSidebar onNavigate={() => setOpen(false)} />}
+        sidebarOpen={open}
+        sidebarBreakpoint="medium"
+        onSidebarOpenChange={setOpen}
+      >
+        <PageContent as="section" maxWidth="xl">
+          <Text variant="title-2">Planning</Text>
+          <WrapBox childSpacing={24} lineSpacing={24} align="start" style={{ marginTop: 24 }}>
+            <Box spacing={8} style={{ flex: "1 1 280px", minWidth: 0 }}>
+              <Text variant="caption-heading" color="dim">Pinned</Text>
+              <BoxedList>
+                <ActionRow title="Roadmap" subtitle="Phase planning" interactive />
+                <ActionRow title="Design notes" subtitle="GNOME shell parity" interactive />
+              </BoxedList>
+            </Box>
+            <Box spacing={8} style={{ flex: "2 1 420px", minWidth: 0 }}>
+              <Text variant="caption-heading" color="dim">Activity</Text>
+              <BoxedList>
+                <ActionRow title="Layout updated" subtitle="Shell aliases and sidebar modes" />
+                <ActionRow title="Stories added" subtitle="Ant parity cookbook" />
+                <ActionRow title="Docs refreshed" subtitle="README and roadmap" />
+              </BoxedList>
+            </Box>
+          </WrapBox>
+        </PageContent>
+      </Layout>
+    );
+  },
+  parameters: { controls: { disable: true } },
+};
+
+export const SidebarOnly: StoryObj<typeof Layout> = {
+  name: "Sidebar only",
+  render: () => (
+    <Layout
+      sidebar={<CookbookSidebar />}
+      footer={<StatusBar><Text variant="caption" color="dim">Sidebar-first shell</Text></StatusBar>}
+    >
+      <CookbookContent title="Sidebar Navigation" rows={8} />
+    </Layout>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+export const CustomSidebarTrigger: StoryObj<typeof Layout> = {
+  name: "Custom sidebar trigger",
+  render: function CustomSidebarTriggerStory() {
+    const [collapsed, setCollapsed] = useState(false);
+    const [open, setOpen] = useState(false);
+
+    function handleTrigger() {
+      if (window.matchMedia("(max-width: 400px)").matches) {
+        setOpen((v) => !v);
+      } else {
+        setCollapsed((v) => !v);
+      }
+    }
+
+    return (
+      <Layout
+        header={<CookbookHeader title="Custom Trigger" onToggleSidebar={handleTrigger} />}
+        sidebar={<CookbookSidebar collapsed={collapsed} onNavigate={() => setOpen(false)} />}
+        sidebarCollapseMode="rail"
+        sidebarCollapsed={collapsed}
+        sidebarOpen={open}
+        onSidebarOpenChange={setOpen}
+      >
+        <CookbookContent title={collapsed ? "Rail sidebar" : "Expanded sidebar"} rows={8} />
+      </Layout>
+    );
+  },
+  parameters: { controls: { disable: true } },
+};
+
+export const ResponsiveSidebar: StoryObj<typeof Layout> = {
+  name: "Responsive sidebar",
+  render: function ResponsiveSidebarStory() {
+    const [open, setOpen] = useState(true);
+
+    return (
+      <Layout
+        header={<CookbookHeader title="Responsive" onToggleSidebar={() => setOpen((v) => !v)} />}
+        sidebar={<CookbookSidebar onNavigate={() => setOpen(false)} />}
+        sidebarOpen={open}
+        sidebarBreakpoint="medium"
+        onSidebarOpenChange={setOpen}
+      >
+        <CookbookContent title="Resize below 550 px" rows={10} />
+      </Layout>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
+    viewport: { defaultViewport: "mobile1" },
+    chromatic: { viewports: [390, 550, 860] },
+  },
+};
+
+export const FixedHeader: StoryObj<typeof Layout> = {
+  name: "Fixed header",
+  render: () => (
+    <Layout
+      header={<CookbookHeader title="Fixed Header" />}
+      footer={<StatusBar><Text variant="caption" color="dim">Only content scrolls</Text></StatusBar>}
+    >
+      <CookbookContent title="Long Content" rows={24} />
+    </Layout>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+export const FixedSidebar: StoryObj<typeof Layout> = {
+  name: "Fixed sidebar",
+  render: () => (
+    <Layout
+      header={<CookbookHeader title="Fixed Sidebar" />}
+      sidebar={<CookbookSidebar />}
+      footer={<StatusBar><Text variant="caption" color="dim">Sidebar stays pinned</Text></StatusBar>}
+    >
+      <CookbookContent title="Scrollable Content" rows={24} />
+    </Layout>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+export const NestedShell: StoryObj<typeof Layout> = {
+  name: "Nested layout",
+  render: () => (
+    <Layout
+      header={<CookbookHeader title="Parent Shell" />}
+      sidebar={<CookbookSidebar />}
+      footer={<StatusBar><Text variant="caption" color="dim">Parent footer</Text></StatusBar>}
+    >
+      <Layout
+        height="parent"
+        scroll="content"
+        header={<ShellAppHeader title="Nested View" actions={<Button variant="flat">Refresh</Button>} />}
+        footer={<StatusBar><Text variant="caption" color="dim">Nested footer</Text></StatusBar>}
+      >
+        <CookbookContent title="Nested Content" rows={16} />
+      </Layout>
+    </Layout>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+export const DarkModePreview: StoryObj<typeof Layout> = {
+  name: "Dark mode preview",
+  render: () => (
+    <Layout
+      header={<CookbookHeader title="Dark Preview" />}
+      sidebar={<CookbookSidebar />}
+      footer={<StatusBar><Text variant="caption" color="dim">Theme: dark</Text></StatusBar>}
+    >
+      <CookbookContent title="Dark Theme" rows={8} />
+    </Layout>
+  ),
+  parameters: { controls: { disable: true } },
+  globals: { theme: "dark", backgrounds: { value: "gnome-dark" } },
+};
+
+export const HighContrastPreview: StoryObj<typeof Layout> = {
+  name: "High contrast preview",
+  render: () => (
+    <Layout
+      header={<CookbookHeader title="High Contrast" />}
+      sidebar={<CookbookSidebar />}
+      footer={<StatusBar><Text variant="caption" color="dim">Theme: high contrast</Text></StatusBar>}
+    >
+      <CookbookContent title="High Contrast" rows={8} />
+    </Layout>
+  ),
+  parameters: { controls: { disable: true } },
+  globals: { theme: "high-contrast" },
 };

--- a/packages/layout/src/components/Layout/Layout.stories.tsx
+++ b/packages/layout/src/components/Layout/Layout.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { GoHome, Settings, Star, Share } from "@gnome-ui/icons";
 import {
@@ -28,6 +28,7 @@ import { AppHeader as ShellAppHeader } from "../AppHeader";
 import { CounterCard } from "../CounterCard";
 import { PageContent } from "../PageContent";
 import { SidebarShell } from "../SidebarShell";
+import { SidebarTrigger } from "../SidebarTrigger";
 import { StatusBar } from "../StatusBar";
 import { UserCard } from "../UserCard";
 
@@ -274,10 +275,12 @@ function AppStatusBar() {
 function CookbookHeader({
   title = "Documents",
   subtitle,
+  leading,
   onToggleSidebar,
 }: {
   title?: string;
   subtitle?: string;
+  leading?: ReactNode;
   onToggleSidebar?: () => void;
 }) {
   return (
@@ -285,11 +288,12 @@ function CookbookHeader({
       title={title}
       subtitle={subtitle}
       leading={
-        onToggleSidebar ? (
+        leading ??
+        (onToggleSidebar ? (
           <Button variant="flat" aria-label="Toggle sidebar" onClick={onToggleSidebar}>
             ☰
           </Button>
-        ) : undefined
+        ) : undefined)
       }
       actions={<Button variant="flat">New</Button>}
     />
@@ -557,14 +561,21 @@ export const HeaderSidebar: StoryObj<typeof Layout> = {
     const [open, setOpen] = useState(false);
     const [collapsed, setCollapsed] = useState(false);
 
-    function handleToggleSidebar() {
-      if (isSidebarOverlay("narrow")) setOpen((v) => !v);
-      else setCollapsed((v) => !v);
-    }
-
     return (
       <Layout
-        header={<CookbookHeader title="Workspace" onToggleSidebar={handleToggleSidebar} />}
+        header={
+          <CookbookHeader
+            title="Workspace"
+            leading={
+              <SidebarTrigger
+                sidebarOpen={open}
+                sidebarCollapsed={collapsed}
+                onSidebarOpenChange={setOpen}
+                onSidebarCollapsedChange={setCollapsed}
+              />
+            }
+          />
+        }
         sidebar={<CookbookSidebar collapsed={collapsed} onNavigate={() => setOpen(false)} />}
         sidebarOpen={open}
         sidebarCollapseMode="rail"
@@ -580,25 +591,35 @@ export const HeaderSidebar: StoryObj<typeof Layout> = {
 };
 
 export const HeaderSidebarNested: StoryObj<typeof Layout> = {
-  name: "Header sidebar 2",
+  name: "Header sidebar nested",
   render: function HeaderSidebarNestedStory() {
     const [open, setOpen] = useState(false);
     const [collapsed, setCollapsed] = useState(false);
 
-    function handleToggleSidebar() {
-      if (isSidebarOverlay("medium")) setOpen((v) => !v);
-      else setCollapsed((v) => !v);
-    }
-
     return (
       <Layout
-        header={<CookbookHeader title="Projects" subtitle="Planning" onToggleSidebar={handleToggleSidebar} />}
+        header={
+          <CookbookHeader
+            title="Projects"
+            subtitle="Planning"
+            leading={
+              <SidebarTrigger
+                sidebarOpen={open}
+                sidebarCollapsed={collapsed}
+                sidebarBreakpoint="medium"
+                onSidebarOpenChange={setOpen}
+                onSidebarCollapsedChange={setCollapsed}
+              />
+            }
+          />
+        }
         sidebar={<CookbookSidebar collapsed={collapsed} onNavigate={() => setOpen(false)} />}
         sidebarOpen={open}
         sidebarBreakpoint="medium"
         sidebarCollapseMode="rail"
         sidebarCollapsed={collapsed}
         onSidebarOpenChange={setOpen}
+        onSidebarClose={() => setOpen(false)}
       >
         <PageContent as="section" maxWidth="xl">
           <Text variant="title-2">Planning</Text>
@@ -645,17 +666,23 @@ export const CustomSidebarTrigger: StoryObj<typeof Layout> = {
     const [collapsed, setCollapsed] = useState(false);
     const [open, setOpen] = useState(false);
 
-    function handleTrigger() {
-      if (isSidebarOverlay("narrow")) {
-        setOpen((v) => !v);
-      } else {
-        setCollapsed((v) => !v);
-      }
-    }
-
     return (
       <Layout
-        header={<CookbookHeader title="Custom Trigger" onToggleSidebar={handleTrigger} />}
+        header={
+          <CookbookHeader
+            title="Custom Trigger"
+            leading={
+              <SidebarTrigger
+                sidebarOpen={open}
+                sidebarCollapsed={collapsed}
+                onSidebarOpenChange={setOpen}
+                onSidebarCollapsedChange={setCollapsed}
+              >
+                Toggle
+              </SidebarTrigger>
+            }
+          />
+        }
         sidebar={<CookbookSidebar collapsed={collapsed} onNavigate={() => setOpen(false)} />}
         sidebarCollapseMode="rail"
         sidebarCollapsed={collapsed}
@@ -675,14 +702,22 @@ export const ResponsiveSidebar: StoryObj<typeof Layout> = {
     const [open, setOpen] = useState(false);
     const [collapsed, setCollapsed] = useState(false);
 
-    function handleToggleSidebar() {
-      if (isSidebarOverlay("medium")) setOpen((v) => !v);
-      else setCollapsed((v) => !v);
-    }
-
     return (
       <Layout
-        header={<CookbookHeader title="Responsive" onToggleSidebar={handleToggleSidebar} />}
+        header={
+          <CookbookHeader
+            title="Responsive"
+            leading={
+              <SidebarTrigger
+                sidebarOpen={open}
+                sidebarCollapsed={collapsed}
+                sidebarBreakpoint="medium"
+                onSidebarOpenChange={setOpen}
+                onSidebarCollapsedChange={setCollapsed}
+              />
+            }
+          />
+        }
         sidebar={<CookbookSidebar collapsed={collapsed} onNavigate={() => setOpen(false)} />}
         sidebarOpen={open}
         sidebarBreakpoint="medium"
@@ -723,6 +758,23 @@ export const FixedSidebar: StoryObj<typeof Layout> = {
       footer={<StatusBar><Text variant="caption" color="dim">Sidebar stays pinned</Text></StatusBar>}
     >
       <CookbookContent title="Scrollable Content" rows={24} />
+    </Layout>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+export const RTLPlacement: StoryObj<typeof Layout> = {
+  name: "RTL sidebar placement",
+  render: () => (
+    <Layout
+      dir="rtl"
+      header={<CookbookHeader title="RTL Layout" />}
+      sidebar={<CookbookSidebar />}
+      sidebarLabel="RTL navigation"
+      sidebarPlacement="start"
+      footer={<StatusBar><Text variant="caption" color="dim">Logical start placement</Text></StatusBar>}
+    >
+      <CookbookContent title="Right-to-left shell" rows={8} />
     </Layout>
   ),
   parameters: { controls: { disable: true } },

--- a/packages/layout/src/components/Layout/Layout.stories.tsx
+++ b/packages/layout/src/components/Layout/Layout.stories.tsx
@@ -331,7 +331,7 @@ function CookbookContent({
     <PageContent as="section" maxWidth="lg">
       <Text variant="title-2">{title}</Text>
       <Text variant="body" color="dim" style={{ marginTop: 8 }}>
-        A GNOME UI application shell pattern equivalent to an Ant Design layout example.
+        A GNOME UI application shell pattern using Adwaita structure and spacing.
       </Text>
       <BoxedList style={{ marginTop: 24 }}>
         {Array.from({ length: rows }, (_, index) => (
@@ -370,7 +370,7 @@ function FilesApp({ startMobileOpen = false }: { startMobileOpen?: boolean }) {
 
   return (
     <Layout
-      topBar={
+      header={
         <AppHeader
           sidebarCollapsed={sidebarCollapsed}
           onToggleSidebar={handleToggleSidebar}
@@ -390,7 +390,7 @@ function FilesApp({ startMobileOpen = false }: { startMobileOpen?: boolean }) {
       }
       sidebarOpen={sidebarOpen}
       onSidebarClose={() => setSidebarOpen(false)}
-      bottomBar={<AppStatusBar />}
+      footer={<AppStatusBar />}
     >
       <AppContent
         activeNav={activeNav}
@@ -417,10 +417,10 @@ named zones following the GNOME Human Interface Guidelines.
 
 | Zone | Prop | Behaviour |
 |------|------|-----------|
-| Top bar | \`topBar\` | Pinned header — never scrolls |
-| Sidebar | \`sidebar\` | Fixed-width lateral navigation |
+| Header | \`header\` / \`topBar\` | Pinned header — never scrolls |
+| Sidebar | \`sidebar\` | Fixed-width lateral navigation, overlay, or rail |
 | Content | \`children\` | Scrollable main area |
-| Bottom bar | \`bottomBar\` | Pinned footer — never scrolls |
+| Footer | \`footer\` / \`bottomBar\` | Pinned footer — never scrolls |
 
 **Install:**
 \`\`\`bash
@@ -432,10 +432,14 @@ npm install @gnome-ui/layout
 import { Layout } from "@gnome-ui/layout";
 import "@gnome-ui/layout/styles";
 
-<Layout topBar={<AppHeader />} sidebar={<AppSidebar />} bottomBar={<AppStatusBar />}>
+<Layout header={<AppHeader />} sidebar={<AppSidebar />} footer={<AppStatusBar />}>
   <AppContent />
 </Layout>
 \`\`\`
+
+The shell supports pinned headers and footers, scroll-contained content,
+sidebar overlays, rail collapse, right-side placement, GNOME breakpoints, and
+the project's \`--gnome-*\` design tokens.
         `,
       },
     },
@@ -457,14 +461,14 @@ export const FilesApplication: StoryObj<typeof Layout> = {
 export const Minimal: StoryObj<typeof Layout> = {
   render: () => (
     <Layout
-      topBar={
+      header={
         <Toolbar style={{ minHeight: 48, padding: "0 16px" }}>
           <Text variant="heading">My App</Text>
           <Spacer />
           <Button variant="suggested">Save</Button>
         </Toolbar>
       }
-      bottomBar={
+      footer={
         <Toolbar style={{ minHeight: 36, padding: "0 16px" }}>
           <Text variant="caption" color="dim">Ready</Text>
         </Toolbar>
@@ -511,7 +515,7 @@ export const ContentOnly: StoryObj<typeof Layout> = {
   parameters: { controls: { disable: true } },
 };
 
-// ─── Ant Design Layout parity cookbook ────────────────────────────────────────
+// ─── Application shell cookbook ────────────────────────────────────────────────
 
 export const BasicStructure: StoryObj<typeof Layout> = {
   name: "Basic structure",
@@ -603,14 +607,14 @@ export const HeaderSidebarNested: StoryObj<typeof Layout> = {
               <Text variant="caption-heading" color="dim">Pinned</Text>
               <BoxedList>
                 <ActionRow title="Roadmap" subtitle="Phase planning" interactive />
-                <ActionRow title="Design notes" subtitle="GNOME shell parity" interactive />
+                <ActionRow title="Design notes" subtitle="GNOME shell structure" interactive />
               </BoxedList>
             </Box>
             <Box spacing={8} style={{ flex: "2 1 420px", minWidth: 0 }}>
               <Text variant="caption-heading" color="dim">Activity</Text>
               <BoxedList>
                 <ActionRow title="Layout updated" subtitle="Shell aliases and sidebar modes" />
-                <ActionRow title="Stories added" subtitle="Ant parity cookbook" />
+                <ActionRow title="Stories added" subtitle="Application shell cookbook" />
                 <ActionRow title="Docs refreshed" subtitle="README and roadmap" />
               </BoxedList>
             </Box>

--- a/packages/layout/src/components/Layout/Layout.stories.tsx
+++ b/packages/layout/src/components/Layout/Layout.stories.tsx
@@ -39,6 +39,17 @@ const userActions = [
   { label: "Sign Out",         onClick: () => alert("sign out"), variant: "destructive" as const },
 ];
 
+const sidebarBreakpointQuery = {
+  narrow: "(max-width: 400px)",
+  medium: "(max-width: 550px)",
+  wide: "(max-width: 860px)",
+} as const;
+
+function isSidebarOverlay(breakpoint: keyof typeof sidebarBreakpointQuery = "narrow") {
+  return typeof window !== "undefined" &&
+    window.matchMedia(sidebarBreakpointQuery[breakpoint]).matches;
+}
+
 // ─── Sub-components ────────────────────────────────────────────────────────────
 
 function AppHeader({
@@ -346,7 +357,7 @@ function FilesApp({ startMobileOpen = false }: { startMobileOpen?: boolean }) {
   const [contentView, setContentView] = useState("grid");
 
   function handleToggleSidebar() {
-    if (window.matchMedia("(max-width: 639px)").matches) {
+    if (isSidebarOverlay("narrow")) {
       // Mobile: only open/close the overlay — never change collapsed state.
       // Changing collapsed while the slide animation runs causes a width-change
       // mid-transition that makes the sidebar look like it expands before hiding.
@@ -540,12 +551,20 @@ export const HeaderSidebar: StoryObj<typeof Layout> = {
   name: "Header sidebar",
   render: function HeaderSidebarStory() {
     const [open, setOpen] = useState(false);
+    const [collapsed, setCollapsed] = useState(false);
+
+    function handleToggleSidebar() {
+      if (isSidebarOverlay("narrow")) setOpen((v) => !v);
+      else setCollapsed((v) => !v);
+    }
 
     return (
       <Layout
-        header={<CookbookHeader title="Workspace" onToggleSidebar={() => setOpen((v) => !v)} />}
-        sidebar={<CookbookSidebar onNavigate={() => setOpen(false)} />}
+        header={<CookbookHeader title="Workspace" onToggleSidebar={handleToggleSidebar} />}
+        sidebar={<CookbookSidebar collapsed={collapsed} onNavigate={() => setOpen(false)} />}
         sidebarOpen={open}
+        sidebarCollapseMode="rail"
+        sidebarCollapsed={collapsed}
         onSidebarOpenChange={setOpen}
         footer={<StatusBar><Text variant="caption" color="dim">Connected</Text></StatusBar>}
       >
@@ -560,13 +579,21 @@ export const HeaderSidebarNested: StoryObj<typeof Layout> = {
   name: "Header sidebar 2",
   render: function HeaderSidebarNestedStory() {
     const [open, setOpen] = useState(false);
+    const [collapsed, setCollapsed] = useState(false);
+
+    function handleToggleSidebar() {
+      if (isSidebarOverlay("medium")) setOpen((v) => !v);
+      else setCollapsed((v) => !v);
+    }
 
     return (
       <Layout
-        header={<CookbookHeader title="Projects" subtitle="Planning" onToggleSidebar={() => setOpen((v) => !v)} />}
-        sidebar={<CookbookSidebar onNavigate={() => setOpen(false)} />}
+        header={<CookbookHeader title="Projects" subtitle="Planning" onToggleSidebar={handleToggleSidebar} />}
+        sidebar={<CookbookSidebar collapsed={collapsed} onNavigate={() => setOpen(false)} />}
         sidebarOpen={open}
         sidebarBreakpoint="medium"
+        sidebarCollapseMode="rail"
+        sidebarCollapsed={collapsed}
         onSidebarOpenChange={setOpen}
       >
         <PageContent as="section" maxWidth="xl">
@@ -615,7 +642,7 @@ export const CustomSidebarTrigger: StoryObj<typeof Layout> = {
     const [open, setOpen] = useState(false);
 
     function handleTrigger() {
-      if (window.matchMedia("(max-width: 400px)").matches) {
+      if (isSidebarOverlay("narrow")) {
         setOpen((v) => !v);
       } else {
         setCollapsed((v) => !v);
@@ -641,14 +668,22 @@ export const CustomSidebarTrigger: StoryObj<typeof Layout> = {
 export const ResponsiveSidebar: StoryObj<typeof Layout> = {
   name: "Responsive sidebar",
   render: function ResponsiveSidebarStory() {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
+    const [collapsed, setCollapsed] = useState(false);
+
+    function handleToggleSidebar() {
+      if (isSidebarOverlay("medium")) setOpen((v) => !v);
+      else setCollapsed((v) => !v);
+    }
 
     return (
       <Layout
-        header={<CookbookHeader title="Responsive" onToggleSidebar={() => setOpen((v) => !v)} />}
-        sidebar={<CookbookSidebar onNavigate={() => setOpen(false)} />}
+        header={<CookbookHeader title="Responsive" onToggleSidebar={handleToggleSidebar} />}
+        sidebar={<CookbookSidebar collapsed={collapsed} onNavigate={() => setOpen(false)} />}
         sidebarOpen={open}
         sidebarBreakpoint="medium"
+        sidebarCollapseMode="rail"
+        sidebarCollapsed={collapsed}
         onSidebarOpenChange={setOpen}
       >
         <CookbookContent title="Resize below 550 px" rows={10} />

--- a/packages/layout/src/components/Layout/Layout.test.tsx
+++ b/packages/layout/src/components/Layout/Layout.test.tsx
@@ -377,5 +377,68 @@ describe("Layout", () => {
       expect(body.className).toMatch(/sidebarCollapsed/);
       expect(aside.style.getPropertyValue("--layout-sidebar-collapsed-width")).toBe("64px");
     });
+
+    it("custom trigger collapses and expands a rail sidebar", () => {
+      function ControlledLayout() {
+        const [collapsed, setCollapsed] = useState(false);
+
+        return (
+          <>
+            <button
+              type="button"
+              onClick={() => setCollapsed((value) => !value)}
+            >
+              Toggle sidebar
+            </button>
+            <Layout
+              sidebar={<nav>Nav</nav>}
+              sidebarCollapseMode="rail"
+              sidebarCollapsed={collapsed}
+            >
+              <p>Content</p>
+            </Layout>
+          </>
+        );
+      }
+
+      const { container } = render(<ControlledLayout />);
+      const body = () => container.querySelector("[class*='body']") as HTMLElement;
+
+      expect(body().className).not.toMatch(/sidebarCollapsed/);
+      fireEvent.click(screen.getByRole("button", { name: "Toggle sidebar" }));
+      expect(body().className).toMatch(/sidebarCollapsed/);
+      fireEvent.click(screen.getByRole("button", { name: "Toggle sidebar" }));
+      expect(body().className).not.toMatch(/sidebarCollapsed/);
+    });
+
+    it("can close the mobile sidebar when a navigation item is selected", async () => {
+      function ControlledLayout() {
+        const [open, setOpen] = useState(true);
+
+        return (
+          <Layout
+            sidebar={
+              <button type="button" onClick={() => setOpen(false)}>
+                Home
+              </button>
+            }
+            sidebarOpen={open}
+            onSidebarOpenChange={setOpen}
+          >
+            <p>Content</p>
+          </Layout>
+        );
+      }
+
+      const { container } = render(<ControlledLayout />);
+      const body = () => container.querySelector("[class*='body']") as HTMLElement;
+
+      expect(body().className).toMatch(/bodySidebarOpen/);
+      fireEvent.click(screen.getByRole("button", { name: "Home" }));
+
+      await waitFor(() => {
+        expect(body().className).not.toMatch(/bodySidebarOpen/);
+      });
+    });
   });
 });

--- a/packages/layout/src/components/Layout/Layout.test.tsx
+++ b/packages/layout/src/components/Layout/Layout.test.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Layout } from "./Layout";
 
 describe("Layout", () => {
@@ -128,6 +129,16 @@ describe("Layout", () => {
     expect(container.querySelector("footer")).not.toBeNull();
   });
 
+  it("applies sidebarLabel to the sidebar landmark wrapper", () => {
+    render(
+      <Layout sidebar={<div>Navigation</div>} sidebarLabel="Primary navigation">
+        <p>Content</p>
+      </Layout>,
+    );
+
+    expect(screen.getByLabelText("Primary navigation")).toBeInTheDocument();
+  });
+
   it("forwards className to the root element", () => {
     const { container } = render(
       <Layout className="custom-shell"><p>Content</p></Layout>,
@@ -252,6 +263,74 @@ describe("Layout", () => {
       );
       fireEvent.keyDown(document, { key: "Escape" });
       expect(onOpenChange).toHaveBeenCalledWith(false, "escape");
+    });
+
+    it("moves focus into the sidebar when opened", () => {
+      render(
+        <Layout
+          sidebar={<button type="button">First sidebar action</button>}
+          sidebarOpen
+        >
+          <button type="button">Content action</button>
+        </Layout>,
+      );
+
+      expect(screen.getByRole("button", { name: "First sidebar action" })).toHaveFocus();
+    });
+
+    it("keeps Tab focus inside the open sidebar", () => {
+      render(
+        <Layout
+          sidebar={
+            <>
+              <button type="button">First</button>
+              <button type="button">Last</button>
+            </>
+          }
+          sidebarOpen
+        >
+          <button type="button">Content action</button>
+        </Layout>,
+      );
+
+      const first = screen.getByRole("button", { name: "First" });
+      const last = screen.getByRole("button", { name: "Last" });
+
+      last.focus();
+      fireEvent.keyDown(document, { key: "Tab" });
+      expect(first).toHaveFocus();
+
+      fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+      expect(last).toHaveFocus();
+    });
+
+    it("restores focus when the open sidebar closes", async () => {
+      function ControlledLayout() {
+        const [open, setOpen] = useState(false);
+
+        return (
+          <>
+            <button type="button" onClick={() => setOpen(true)}>Trigger</button>
+            <Layout
+              sidebar={<button type="button">Sidebar action</button>}
+              sidebarOpen={open}
+              onSidebarOpenChange={setOpen}
+            >
+              <p>Content</p>
+            </Layout>
+          </>
+        );
+      }
+
+      render(<ControlledLayout />);
+      const trigger = screen.getByRole("button", { name: "Trigger" });
+
+      trigger.focus();
+      fireEvent.click(trigger);
+      expect(screen.getByRole("button", { name: "Sidebar action" })).toHaveFocus();
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      await waitFor(() => expect(trigger).toHaveFocus());
     });
 
     it("applies end placement class when sidebarPlacement is end", () => {

--- a/packages/layout/src/components/Layout/Layout.test.tsx
+++ b/packages/layout/src/components/Layout/Layout.test.tsx
@@ -17,6 +17,25 @@ describe("Layout", () => {
     expect(screen.getByText("App Header")).toBeInTheDocument();
   });
 
+  it("renders the header alias when provided", () => {
+    render(
+      <Layout header={<div>Alias Header</div>}>
+        <p>Content</p>
+      </Layout>,
+    );
+    expect(screen.getByText("Alias Header")).toBeInTheDocument();
+  });
+
+  it("prefers topBar over header when both are provided", () => {
+    render(
+      <Layout topBar={<div>Legacy Header</div>} header={<div>Alias Header</div>}>
+        <p>Content</p>
+      </Layout>,
+    );
+    expect(screen.getByText("Legacy Header")).toBeInTheDocument();
+    expect(screen.queryByText("Alias Header")).not.toBeInTheDocument();
+  });
+
   it("does not render a top-bar wrapper when topBar is omitted", () => {
     const { container } = render(
       <Layout><p>Content</p></Layout>,
@@ -50,6 +69,25 @@ describe("Layout", () => {
     expect(screen.getByText("Status bar")).toBeInTheDocument();
   });
 
+  it("renders the footer alias when provided", () => {
+    render(
+      <Layout footer={<div>Alias Footer</div>}>
+        <p>Content</p>
+      </Layout>,
+    );
+    expect(screen.getByText("Alias Footer")).toBeInTheDocument();
+  });
+
+  it("prefers bottomBar over footer when both are provided", () => {
+    render(
+      <Layout bottomBar={<div>Legacy Footer</div>} footer={<div>Alias Footer</div>}>
+        <p>Content</p>
+      </Layout>,
+    );
+    expect(screen.getByText("Legacy Footer")).toBeInTheDocument();
+    expect(screen.queryByText("Alias Footer")).not.toBeInTheDocument();
+  });
+
   it("does not render a bottom-bar wrapper when bottomBar is omitted", () => {
     const { container } = render(
       <Layout><p>Content</p></Layout>,
@@ -71,6 +109,23 @@ describe("Layout", () => {
     expect(screen.getByText("Sidebar")).toBeInTheDocument();
     expect(screen.getByText("Content")).toBeInTheDocument();
     expect(screen.getByText("Footer")).toBeInTheDocument();
+  });
+
+  it("uses semantic landmark elements for the shell zones", () => {
+    const { container } = render(
+      <Layout
+        header={<div>Header</div>}
+        sidebar={<div>Navigation</div>}
+        footer={<div>Footer</div>}
+      >
+        <p>Content</p>
+      </Layout>,
+    );
+
+    expect(container.querySelector("header")).not.toBeNull();
+    expect(container.querySelector("aside")).not.toBeNull();
+    expect(container.querySelector("main")).not.toBeNull();
+    expect(container.querySelector("footer")).not.toBeNull();
   });
 
   it("forwards className to the root element", () => {
@@ -97,6 +152,35 @@ describe("Layout", () => {
     );
     expect((container.firstChild as HTMLElement).style.height).toBe("500px");
   });
+
+  it("defaults to viewport height and content scrolling", () => {
+    const { container } = render(<Layout><p>Content</p></Layout>);
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toMatch(/heightViewport/);
+    expect(root.className).toMatch(/scrollContent/);
+  });
+
+  it("supports parent height for nested layouts", () => {
+    const { container } = render(
+      <Layout height="parent"><p>Content</p></Layout>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/heightParent/);
+  });
+
+  it.each(["content", "page", "none"] as const)(
+    "supports the %s scroll model",
+    (scroll) => {
+      const { container } = render(
+        <Layout scroll={scroll}><p>Content</p></Layout>,
+      );
+      const expectedClass = {
+        content: /scrollContent/,
+        page: /scrollPage/,
+        none: /scrollNone/,
+      }[scroll];
+      expect((container.firstChild as HTMLElement).className).toMatch(expectedClass);
+    },
+  );
 
   describe("mobile sidebar overlay", () => {
     it("does not apply bodySidebarOpen class when sidebarOpen is false", () => {

--- a/packages/layout/src/components/Layout/Layout.test.tsx
+++ b/packages/layout/src/components/Layout/Layout.test.tsx
@@ -222,5 +222,81 @@ describe("Layout", () => {
       fireEvent.click(backdrop);
       expect(onClose).toHaveBeenCalledTimes(1);
     });
+
+    it("calls onSidebarOpenChange with backdrop reason when the backdrop is clicked", () => {
+      const onOpenChange = vi.fn();
+      const { container } = render(
+        <Layout
+          sidebar={<nav>Nav</nav>}
+          sidebarOpen
+          onSidebarOpenChange={onOpenChange}
+        >
+          <p>Content</p>
+        </Layout>,
+      );
+      const backdrop = container.querySelector("[class*='backdrop']") as HTMLElement;
+      fireEvent.click(backdrop);
+      expect(onOpenChange).toHaveBeenCalledWith(false, "backdrop");
+    });
+
+    it("calls onSidebarOpenChange with escape reason when Escape is pressed", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <Layout
+          sidebar={<nav>Nav</nav>}
+          sidebarOpen
+          onSidebarOpenChange={onOpenChange}
+        >
+          <p>Content</p>
+        </Layout>,
+      );
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onOpenChange).toHaveBeenCalledWith(false, "escape");
+    });
+
+    it("applies end placement class when sidebarPlacement is end", () => {
+      const { container } = render(
+        <Layout sidebar={<nav>Nav</nav>} sidebarPlacement="end">
+          <p>Content</p>
+        </Layout>,
+      );
+      expect(container.querySelector("[class*='bodySidebarEnd']")).not.toBeNull();
+    });
+
+    it.each(["narrow", "medium", "wide"] as const)(
+      "applies %s sidebar breakpoint class",
+      (sidebarBreakpoint) => {
+        const { container } = render(
+          <Layout sidebar={<nav>Nav</nav>} sidebarBreakpoint={sidebarBreakpoint}>
+            <p>Content</p>
+          </Layout>,
+        );
+        const expectedClass = {
+          narrow: /breakpointNarrow/,
+          medium: /breakpointMedium/,
+          wide: /breakpointWide/,
+        }[sidebarBreakpoint];
+        expect(container.querySelector("[class*='body']")?.className).toMatch(expectedClass);
+      },
+    );
+
+    it("applies rail collapsed class and collapsed width variable", () => {
+      const { container } = render(
+        <Layout
+          sidebar={<nav>Nav</nav>}
+          sidebarCollapseMode="rail"
+          sidebarCollapsed
+          sidebarCollapsedWidth={64}
+        >
+          <p>Content</p>
+        </Layout>,
+      );
+      const body = container.querySelector("[class*='body']") as HTMLElement;
+      const aside = container.querySelector("aside") as HTMLElement;
+
+      expect(body.className).toMatch(/collapseRail/);
+      expect(body.className).toMatch(/sidebarCollapsed/);
+      expect(aside.style.getPropertyValue("--layout-sidebar-collapsed-width")).toBe("64px");
+    });
   });
 });

--- a/packages/layout/src/components/Layout/Layout.tsx
+++ b/packages/layout/src/components/Layout/Layout.tsx
@@ -31,8 +31,8 @@ export interface LayoutProps extends Omit<HTMLAttributes<HTMLDivElement>, "heigh
    */
   topBar?: ReactNode;
   /**
-   * Header area — alias for `topBar` using the Ant-style / shell-style naming.
-   * Typically a `Toolbar`, `HeaderBar`, or future `AppHeader`.
+   * Header area — alias for `topBar` using shell-style naming.
+   * Typically a `Toolbar`, `HeaderBar`, or `AppHeader`.
    */
   header?: ReactNode;
   /**
@@ -107,8 +107,8 @@ export interface LayoutProps extends Omit<HTMLAttributes<HTMLDivElement>, "heigh
    */
   bottomBar?: ReactNode;
   /**
-   * Footer area — alias for `bottomBar` using the Ant-style / shell-style
-   * naming. Typically a compact `Toolbar` or status bar.
+   * Footer area — alias for `bottomBar` using shell-style naming. Typically a
+   * compact `Toolbar` or status bar.
    */
   footer?: ReactNode;
   /**

--- a/packages/layout/src/components/Layout/Layout.tsx
+++ b/packages/layout/src/components/Layout/Layout.tsx
@@ -1,12 +1,23 @@
 import type { HTMLAttributes, ReactNode } from "react";
 import styles from "./Layout.module.css";
 
-export interface LayoutProps extends HTMLAttributes<HTMLDivElement> {
+export type LayoutHeight = "viewport" | "parent";
+export type LayoutScroll = "content" | "page" | "none";
+
+export interface LayoutProps extends Omit<HTMLAttributes<HTMLDivElement>, "height"> {
   /**
    * Top bar area — typically a `Toolbar` or `HeaderBar` with logo, search,
    * and action buttons. Pinned to the top; never scrolls.
+   *
+   * @deprecated Prefer `header` for new code. `topBar` remains supported for
+   * compatibility and takes precedence when both props are provided.
    */
   topBar?: ReactNode;
+  /**
+   * Header area — alias for `topBar` using the Ant-style / shell-style naming.
+   * Typically a `Toolbar`, `HeaderBar`, or future `AppHeader`.
+   */
+  header?: ReactNode;
   /**
    * Sidebar navigation panel — typically a `Sidebar` component.
    * Rendered at the leading edge of the body zone and fills the full
@@ -36,18 +47,43 @@ export interface LayoutProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Bottom status bar — typically a `Toolbar` with status text or action
    * shortcuts. Pinned to the bottom; never scrolls.
+   *
+   * @deprecated Prefer `footer` for new code. `bottomBar` remains supported for
+   * compatibility and takes precedence when both props are provided.
    */
   bottomBar?: ReactNode;
+  /**
+   * Footer area — alias for `bottomBar` using the Ant-style / shell-style
+   * naming. Typically a compact `Toolbar` or status bar.
+   */
+  footer?: ReactNode;
+  /**
+   * Height model for the shell.
+   * - `"viewport"` — fills the browser viewport (`100vh`), suitable for apps.
+   * - `"parent"` — fills its parent (`100%`), suitable for nested layouts.
+   *
+   * Defaults to `"viewport"` to preserve the original full-page behaviour.
+   */
+  height?: LayoutHeight;
+  /**
+   * Scroll model for the shell.
+   * - `"content"` — only the content area scrolls; bars remain pinned.
+   * - `"page"` — the whole shell can scroll as one document.
+   * - `"none"` — no internal scroll containers.
+   *
+   * Defaults to `"content"` to preserve the original app-shell behaviour.
+   */
+  scroll?: LayoutScroll;
 }
 
 /**
  * Full-page application shell following the GNOME Human Interface Guidelines.
  *
  * Composes four named zones:
- * - **`topBar`** — pinned header / toolbar row (e.g. `Toolbar` with logo + search).
+ * - **`header` / `topBar`** — pinned header / toolbar row.
  * - **`sidebar`** — fixed-width lateral navigation (e.g. collapsible `Sidebar`).
  * - **`children`** — scrollable main content area.
- * - **`bottomBar`** — pinned footer / status toolbar.
+ * - **`footer` / `bottomBar`** — pinned footer / status toolbar.
  *
  * All zones are optional. All `<div>` props are forwarded to the root element.
  *
@@ -70,14 +106,31 @@ export interface LayoutProps extends HTMLAttributes<HTMLDivElement> {
  */
 export function Layout({
   topBar,
+  header,
   sidebar,
   sidebarOpen = false,
   onSidebarClose,
   children,
   bottomBar,
+  footer,
+  height = "viewport",
+  scroll = "content",
   className,
   ...props
 }: LayoutProps) {
+  const resolvedHeader = topBar ?? header;
+  const resolvedFooter = bottomBar ?? footer;
+
+  const rootClass = [
+    styles.layout,
+    height === "parent" ? styles.heightParent : styles.heightViewport,
+    scroll === "page" ? styles.scrollPage : undefined,
+    scroll === "none" ? styles.scrollNone : styles.scrollContent,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   const bodyClass = [
     styles.body,
     sidebar && sidebarOpen ? styles.bodySidebarOpen : undefined,
@@ -87,15 +140,15 @@ export function Layout({
 
   return (
     <div
-      className={[styles.layout, className].filter(Boolean).join(" ")}
+      className={rootClass}
       {...props}
     >
-      {topBar && <div className={styles.topBar}>{topBar}</div>}
+      {resolvedHeader && <header className={styles.topBar}>{resolvedHeader}</header>}
 
       <div className={bodyClass}>
         {sidebar && (
           <>
-            <div className={styles.sidebar}>{sidebar}</div>
+            <aside className={styles.sidebar}>{sidebar}</aside>
             {/* Backdrop — visible on mobile when sidebar is open */}
             <div
               className={styles.backdrop}
@@ -104,10 +157,10 @@ export function Layout({
             />
           </>
         )}
-        <div className={styles.content}>{children}</div>
+        <main className={styles.content}>{children}</main>
       </div>
 
-      {bottomBar && <div className={styles.bottomBar}>{bottomBar}</div>}
+      {resolvedFooter && <footer className={styles.bottomBar}>{resolvedFooter}</footer>}
     </div>
   );
 }

--- a/packages/layout/src/components/Layout/Layout.tsx
+++ b/packages/layout/src/components/Layout/Layout.tsx
@@ -1,8 +1,17 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import {
+  useEffect,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
 import styles from "./Layout.module.css";
 
 export type LayoutHeight = "viewport" | "parent";
 export type LayoutScroll = "content" | "page" | "none";
+export type LayoutSidebarBreakpoint = "narrow" | "medium" | "wide";
+export type LayoutSidebarCollapseMode = "none" | "rail" | "overlay";
+export type LayoutSidebarPlacement = "start" | "end";
+export type LayoutSidebarOpenChangeReason = "backdrop" | "escape" | "trigger";
 
 export interface LayoutProps extends Omit<HTMLAttributes<HTMLDivElement>, "height"> {
   /**
@@ -29,11 +38,43 @@ export interface LayoutProps extends Omit<HTMLAttributes<HTMLDivElement>, "heigh
    */
   sidebar?: ReactNode;
   /**
+   * Sidebar edge. `start` follows the text direction; `end` mirrors right-side
+   * sider layouts.
+   */
+  sidebarPlacement?: LayoutSidebarPlacement;
+  /**
+   * Breakpoint where the sidebar becomes an overlay.
+   * - `"narrow"` — 400 px, GNOME split-view threshold.
+   * - `"medium"` — 550 px, GNOME bottom-navigation threshold.
+   * - `"wide"` — 860 px, GNOME nested-layout threshold.
+   */
+  sidebarBreakpoint?: LayoutSidebarBreakpoint;
+  /**
    * Controls sidebar visibility **on narrow (mobile) viewports only**.
    * On wider viewports the sidebar is always visible regardless of this prop.
    * Defaults to `false`.
    */
   sidebarOpen?: boolean;
+  /**
+   * Collapse mode for the sidebar slot on wide layouts.
+   * - `"none"` — no shell-level collapse styling.
+   * - `"rail"` — sidebar remains in flow at `sidebarCollapsedWidth`.
+   * - `"overlay"` — collapsed sidebar is hidden until `sidebarOpen`.
+   */
+  sidebarCollapseMode?: LayoutSidebarCollapseMode;
+  /** Whether the sidebar is collapsed on wide layouts. */
+  sidebarCollapsed?: boolean;
+  /** Width used by `sidebarCollapseMode="rail"`. Defaults to `56`. */
+  sidebarCollapsedWidth?: number;
+  /**
+   * Called when the shell requests sidebar open-state changes, such as backdrop
+   * click or Escape. External triggers can call this same handler with
+   * `"trigger"` for symmetry.
+   */
+  onSidebarOpenChange?: (
+    open: boolean,
+    reason: LayoutSidebarOpenChangeReason,
+  ) => void;
   /**
    * Called when the user taps the backdrop behind the sidebar on mobile.
    * Use this to set `sidebarOpen` back to `false`.
@@ -108,7 +149,13 @@ export function Layout({
   topBar,
   header,
   sidebar,
+  sidebarPlacement = "start",
+  sidebarBreakpoint = "narrow",
   sidebarOpen = false,
+  sidebarCollapseMode = "none",
+  sidebarCollapsed = false,
+  sidebarCollapsedWidth = 56,
+  onSidebarOpenChange,
   onSidebarClose,
   children,
   bottomBar,
@@ -134,9 +181,41 @@ export function Layout({
   const bodyClass = [
     styles.body,
     sidebar && sidebarOpen ? styles.bodySidebarOpen : undefined,
+    sidebarPlacement === "end" ? styles.bodySidebarEnd : undefined,
+    sidebarBreakpoint === "medium" ? styles.breakpointMedium : undefined,
+    sidebarBreakpoint === "wide" ? styles.breakpointWide : styles.breakpointNarrow,
+    sidebarCollapseMode === "rail" ? styles.collapseRail : undefined,
+    sidebarCollapseMode === "overlay" ? styles.collapseOverlay : undefined,
+    sidebarCollapsed ? styles.sidebarCollapsed : undefined,
   ]
     .filter(Boolean)
     .join(" ");
+
+  const sidebarStyle = {
+    "--layout-sidebar-collapsed-width": `${sidebarCollapsedWidth}px`,
+  } as CSSProperties;
+
+  const closeSidebar = (reason: LayoutSidebarOpenChangeReason) => {
+    onSidebarOpenChange?.(false, reason);
+    onSidebarClose?.();
+  };
+
+  useEffect(() => {
+    if (!sidebar || !sidebarOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeSidebar("escape");
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [sidebar, sidebarOpen, onSidebarOpenChange, onSidebarClose]);
+
+  const sidebarSlot = sidebar && (
+    <aside className={styles.sidebar} style={sidebarStyle}>
+      {sidebar}
+    </aside>
+  );
 
   return (
     <div
@@ -146,18 +225,16 @@ export function Layout({
       {resolvedHeader && <header className={styles.topBar}>{resolvedHeader}</header>}
 
       <div className={bodyClass}>
+        {sidebar && sidebarPlacement === "start" && sidebarSlot}
         {sidebar && (
-          <>
-            <aside className={styles.sidebar}>{sidebar}</aside>
-            {/* Backdrop — visible on mobile when sidebar is open */}
-            <div
-              className={styles.backdrop}
-              onClick={onSidebarClose}
-              aria-hidden="true"
-            />
-          </>
+          <div
+            className={styles.backdrop}
+            onClick={() => closeSidebar("backdrop")}
+            aria-hidden="true"
+          />
         )}
         <main className={styles.content}>{children}</main>
+        {sidebar && sidebarPlacement === "end" && sidebarSlot}
       </div>
 
       {resolvedFooter && <footer className={styles.bottomBar}>{resolvedFooter}</footer>}

--- a/packages/layout/src/components/Layout/Layout.tsx
+++ b/packages/layout/src/components/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useRef,
   type CSSProperties,
   type HTMLAttributes,
   type ReactNode,
@@ -42,6 +43,11 @@ export interface LayoutProps extends Omit<HTMLAttributes<HTMLDivElement>, "heigh
    * sider layouts.
    */
   sidebarPlacement?: LayoutSidebarPlacement;
+  /**
+   * Accessible label for the sidebar landmark wrapper. Provide this when the
+   * sidebar content does not include its own labelled `nav`.
+   */
+  sidebarLabel?: string;
   /**
    * Breakpoint where the sidebar becomes an overlay.
    * - `"narrow"` — 400 px, GNOME split-view threshold.
@@ -150,6 +156,7 @@ export function Layout({
   header,
   sidebar,
   sidebarPlacement = "start",
+  sidebarLabel,
   sidebarBreakpoint = "narrow",
   sidebarOpen = false,
   sidebarCollapseMode = "none",
@@ -165,6 +172,8 @@ export function Layout({
   className,
   ...props
 }: LayoutProps) {
+  const sidebarRef = useRef<HTMLElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
   const resolvedHeader = topBar ?? header;
   const resolvedFooter = bottomBar ?? footer;
 
@@ -201,18 +210,85 @@ export function Layout({
   };
 
   useEffect(() => {
-    if (!sidebar || !sidebarOpen) return;
+    if (!sidebar || !sidebarOpen) return undefined;
+
+    previouslyFocusedRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    const getFocusableElements = () => {
+      const sidebarElement = sidebarRef.current;
+      if (!sidebarElement) return [];
+
+      return Array.from(
+        sidebarElement.querySelectorAll<HTMLElement>(
+          [
+            "a[href]",
+            "button:not([disabled])",
+            "input:not([disabled])",
+            "select:not([disabled])",
+            "textarea:not([disabled])",
+            "[tabindex]:not([tabindex='-1'])",
+          ].join(","),
+        ),
+      ).filter((element) => !element.hasAttribute("hidden"));
+    };
+
+    const focusableElements = getFocusableElements();
+    (focusableElements[0] ?? sidebarRef.current)?.focus();
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") closeSidebar("escape");
+      if (event.key === "Escape") {
+        closeSidebar("escape");
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const currentFocusableElements = getFocusableElements();
+      if (!currentFocusableElements.length) {
+        event.preventDefault();
+        sidebarRef.current?.focus();
+        return;
+      }
+
+      const firstElement = currentFocusableElements[0];
+      const lastElement = currentFocusableElements[currentFocusableElements.length - 1];
+      const activeElement = document.activeElement;
+
+      if (event.shiftKey && activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      } else if (!sidebarRef.current?.contains(activeElement)) {
+        event.preventDefault();
+        firstElement.focus();
+      }
     };
 
     document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      if (
+        previouslyFocusedRef.current &&
+        document.contains(previouslyFocusedRef.current)
+      ) {
+        previouslyFocusedRef.current.focus();
+      }
+      previouslyFocusedRef.current = null;
+    };
   }, [sidebar, sidebarOpen, onSidebarOpenChange, onSidebarClose]);
 
   const sidebarSlot = sidebar && (
-    <aside className={styles.sidebar} style={sidebarStyle}>
+    <aside
+      ref={sidebarRef}
+      className={styles.sidebar}
+      style={sidebarStyle}
+      aria-label={sidebarLabel}
+      tabIndex={sidebarOpen ? -1 : undefined}
+    >
       {sidebar}
     </aside>
   );

--- a/packages/layout/src/components/Layout/Layout.tsx
+++ b/packages/layout/src/components/Layout/Layout.tsx
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useRef,
+  useState,
   type CSSProperties,
   type HTMLAttributes,
   type ReactNode,
@@ -13,6 +14,12 @@ export type LayoutSidebarBreakpoint = "narrow" | "medium" | "wide";
 export type LayoutSidebarCollapseMode = "none" | "rail" | "overlay";
 export type LayoutSidebarPlacement = "start" | "end";
 export type LayoutSidebarOpenChangeReason = "backdrop" | "escape" | "trigger";
+
+const sidebarBreakpointQuery: Record<LayoutSidebarBreakpoint, string> = {
+  narrow: "(max-width: 400px)",
+  medium: "(max-width: 550px)",
+  wide: "(max-width: 860px)",
+};
 
 export interface LayoutProps extends Omit<HTMLAttributes<HTMLDivElement>, "height"> {
   /**
@@ -174,8 +181,13 @@ export function Layout({
 }: LayoutProps) {
   const sidebarRef = useRef<HTMLElement>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const [sidebarMatchesOverlayBreakpoint, setSidebarMatchesOverlayBreakpoint] =
+    useState(false);
   const resolvedHeader = topBar ?? header;
   const resolvedFooter = bottomBar ?? footer;
+  const sidebarOverlayActive =
+    sidebarMatchesOverlayBreakpoint ||
+    (sidebarCollapseMode === "overlay" && sidebarCollapsed);
 
   const rootClass = [
     styles.layout,
@@ -210,7 +222,21 @@ export function Layout({
   };
 
   useEffect(() => {
-    if (!sidebar || !sidebarOpen) return undefined;
+    if (typeof window === "undefined" || !window.matchMedia) {
+      setSidebarMatchesOverlayBreakpoint(true);
+      return undefined;
+    }
+
+    const query = window.matchMedia(sidebarBreakpointQuery[sidebarBreakpoint]);
+    const updateMatch = () => setSidebarMatchesOverlayBreakpoint(query.matches);
+
+    updateMatch();
+    query.addEventListener?.("change", updateMatch);
+    return () => query.removeEventListener?.("change", updateMatch);
+  }, [sidebarBreakpoint]);
+
+  useEffect(() => {
+    if (!sidebar || !sidebarOpen || !sidebarOverlayActive) return undefined;
 
     previouslyFocusedRef.current = document.activeElement instanceof HTMLElement
       ? document.activeElement
@@ -279,7 +305,13 @@ export function Layout({
       }
       previouslyFocusedRef.current = null;
     };
-  }, [sidebar, sidebarOpen, onSidebarOpenChange, onSidebarClose]);
+  }, [
+    sidebar,
+    sidebarOpen,
+    sidebarOverlayActive,
+    onSidebarOpenChange,
+    onSidebarClose,
+  ]);
 
   const sidebarSlot = sidebar && (
     <aside

--- a/packages/layout/src/components/Layout/index.ts
+++ b/packages/layout/src/components/Layout/index.ts
@@ -1,2 +1,2 @@
 export { Layout } from "./Layout";
-export type { LayoutProps } from "./Layout";
+export type { LayoutHeight, LayoutProps, LayoutScroll } from "./Layout";

--- a/packages/layout/src/components/Layout/index.ts
+++ b/packages/layout/src/components/Layout/index.ts
@@ -1,2 +1,10 @@
 export { Layout } from "./Layout";
-export type { LayoutHeight, LayoutProps, LayoutScroll } from "./Layout";
+export type {
+  LayoutHeight,
+  LayoutProps,
+  LayoutScroll,
+  LayoutSidebarBreakpoint,
+  LayoutSidebarCollapseMode,
+  LayoutSidebarOpenChangeReason,
+  LayoutSidebarPlacement,
+} from "./Layout";

--- a/packages/layout/src/components/PageContent/PageContent.module.css
+++ b/packages/layout/src/components/PageContent/PageContent.module.css
@@ -11,15 +11,15 @@
 }
 
 .paddingCompact {
-  padding: var(--gnome-space-2, 12px);
+  padding: var(--gnome-layout-content-padding-compact, var(--gnome-space-2, 12px));
 }
 
 .paddingNormal {
-  padding: var(--gnome-space-4, 24px);
+  padding: var(--gnome-layout-content-padding, var(--gnome-space-4, 24px));
 }
 
 .paddingSpacious {
-  padding: var(--gnome-space-5, 36px);
+  padding: var(--gnome-layout-content-padding-spacious, var(--gnome-space-5, 36px));
 }
 
 .clamped {

--- a/packages/layout/src/components/PageContent/PageContent.module.css
+++ b/packages/layout/src/components/PageContent/PageContent.module.css
@@ -1,0 +1,38 @@
+.pageContent {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  color: var(--gnome-view-fg-color, var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8)));
+}
+
+.paddingNone {
+  padding: 0;
+}
+
+.paddingCompact {
+  padding: var(--gnome-space-2, 12px);
+}
+
+.paddingNormal {
+  padding: var(--gnome-space-4, 24px);
+}
+
+.paddingSpacious {
+  padding: var(--gnome-space-5, 36px);
+}
+
+.clamped {
+  display: block;
+}
+
+.clamp {
+  min-width: 0;
+}
+
+@media (max-width: 550px) {
+  .paddingNormal,
+  .paddingSpacious {
+    padding: var(--gnome-space-3, 18px);
+  }
+}

--- a/packages/layout/src/components/PageContent/PageContent.stories.tsx
+++ b/packages/layout/src/components/PageContent/PageContent.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Text, BoxedList, ActionRow } from "@gnome-ui/react";
+import { PageContent } from "./PageContent";
+
+const meta: Meta<typeof PageContent> = {
+  title: "Layout/PageContent",
+  component: PageContent,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: "Page content container with GNOME spacing and optional clamp.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PageContent>;
+
+export const Normal: Story = {
+  render: () => (
+    <PageContent maxWidth="md">
+      <Text variant="title-2">Settings</Text>
+      <BoxedList style={{ marginTop: 24 }}>
+        <ActionRow title="Notifications" subtitle="Banners, sounds, and badges" />
+        <ActionRow title="Privacy" subtitle="Location and camera access" />
+        <ActionRow title="Appearance" subtitle="Style and accent colour" />
+      </BoxedList>
+    </PageContent>
+  ),
+};
+
+export const FullWidth: Story = {
+  render: () => (
+    <PageContent maxWidth="none" padding="spacious">
+      <Text variant="title-2">Dashboard</Text>
+      <div style={{ marginTop: 24, minHeight: 360, background: "var(--gnome-view-bg-color)", border: "1px solid var(--gnome-border-subtle)", borderRadius: 12 }} />
+    </PageContent>
+  ),
+};

--- a/packages/layout/src/components/PageContent/PageContent.test.tsx
+++ b/packages/layout/src/components/PageContent/PageContent.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PageContent } from "./PageContent";
+
+describe("PageContent", () => {
+  it("renders children", () => {
+    render(<PageContent>Documents</PageContent>);
+    expect(screen.getByText("Documents")).toBeInTheDocument();
+  });
+
+  it("renders main by default", () => {
+    const { container } = render(<PageContent>Documents</PageContent>);
+    expect((container.firstChild as HTMLElement).tagName).toBe("MAIN");
+  });
+
+  it("supports a custom element", () => {
+    const { container } = render(<PageContent as="section">Documents</PageContent>);
+    expect((container.firstChild as HTMLElement).tagName).toBe("SECTION");
+  });
+
+  it.each(["none", "compact", "normal", "spacious"] as const)(
+    "applies %s padding class",
+    (padding) => {
+      const { container } = render(
+        <PageContent padding={padding}>Documents</PageContent>,
+      );
+      expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(`padding${padding[0].toUpperCase() + padding.slice(1)}`));
+    },
+  );
+
+  it("does not clamp by default", () => {
+    const { container } = render(<PageContent>Documents</PageContent>);
+    expect(container.querySelector("[class*='clamp']")).toBeNull();
+  });
+
+  it("uses Clamp for named maxWidth", () => {
+    const { container } = render(<PageContent maxWidth="md">Documents</PageContent>);
+    const clamp = (container.firstChild as HTMLElement).firstElementChild as HTMLElement;
+    expect(clamp).not.toBeNull();
+    expect(clamp.style.maxWidth).toBe("600px");
+  });
+
+  it("uses Clamp for numeric maxWidth", () => {
+    const { container } = render(<PageContent maxWidth={720}>Documents</PageContent>);
+    const clamp = (container.firstChild as HTMLElement).firstElementChild as HTMLElement;
+    expect(clamp.style.maxWidth).toBe("720px");
+  });
+
+  it("forwards HTML attributes", () => {
+    render(<PageContent data-testid="page">Documents</PageContent>);
+    expect(screen.getByTestId("page")).toBeInTheDocument();
+  });
+});

--- a/packages/layout/src/components/PageContent/PageContent.tsx
+++ b/packages/layout/src/components/PageContent/PageContent.tsx
@@ -1,0 +1,76 @@
+import type { ElementType, HTMLAttributes, ReactNode } from "react";
+import { Clamp } from "@gnome-ui/react";
+import styles from "./PageContent.module.css";
+
+export type PageContentPadding = "none" | "compact" | "normal" | "spacious";
+export type PageContentMaxWidth = "none" | "sm" | "md" | "lg" | "xl" | number;
+
+export interface PageContentProps extends HTMLAttributes<HTMLElement> {
+  /** Element to render. Defaults to `main`. */
+  as?: ElementType;
+  /** Maximum readable width. Use `none` to fill the available area. */
+  maxWidth?: PageContentMaxWidth;
+  /** Responsive padding density. */
+  padding?: PageContentPadding;
+  /** Page content. */
+  children?: ReactNode;
+}
+
+const maxWidthMap: Record<Exclude<PageContentMaxWidth, "none" | number>, number> = {
+  sm: 480,
+  md: 600,
+  lg: 840,
+  xl: 1080,
+};
+
+const paddingClass: Record<PageContentPadding, string> = {
+  none: styles.paddingNone,
+  compact: styles.paddingCompact,
+  normal: styles.paddingNormal,
+  spacious: styles.paddingSpacious,
+};
+
+function resolveMaxWidth(maxWidth: PageContentMaxWidth) {
+  if (typeof maxWidth === "number") return maxWidth;
+  if (maxWidth === "none") return undefined;
+  return maxWidthMap[maxWidth];
+}
+
+/**
+ * Scroll-safe page content container for `Layout`.
+ *
+ * It provides the GNOME page padding rhythm and optional Adwaita `Clamp`
+ * behaviour for readable content widths.
+ */
+export function PageContent({
+  as: Component = "main",
+  maxWidth = "none",
+  padding = "normal",
+  children,
+  className,
+  ...props
+}: PageContentProps) {
+  const maximumSize = resolveMaxWidth(maxWidth);
+
+  return (
+    <Component
+      className={[
+        styles.pageContent,
+        paddingClass[padding],
+        maximumSize ? styles.clamped : null,
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
+      {maximumSize ? (
+        <Clamp maximumSize={maximumSize} className={styles.clamp}>
+          {children}
+        </Clamp>
+      ) : (
+        children
+      )}
+    </Component>
+  );
+}

--- a/packages/layout/src/components/PageContent/index.ts
+++ b/packages/layout/src/components/PageContent/index.ts
@@ -1,0 +1,6 @@
+export { PageContent } from "./PageContent";
+export type {
+  PageContentMaxWidth,
+  PageContentPadding,
+  PageContentProps,
+} from "./PageContent";

--- a/packages/layout/src/components/SidebarShell/SidebarShell.module.css
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.module.css
@@ -45,3 +45,20 @@
     transition: width var(--gnome-duration-normal, 200ms) var(--gnome-easing-default, ease);
   }
 }
+
+@media (prefers-contrast: more) {
+  .shell {
+    border-inline-end-width: 2px;
+  }
+
+  .header,
+  .footer {
+    border-block-width: 2px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shell {
+    transition: none;
+  }
+}

--- a/packages/layout/src/components/SidebarShell/SidebarShell.module.css
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.module.css
@@ -1,7 +1,7 @@
 .shell {
   display: flex;
   flex-direction: column;
-  width: clamp(180px, 25vw, 280px);
+  width: var(--gnome-layout-sidebar-width, clamp(180px, 25%, 280px));
   height: 100%;
   min-height: 0;
   background: var(--gnome-sidebar-bg-color, #ebebeb);
@@ -37,7 +37,7 @@
 }
 
 .shell:has(.navigation[class*="collapsed"]) {
-  width: 56px;
+  width: var(--gnome-layout-sidebar-rail-width, 56px);
 }
 
 @supports not selector(:has(*)) {

--- a/packages/layout/src/components/SidebarShell/SidebarShell.module.css
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.module.css
@@ -36,14 +36,12 @@
   width: 100%;
 }
 
-.shell:has(.navigation[class*="collapsed"]) {
+.collapsed {
   width: var(--gnome-layout-sidebar-rail-width, 56px);
 }
 
-@supports not selector(:has(*)) {
-  .shell {
-    transition: width var(--gnome-duration-normal, 200ms) var(--gnome-easing-default, ease);
-  }
+.shell {
+  transition: width var(--gnome-duration-normal, 200ms) var(--gnome-easing-default, ease);
 }
 
 @media (prefers-contrast: more) {

--- a/packages/layout/src/components/SidebarShell/SidebarShell.module.css
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.module.css
@@ -1,0 +1,47 @@
+.shell {
+  display: flex;
+  flex-direction: column;
+  width: clamp(180px, 25vw, 280px);
+  height: 100%;
+  min-height: 0;
+  background: var(--gnome-sidebar-bg-color, #ebebeb);
+  color: var(--gnome-sidebar-fg-color, rgba(0, 0, 0, 0.8));
+  border-inline-end: 1px solid var(--gnome-headerbar-border-color, rgba(0, 0, 0, 0.12));
+  overflow: hidden;
+}
+
+.header,
+.footer {
+  flex-shrink: 0;
+  padding: var(--gnome-space-1, 6px);
+}
+
+.header {
+  border-block-end: 1px solid var(--gnome-divider-color, rgba(0, 0, 0, 0.07));
+}
+
+.footer {
+  border-block-start: 1px solid var(--gnome-divider-color, rgba(0, 0, 0, 0.07));
+}
+
+.navigation {
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 0;
+  border-inline-end: 0;
+  background: transparent;
+}
+
+.navigation[class] {
+  width: 100%;
+}
+
+.shell:has(.navigation[class*="collapsed"]) {
+  width: 56px;
+}
+
+@supports not selector(:has(*)) {
+  .shell {
+    transition: width var(--gnome-duration-normal, 200ms) var(--gnome-easing-default, ease);
+  }
+}

--- a/packages/layout/src/components/SidebarShell/SidebarShell.stories.tsx
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button, SidebarSection, SidebarItem, Text } from "@gnome-ui/react";
+import { GoHome, Settings, Star } from "@gnome-ui/icons";
+import { SidebarShell } from "./SidebarShell";
+
+const meta: Meta<typeof SidebarShell> = {
+  title: "Layout/SidebarShell",
+  component: SidebarShell,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: "Full-height GNOME sidebar with fixed header/footer and scrollable navigation.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SidebarShell>;
+
+export const Standard: Story = {
+  render: () => (
+    <div style={{ height: "100vh" }}>
+      <SidebarShell
+        header={<Text variant="heading">Files</Text>}
+        footer={<Button variant="flat" style={{ width: "100%" }}>Preferences</Button>}
+        aria-label="Files navigation"
+      >
+        <SidebarSection>
+          <SidebarItem label="Home" icon={GoHome} active />
+          <SidebarItem label="Starred" icon={Star} />
+          <SidebarItem label="Settings" icon={Settings} />
+        </SidebarSection>
+      </SidebarShell>
+    </div>
+  ),
+};
+
+export const Collapsed: Story = {
+  render: () => (
+    <div style={{ height: "100vh" }}>
+      <SidebarShell collapsed aria-label="Files navigation">
+        <SidebarSection>
+          <SidebarItem label="Home" icon={GoHome} active />
+          <SidebarItem label="Starred" icon={Star} />
+          <SidebarItem label="Settings" icon={Settings} />
+        </SidebarSection>
+      </SidebarShell>
+    </div>
+  ),
+};
+
+export const Searchable: Story = {
+  render: () => (
+    <div style={{ height: "100vh" }}>
+      <SidebarShell searchable header={<Text variant="heading">Files</Text>}>
+        <SidebarSection>
+          <SidebarItem label="Home" icon={GoHome} active />
+          <SidebarItem label="Starred" icon={Star} />
+          <SidebarItem label="Settings" icon={Settings} />
+        </SidebarSection>
+      </SidebarShell>
+    </div>
+  ),
+};

--- a/packages/layout/src/components/SidebarShell/SidebarShell.test.tsx
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SidebarSection, SidebarItem } from "@gnome-ui/react";
+import { SidebarShell } from "./SidebarShell";
+
+describe("SidebarShell", () => {
+  it("renders header, navigation children, and footer", () => {
+    render(
+      <SidebarShell header={<div>Workspace</div>} footer={<div>Ada</div>}>
+        <SidebarSection>
+          <SidebarItem label="Home" />
+        </SidebarSection>
+      </SidebarShell>,
+    );
+
+    expect(screen.getByText("Workspace")).toBeInTheDocument();
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("Ada")).toBeInTheDocument();
+  });
+
+  it("passes Sidebar props through", () => {
+    render(
+      <SidebarShell searchable aria-label="Primary navigation">
+        <SidebarSection>
+          <SidebarItem label="Home" />
+        </SidebarSection>
+      </SidebarShell>,
+    );
+
+    expect(screen.getByRole("navigation", { name: "Primary navigation" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("forwards className to the shell root", () => {
+    const { container } = render(<SidebarShell className="custom-sidebar" />);
+    expect(container.firstChild).toHaveClass("custom-sidebar");
+  });
+});

--- a/packages/layout/src/components/SidebarShell/SidebarShell.test.tsx
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.test.tsx
@@ -35,4 +35,9 @@ describe("SidebarShell", () => {
     const { container } = render(<SidebarShell className="custom-sidebar" />);
     expect(container.firstChild).toHaveClass("custom-sidebar");
   });
+
+  it("applies collapsed class to the shell root", () => {
+    const { container } = render(<SidebarShell collapsed />);
+    expect((container.firstChild as HTMLElement).className).toMatch(/collapsed/);
+  });
 });

--- a/packages/layout/src/components/SidebarShell/SidebarShell.tsx
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.tsx
@@ -19,13 +19,22 @@ export function SidebarShell({
   header,
   children,
   footer,
+  collapsed,
   className,
   ...sidebarProps
 }: SidebarShellProps) {
   return (
-    <div className={[styles.shell, className].filter(Boolean).join(" ")}>
+    <div
+      className={[
+        styles.shell,
+        collapsed ? styles.collapsed : null,
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
       {header && <div className={styles.header}>{header}</div>}
-      <Sidebar className={styles.navigation} {...sidebarProps}>
+      <Sidebar className={styles.navigation} collapsed={collapsed} {...sidebarProps}>
         {children}
       </Sidebar>
       {footer && <div className={styles.footer}>{footer}</div>}

--- a/packages/layout/src/components/SidebarShell/SidebarShell.tsx
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import { Sidebar, type SidebarProps } from "@gnome-ui/react";
+import styles from "./SidebarShell.module.css";
+
+export interface SidebarShellProps extends Omit<SidebarProps, "children"> {
+  /** Fixed header area above the navigation list. */
+  header?: ReactNode;
+  /** Navigation content, usually `SidebarSection` children. */
+  children?: ReactNode;
+  /** Fixed footer area below the navigation list. */
+  footer?: ReactNode;
+}
+
+/**
+ * Full-height sidebar composition with fixed header/footer and scrollable
+ * GNOME `Sidebar` navigation in the middle.
+ */
+export function SidebarShell({
+  header,
+  children,
+  footer,
+  className,
+  ...sidebarProps
+}: SidebarShellProps) {
+  return (
+    <div className={[styles.shell, className].filter(Boolean).join(" ")}>
+      {header && <div className={styles.header}>{header}</div>}
+      <Sidebar className={styles.navigation} {...sidebarProps}>
+        {children}
+      </Sidebar>
+      {footer && <div className={styles.footer}>{footer}</div>}
+    </div>
+  );
+}

--- a/packages/layout/src/components/SidebarShell/index.ts
+++ b/packages/layout/src/components/SidebarShell/index.ts
@@ -1,0 +1,2 @@
+export { SidebarShell } from "./SidebarShell";
+export type { SidebarShellProps } from "./SidebarShell";

--- a/packages/layout/src/components/SidebarTrigger/SidebarTrigger.stories.tsx
+++ b/packages/layout/src/components/SidebarTrigger/SidebarTrigger.stories.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { SidebarTrigger } from "./SidebarTrigger";
+
+const meta: Meta<typeof SidebarTrigger> = {
+  title: "Layout/SidebarTrigger",
+  component: SidebarTrigger,
+  parameters: {
+    docs: {
+      description: {
+        component: "Header button that opens overlay sidebars on narrow screens and toggles rail collapse on wider screens.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SidebarTrigger>;
+
+export const Basic: Story = {
+  render: function BasicStory() {
+    const [open, setOpen] = useState(false);
+    const [collapsed, setCollapsed] = useState(false);
+
+    return (
+      <SidebarTrigger
+        sidebarOpen={open}
+        sidebarCollapsed={collapsed}
+        onSidebarOpenChange={setOpen}
+        onSidebarCollapsedChange={setCollapsed}
+      />
+    );
+  },
+};

--- a/packages/layout/src/components/SidebarTrigger/SidebarTrigger.test.tsx
+++ b/packages/layout/src/components/SidebarTrigger/SidebarTrigger.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { SidebarTrigger } from "./SidebarTrigger";
+
+const originalMatchMedia = window.matchMedia;
+
+function mockMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation(() => ({
+    matches,
+    media: "",
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+function mockMutableMatchMedia(matches: boolean) {
+  let currentMatches = matches;
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+  window.matchMedia = vi.fn().mockImplementation(() => ({
+    get matches() {
+      return currentMatches;
+    },
+    media: "",
+    onchange: null,
+    addEventListener: (_event: "change", listener: (event: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_event: "change", listener: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    },
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+
+  return {
+    setMatches(nextMatches: boolean) {
+      currentMatches = nextMatches;
+      listeners.forEach((listener) =>
+        listener({ matches: nextMatches } as MediaQueryListEvent),
+      );
+    },
+  };
+}
+
+describe("SidebarTrigger", () => {
+  beforeEach(() => {
+    mockMatchMedia(false);
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("toggles collapsed state on wide screens", () => {
+    const onOpenChange = vi.fn();
+    const onCollapsedChange = vi.fn();
+
+    render(
+      <SidebarTrigger
+        sidebarOpen={false}
+        sidebarCollapsed={false}
+        onSidebarOpenChange={onOpenChange}
+        onSidebarCollapsedChange={onCollapsedChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(onCollapsedChange).toHaveBeenCalledWith(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("toggles open state on overlay breakpoints", () => {
+    mockMatchMedia(true);
+    const onOpenChange = vi.fn();
+    const onCollapsedChange = vi.fn();
+
+    render(
+      <SidebarTrigger
+        sidebarOpen={false}
+        sidebarCollapsed={false}
+        onSidebarOpenChange={onOpenChange}
+        onSidebarCollapsedChange={onCollapsedChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(onOpenChange).toHaveBeenCalledWith(true, "trigger");
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+  });
+
+  it("reacts when the viewport crosses the overlay breakpoint", () => {
+    const media = mockMutableMatchMedia(false);
+    const onOpenChange = vi.fn();
+    const onCollapsedChange = vi.fn();
+
+    render(
+      <SidebarTrigger
+        sidebarOpen={false}
+        sidebarCollapsed={false}
+        onSidebarOpenChange={onOpenChange}
+        onSidebarCollapsedChange={onCollapsedChange}
+      />,
+    );
+
+    act(() => {
+      media.setMatches(true);
+    });
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(onOpenChange).toHaveBeenCalledWith(true, "trigger");
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+  });
+
+  it("forwards aria-label", () => {
+    render(
+      <SidebarTrigger
+        aria-label="Toggle navigation"
+        sidebarOpen={false}
+        sidebarCollapsed={false}
+        onSidebarOpenChange={() => {}}
+        onSidebarCollapsedChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Toggle navigation" })).toBeInTheDocument();
+  });
+
+  it("describes the wide-screen action from collapsed state", () => {
+    render(
+      <SidebarTrigger
+        sidebarOpen={false}
+        sidebarCollapsed={false}
+        onSidebarOpenChange={() => {}}
+        onSidebarCollapsedChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeInTheDocument();
+  });
+
+  it("describes the overlay action from open state", () => {
+    mockMatchMedia(true);
+
+    render(
+      <SidebarTrigger
+        sidebarOpen
+        sidebarCollapsed={false}
+        onSidebarOpenChange={() => {}}
+        onSidebarCollapsedChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeInTheDocument();
+  });
+});

--- a/packages/layout/src/components/SidebarTrigger/SidebarTrigger.tsx
+++ b/packages/layout/src/components/SidebarTrigger/SidebarTrigger.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Button, type ButtonProps } from "@gnome-ui/react";
+import type {
+  LayoutSidebarBreakpoint,
+  LayoutSidebarOpenChangeReason,
+} from "../Layout";
+
+const sidebarBreakpointQuery: Record<LayoutSidebarBreakpoint, string> = {
+  narrow: "(max-width: 400px)",
+  medium: "(max-width: 550px)",
+  wide: "(max-width: 860px)",
+};
+
+function matchesSidebarOverlay(breakpoint: LayoutSidebarBreakpoint) {
+  return typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia(sidebarBreakpointQuery[breakpoint]).matches;
+}
+
+export interface SidebarTriggerProps extends Omit<ButtonProps, "onClick"> {
+  /** Current overlay-open state. */
+  sidebarOpen: boolean;
+  /** Current rail-collapsed state. */
+  sidebarCollapsed: boolean;
+  /** Breakpoint at which the sidebar becomes an overlay. */
+  sidebarBreakpoint?: LayoutSidebarBreakpoint;
+  /** Called when the trigger toggles overlay open state. */
+  onSidebarOpenChange: (
+    open: boolean,
+    reason: LayoutSidebarOpenChangeReason,
+  ) => void;
+  /** Called when the trigger toggles rail collapse state. */
+  onSidebarCollapsedChange: (collapsed: boolean) => void;
+  /** Button contents. Defaults to a menu glyph. */
+  children?: ReactNode;
+}
+
+/**
+ * Sidebar toggle button for app headers.
+ *
+ * On overlay breakpoints it opens/closes the sidebar. On wider screens it
+ * toggles icon-only rail collapse.
+ */
+export function SidebarTrigger({
+  sidebarOpen,
+  sidebarCollapsed,
+  sidebarBreakpoint = "narrow",
+  onSidebarOpenChange,
+  onSidebarCollapsedChange,
+  children = "☰",
+  "aria-label": ariaLabel,
+  variant = "flat",
+  ...props
+}: SidebarTriggerProps) {
+  const [overlay, setOverlay] = useState(() =>
+    matchesSidebarOverlay(sidebarBreakpoint),
+  );
+  const sidebarVisible = overlay ? sidebarOpen : !sidebarCollapsed;
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      setOverlay(false);
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia(sidebarBreakpointQuery[sidebarBreakpoint]);
+    const updateOverlay = () => setOverlay(mediaQuery.matches);
+
+    updateOverlay();
+    mediaQuery.addEventListener?.("change", updateOverlay);
+    return () => mediaQuery.removeEventListener?.("change", updateOverlay);
+  }, [sidebarBreakpoint]);
+
+  const handleClick = () => {
+    if (overlay) {
+      onSidebarOpenChange(!sidebarOpen, "trigger");
+    } else {
+      onSidebarCollapsedChange(!sidebarCollapsed);
+    }
+  };
+
+  return (
+    <Button
+      {...props}
+      type="button"
+      variant={variant}
+      aria-label={ariaLabel ?? (sidebarVisible ? "Hide sidebar" : "Show sidebar")}
+      onClick={handleClick}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/packages/layout/src/components/SidebarTrigger/index.ts
+++ b/packages/layout/src/components/SidebarTrigger/index.ts
@@ -1,0 +1,2 @@
+export { SidebarTrigger } from "./SidebarTrigger";
+export type { SidebarTriggerProps } from "./SidebarTrigger";

--- a/packages/layout/src/components/StatusBar/StatusBar.module.css
+++ b/packages/layout/src/components/StatusBar/StatusBar.module.css
@@ -1,0 +1,12 @@
+.statusBar {
+  min-height: 36px;
+  padding-inline: var(--gnome-space-3, 18px);
+  color: var(--gnome-window-fg-color, rgba(0, 0, 0, 0.8));
+}
+
+.trailing {
+  display: flex;
+  align-items: center;
+  gap: var(--gnome-space-1, 6px);
+  min-width: 0;
+}

--- a/packages/layout/src/components/StatusBar/StatusBar.stories.tsx
+++ b/packages/layout/src/components/StatusBar/StatusBar.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Text } from "@gnome-ui/react";
+import { StatusBar } from "./StatusBar";
+
+const meta: Meta<typeof StatusBar> = {
+  title: "Layout/StatusBar",
+  component: StatusBar,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: "Compact footer/status bar for application shells.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StatusBar>;
+
+export const Basic: Story = {
+  render: () => (
+    <StatusBar trailing={<Text variant="caption" color="dim">GNOME Files 48.0</Text>}>
+      <Text variant="caption" color="dim">1,248 items</Text>
+    </StatusBar>
+  ),
+};

--- a/packages/layout/src/components/StatusBar/StatusBar.test.tsx
+++ b/packages/layout/src/components/StatusBar/StatusBar.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatusBar } from "./StatusBar";
+
+describe("StatusBar", () => {
+  it("renders children", () => {
+    render(<StatusBar>Ready</StatusBar>);
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+  });
+
+  it("renders trailing content", () => {
+    render(<StatusBar trailing={<span>Synced</span>}>Ready</StatusBar>);
+    expect(screen.getByText("Synced")).toBeInTheDocument();
+  });
+
+  it("forwards HTML attributes", () => {
+    render(<StatusBar data-testid="status-bar">Ready</StatusBar>);
+    expect(screen.getByTestId("status-bar")).toBeInTheDocument();
+  });
+});

--- a/packages/layout/src/components/StatusBar/StatusBar.tsx
+++ b/packages/layout/src/components/StatusBar/StatusBar.tsx
@@ -1,0 +1,35 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { Spacer, Toolbar } from "@gnome-ui/react";
+import styles from "./StatusBar.module.css";
+
+export interface StatusBarProps extends HTMLAttributes<HTMLDivElement> {
+  /** Leading status content. */
+  children?: ReactNode;
+  /** Optional trailing status/actions. */
+  trailing?: ReactNode;
+}
+
+/**
+ * Compact footer/status bar for `Layout.footer`.
+ */
+export function StatusBar({
+  children,
+  trailing,
+  className,
+  ...props
+}: StatusBarProps) {
+  return (
+    <Toolbar
+      className={[styles.statusBar, className].filter(Boolean).join(" ")}
+      {...props}
+    >
+      {children}
+      {trailing && (
+        <>
+          <Spacer />
+          <div className={styles.trailing}>{trailing}</div>
+        </>
+      )}
+    </Toolbar>
+  );
+}

--- a/packages/layout/src/components/StatusBar/index.ts
+++ b/packages/layout/src/components/StatusBar/index.ts
@@ -1,0 +1,2 @@
+export { StatusBar } from "./StatusBar";
+export type { StatusBarProps } from "./StatusBar";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -1,6 +1,19 @@
 export { Layout } from "./components/Layout";
 export type { LayoutHeight, LayoutProps, LayoutScroll } from "./components/Layout";
 
+export { AppHeader } from "./components/AppHeader";
+export type { AppHeaderProps } from "./components/AppHeader";
+
+export { PageContent } from "./components/PageContent";
+export type {
+  PageContentMaxWidth,
+  PageContentPadding,
+  PageContentProps,
+} from "./components/PageContent";
+
+export { StatusBar } from "./components/StatusBar";
+export type { StatusBarProps } from "./components/StatusBar";
+
 export { CounterCard } from "./components/CounterCard";
 export type { CounterCardProps } from "./components/CounterCard";
 

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -1,5 +1,5 @@
 export { Layout } from "./components/Layout";
-export type { LayoutProps } from "./components/Layout";
+export type { LayoutHeight, LayoutProps, LayoutScroll } from "./components/Layout";
 
 export { CounterCard } from "./components/CounterCard";
 export type { CounterCardProps } from "./components/CounterCard";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -22,6 +22,9 @@ export type {
 export { SidebarShell } from "./components/SidebarShell";
 export type { SidebarShellProps } from "./components/SidebarShell";
 
+export { SidebarTrigger } from "./components/SidebarTrigger";
+export type { SidebarTriggerProps } from "./components/SidebarTrigger";
+
 export { StatusBar } from "./components/StatusBar";
 export type { StatusBarProps } from "./components/StatusBar";
 

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -1,5 +1,13 @@
 export { Layout } from "./components/Layout";
-export type { LayoutHeight, LayoutProps, LayoutScroll } from "./components/Layout";
+export type {
+  LayoutHeight,
+  LayoutProps,
+  LayoutScroll,
+  LayoutSidebarBreakpoint,
+  LayoutSidebarCollapseMode,
+  LayoutSidebarOpenChangeReason,
+  LayoutSidebarPlacement,
+} from "./components/Layout";
 
 export { AppHeader } from "./components/AppHeader";
 export type { AppHeaderProps } from "./components/AppHeader";
@@ -10,6 +18,9 @@ export type {
   PageContentPadding,
   PageContentProps,
 } from "./components/PageContent";
+
+export { SidebarShell } from "./components/SidebarShell";
+export type { SidebarShellProps } from "./components/SidebarShell";
 
 export { StatusBar } from "./components/StatusBar";
 export type { StatusBarProps } from "./components/StatusBar";

--- a/packages/react/src/components/NavigationSplitView/NavigationSplitView.module.css
+++ b/packages/react/src/components/NavigationSplitView/NavigationSplitView.module.css
@@ -14,7 +14,7 @@
 }
 
 .expanded .sidebar {
-  width: var(--sidebar-width, clamp(180px, 25%, 280px));
+  width: var(--sidebar-width, var(--gnome-layout-sidebar-width, clamp(180px, 25%, 280px)));
   flex-shrink: 0;
   overflow-y: auto;
 }

--- a/packages/react/src/components/OverlaySplitView/OverlaySplitView.module.css
+++ b/packages/react/src/components/OverlaySplitView/OverlaySplitView.module.css
@@ -19,14 +19,14 @@
 }
 
 .wide .sidebar {
-  width: var(--sidebar-width, clamp(180px, 25%, 280px));
+  width: var(--sidebar-width, var(--gnome-layout-sidebar-width, clamp(180px, 25%, 280px)));
   flex-shrink: 0;
   overflow-y: auto;
   transition: width 200ms var(--gnome-easing-default, ease);
 }
 
 .wide.collapsed .sidebar {
-  width: 56px;
+  width: var(--gnome-layout-sidebar-rail-width, 56px);
 }
 
 .wide .content {
@@ -46,7 +46,7 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  width: var(--sidebar-width, clamp(180px, 75%, 280px));
+  width: var(--sidebar-width, var(--gnome-layout-sidebar-overlay-width, clamp(180px, 75%, 280px)));
   overflow-y: auto;
   z-index: 100;
 

--- a/packages/react/src/components/Sidebar/Sidebar.module.css
+++ b/packages/react/src/components/Sidebar/Sidebar.module.css
@@ -3,7 +3,7 @@
 .sidebar {
   display: flex;
   flex-direction: column;
-  width: 240px;
+  width: var(--gnome-layout-sidebar-default-width, 240px);
   height: 100%;
   background-color: var(--gnome-sidebar-bg-color, #ebebeb);
   color: var(--gnome-sidebar-fg-color, rgba(0, 0, 0, 0.8));
@@ -388,7 +388,7 @@ button.sectionHeader:focus-visible {
 /* ─── Collapsed (icon-only / rail) mode ────────────────────────────────────── */
 
 .collapsed {
-  width: 56px;
+  width: var(--gnome-layout-sidebar-rail-width, 56px);
   transition: width 200ms var(--gnome-easing-default, ease);
 }
 


### PR DESCRIPTION
## What

Adds and polishes the `@gnome-ui/layout` application shell API with reusable header, sidebar, content, footer, and responsive sidebar trigger patterns.

## Why

The layout package needed a complete shell composition that supports GNOME-style app structures, responsive sidebars, accessible overlay behavior, cookbook stories, and package documentation without relying on external layout references.

## Changes

- [x] New component
- [x] Bug fix
- [x] Enhancement
- [x] Docs
- [ ] Chore (deps, config, CI)

## Checklist

- [x] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [x] All styles use CSS custom properties from `@gnome-ui/core`
- [x] Dark mode works via `@media (prefers-color-scheme: dark)`
- [x] Keyboard accessible
- [x] Storybook story added or updated
- [x] TypeScript types exported
- [x] `ROADMAP.md` updated if applicable
