### PR TITLE
Feature/fixes and updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-plugin-react-refresh": "^0.4.7",
         "globals": "^15.0.0",
         "semantic-release": "^25.0.3",
-        "super-configs": "^1.5.0",
+        "super-configs": "^1.7.0",
         "turbo": "^2.8.20",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.0"
@@ -752,21 +752,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -775,9 +775,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1731,20 +1731,22 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
         "@tybys/wasm-util": "^0.10.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -1905,9 +1907,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1960,9 +1962,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1977,9 +1979,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1994,9 +1996,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -2011,9 +2013,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -2028,9 +2030,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -2045,13 +2047,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2062,13 +2067,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2079,13 +2087,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2096,13 +2107,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2113,13 +2127,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2130,13 +2147,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2147,9 +2167,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -2164,9 +2184,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -2174,16 +2194,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -2198,9 +2220,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -3413,9 +3435,9 @@
       ]
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -9188,9 +9210,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -12811,14 +12833,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -12827,27 +12849,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -13900,9 +13922,9 @@
       }
     },
     "node_modules/super-configs": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/super-configs/-/super-configs-1.5.0.tgz",
-      "integrity": "sha512-GaxKrXr6WcoOVtfyTJwsgS+k6CBh0wQ3NbFPJOyUBQqaemfytexC1z2AkLtdoxPfzTDHAoa/3NeGgK86Itm1qg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/super-configs/-/super-configs-1.7.0.tgz",
+      "integrity": "sha512-E5IwLh0wkmmnuV8qMeF7E8OQlBdeqVtLBr1Dr1uW+b74WhjT+pJ2eXnphz/mZSSxUHNOc/QRwSxK3w1LU1QeMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14175,14 +14197,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -14732,17 +14754,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -14758,8 +14780,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -15552,7 +15574,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "storybook": "^10.3.3",
-        "vite": "^8.0.3",
+        "vite": "^8.0.16",
         "vite-magic-tree-shaking": "^1.0.0",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.1.4"
@@ -15599,7 +15621,7 @@
         "jsdom": "^29.0.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "vite": "^8.0.3",
+        "vite": "^8.0.16",
         "vite-magic-tree-shaking": "^1.0.0",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.1.4"
@@ -15624,7 +15646,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "storybook": "^10.3.3",
-        "vite": "^8.0.3",
+        "vite": "^8.0.16",
         "vite-magic-tree-shaking": "^1.0.0",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.1.4"
@@ -15632,7 +15654,7 @@
     },
     "packages/layout": {
       "name": "@gnome-ui/layout",
-      "version": "1.28.1",
+      "version": "1.28.2",
       "license": "MIT",
       "dependencies": {
         "@gnome-ui/core": "*",
@@ -15656,7 +15678,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "storybook": "^10.3.3",
-        "vite": "^8.0.3",
+        "vite": "^8.0.16",
         "vite-magic-tree-shaking": "^1.0.0",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.1.4"
@@ -15675,14 +15697,14 @@
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.4",
         "jsdom": "^29.0.2",
-        "vite": "^8.0.3",
+        "vite": "^8.0.16",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.1.4"
       }
     },
     "packages/react": {
       "name": "@gnome-ui/react",
-      "version": "1.45.0",
+      "version": "1.45.1",
       "license": "MIT",
       "dependencies": {
         "@gnome-ui/core": "*",
@@ -15703,7 +15725,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "storybook": "^10.3.3",
-        "vite": "^8.0.3",
+        "vite": "^8.0.16",
         "vite-magic-tree-shaking": "^1.0.0",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.1.4"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "turbo test"
   },
   "overrides": {
-    "vite": "^8.0.3"
+    "vite": "^8.0.16",
+    "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
@@ -35,7 +36,7 @@
     "eslint-plugin-react-refresh": "^0.4.7",
     "globals": "^15.0.0",
     "semantic-release": "^25.0.3",
-    "super-configs": "^1.5.0",
+    "super-configs": "^1.7.0",
     "turbo": "^2.8.20",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.0"

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -118,7 +118,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "storybook": "^10.3.3",
-    "vite": "^8.0.3",
+    "vite": "^8.0.16",
     "vite-magic-tree-shaking": "^1.0.0",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.1.4"

--- a/packages/charts/src/README.md
+++ b/packages/charts/src/README.md
@@ -1,0 +1,52 @@
+Inline sparkline charts for embedding compact trend visualizations inside cards, tables, and dashboards — no axes, no labels, minimal chrome.
+
+Three variants are available: `SparkAreaChart`, `SparkLineChart`, and `SparkBarChart`. All accept either a plain number array or an object array with a `dataKey`.
+
+```tsx
+import { SparkAreaChart, SparkBarChart, SparkLineChart } from '@gnome-ui/charts';
+
+// Plain numbers
+<SparkAreaChart data={[42, 58, 35, 72, 61]} height={48} aria-label="Weekly trend" />
+
+// Object array
+<SparkLineChart
+  data={[{ day: 'Mon', value: 42 }, { day: 'Tue', value: 58 }]}
+  dataKey="value"
+  height={48}
+  aria-label="Daily sessions"
+/>
+
+// Custom color
+<SparkBarChart data={[88, 72, 95, 60, 48]} color="var(--gnome-red-3, #e01b24)" height={48} aria-label="Error rate" />
+```
+
+### Shared props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `number[] \| Record<string, unknown>[]` | — | Data points |
+| `dataKey` | `string` | `"value"` | Key when data is an object array |
+| `color` | `string` | accent color | Fill / stroke color |
+| `height` | `number` | `40` | Chart height in px |
+| `aria-label` | `string` | — | Accessible label (recommended) |
+
+### SparkAreaChart extra props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `gradient` | `boolean` | `true` | Gradient fill from top to bottom |
+| `fillOpacity` | `number` | `0.2` | Fill opacity when `gradient` is false |
+| `strokeWidth` | `number` | `1.5` | Stroke width |
+
+### SparkBarChart extra props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `barSize` | `number` | auto | Bar width in px |
+| `fillOpacity` | `number` | `0.85` | Bar fill opacity |
+
+### Guidelines
+
+- Always pass `aria-label` — sparklines have no visible axis text.
+- Set `aria-hidden` on the wrapper when a sibling element already describes the trend.
+- Embed inside a `Card` or `StatCard` with a metric value and trend indicator for full context.

--- a/packages/charts/src/SparkCharts.stories.tsx
+++ b/packages/charts/src/SparkCharts.stories.tsx
@@ -108,7 +108,7 @@ export const AllColors: Story = {
 
 // ─── In Cards ─────────────────────────────────────────────────────────────────
 
-function MetricCard({
+const MetricCard = ({
   label,
   value,
   trend,
@@ -118,7 +118,7 @@ function MetricCard({
   value: string;
   trend: string;
   children: ReactNode;
-}) {
+}) => {
   return (
     <Card style={{ width: 200 }}>
       <Text variant="caption" color="dim">
@@ -136,7 +136,7 @@ function MetricCard({
       {children}
     </Card>
   );
-}
+};
 
 export const InCards: Story = {
   name: 'Embedded in Cards',

--- a/packages/charts/src/SparkCharts.stories.tsx
+++ b/packages/charts/src/SparkCharts.stories.tsx
@@ -6,6 +6,7 @@ import { GNOME_CHART_PALETTE } from './colors';
 import { SparkAreaChart } from './components/SparkAreaChart';
 import { SparkBarChart } from './components/SparkBarChart';
 import { SparkLineChart } from './components/SparkLineChart';
+import readme from './README.md?raw';
 
 // ─── Sample data ─────────────────────────────────────────────────────────────
 
@@ -17,7 +18,11 @@ const OBJECTS = NUMBERS.map((v, i) => ({ day: `D${i + 1}`, sessions: v }));
 
 const meta: Meta = {
   title: 'Charts/Spark',
-  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: { description: { component: readme } },
+  },
 };
 
 export default meta;

--- a/packages/charts/src/components/AreaChart/AreaChart.stories.tsx
+++ b/packages/charts/src/components/AreaChart/AreaChart.stories.tsx
@@ -1,11 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { AreaChart } from './AreaChart';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof AreaChart> = {
   title: 'Charts/AreaChart',
   component: AreaChart,
-  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: { description: { component: readme } },
+  },
 };
 
 export default meta;

--- a/packages/charts/src/components/AreaChart/AreaChart.tsx
+++ b/packages/charts/src/components/AreaChart/AreaChart.tsx
@@ -47,7 +47,7 @@ const TOOLTIP_CONTENT_STYLE = {
   boxShadow: '0 2px 8px rgba(0,0,0,0.12)',
 };
 
-export function AreaChart({
+export const AreaChart = ({
   data,
   series,
   xAxisKey = 'name',
@@ -57,7 +57,7 @@ export function AreaChart({
   stacked = false,
   gradient = false,
   className,
-}: AreaChartProps) {
+}: AreaChartProps) => {
   const formatNumber = useNumberFormatter().format;
 
   const seriesWithColors = series.map((s, i) => ({
@@ -135,4 +135,4 @@ export function AreaChart({
       </ResponsiveContainer>
     </div>
   );
-}
+};

--- a/packages/charts/src/components/AreaChart/README.md
+++ b/packages/charts/src/components/AreaChart/README.md
@@ -1,0 +1,40 @@
+Area chart built on Recharts with GNOME design tokens, supporting stacked areas and gradient fills.
+
+Each series renders as a filled area beneath a line. Enable `gradient` for a top-to-bottom opacity fade, and `stacked` to accumulate series vertically.
+
+```tsx
+import { AreaChart } from '@gnome-ui/charts';
+
+<AreaChart
+  data={[
+    { week: 'W1', downloads: 320, installs: 210 },
+    { week: 'W2', downloads: 480, installs: 310 },
+  ]}
+  series={[
+    { dataKey: 'downloads', name: 'Downloads' },
+    { dataKey: 'installs', name: 'Installs' },
+  ]}
+  xAxisKey="week"
+  showLegend
+  gradient
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `Record<string, unknown>[]` | — | Array of data points |
+| `series` | `AreaChartSeries[]` | — | Series definitions (`dataKey`, `name?`, `color?`) |
+| `xAxisKey` | `string` | `"name"` | Key used for the x-axis labels |
+| `height` | `number` | `300` | Chart height in px |
+| `showGrid` | `boolean` | `true` | Show horizontal grid lines |
+| `showLegend` | `boolean` | `false` | Show series legend |
+| `stacked` | `boolean` | `false` | Stack areas on top of each other |
+| `gradient` | `boolean` | `false` | Apply top-to-bottom gradient fill |
+
+### Guidelines
+
+- Use when the area beneath the line carries meaning (volume, cumulative counts).
+- `stacked + gradient` works well for dashboards showing part-to-whole relationships.
+- For compact inline use, prefer `SparkAreaChart`.

--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -1,11 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { BarChart } from './BarChart';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof BarChart> = {
   title: 'Charts/BarChart',
   component: BarChart,
-  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: { description: { component: readme } },
+  },
 };
 
 export default meta;

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -45,7 +45,7 @@ const TOOLTIP_CONTENT_STYLE = {
   boxShadow: '0 2px 8px rgba(0,0,0,0.12)',
 };
 
-export function BarChart({
+export const BarChart = ({
   data,
   series,
   xAxisKey = 'name',
@@ -53,7 +53,7 @@ export function BarChart({
   showGrid = true,
   showLegend = false,
   className,
-}: BarChartProps) {
+}: BarChartProps) => {
   const formatNumber = useNumberFormatter().format;
 
   return (
@@ -106,4 +106,4 @@ export function BarChart({
       </ResponsiveContainer>
     </div>
   );
-}
+};

--- a/packages/charts/src/components/BarChart/README.md
+++ b/packages/charts/src/components/BarChart/README.md
@@ -1,0 +1,37 @@
+Bar chart built on Recharts with GNOME design tokens for grouped comparisons across categories.
+
+Renders vertical bars with optional grid lines and a legend for multi-series data.
+
+```tsx
+import { BarChart } from '@gnome-ui/charts';
+
+<BarChart
+  data={[
+    { month: 'Jan', users: 420, sessions: 680 },
+    { month: 'Feb', users: 380, sessions: 590 },
+  ]}
+  series={[
+    { dataKey: 'users', name: 'Users' },
+    { dataKey: 'sessions', name: 'Sessions' },
+  ]}
+  xAxisKey="month"
+  showLegend
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `Record<string, unknown>[]` | — | Array of data points |
+| `series` | `BarChartSeries[]` | — | Series definitions (`dataKey`, `name?`, `color?`) |
+| `xAxisKey` | `string` | `"name"` | Key used for the x-axis labels |
+| `height` | `number` | `300` | Chart height in px |
+| `showGrid` | `boolean` | `true` | Show horizontal grid lines |
+| `showLegend` | `boolean` | `false` | Show series legend |
+
+### Guidelines
+
+- Use for comparing discrete categories (months, items, groups).
+- For compact inline use, prefer `SparkBarChart`.
+- Pass `color` in each series to override the default GNOME palette.

--- a/packages/charts/src/components/CloudChart/CloudChart.stories.tsx
+++ b/packages/charts/src/components/CloudChart/CloudChart.stories.tsx
@@ -1,11 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { CloudChart } from './CloudChart';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof CloudChart> = {
   title: 'Charts/CloudChart',
   component: CloudChart,
-  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: { description: { component: readme } },
+  },
 };
 
 export default meta;

--- a/packages/charts/src/components/CloudChart/CloudChart.tsx
+++ b/packages/charts/src/components/CloudChart/CloudChart.tsx
@@ -17,14 +17,14 @@ export interface CloudChartProps {
   'aria-label'?: string;
 }
 
-export function CloudChart({
+export const CloudChart = ({
   data,
   height = 300,
   minFontSize = 12,
   maxFontSize = 48,
   className,
   'aria-label': ariaLabel,
-}: CloudChartProps) {
+}: CloudChartProps) => {
   const values = data.map((d) => d.value);
   const min = Math.min(...values);
   const max = Math.max(...values);
@@ -61,4 +61,4 @@ export function CloudChart({
       ))}
     </div>
   );
-}
+};

--- a/packages/charts/src/components/CloudChart/README.md
+++ b/packages/charts/src/components/CloudChart/README.md
@@ -1,0 +1,42 @@
+Word/tag cloud that scales each term's font size proportionally to its numeric value.
+
+Font size is linearly interpolated between `minFontSize` and `maxFontSize`. Items with equal values render at the midpoint. Colors cycle through the GNOME chart palette unless overridden per item.
+
+```tsx
+import { CloudChart } from '@gnome-ui/charts';
+
+<CloudChart
+  data={[
+    { text: 'TypeScript', value: 95 },
+    { text: 'React', value: 88 },
+    { text: 'Node.js', value: 76 },
+    { text: 'CSS', value: 70 },
+  ]}
+/>
+```
+
+### Custom colors
+
+```tsx
+<CloudChart
+  data={[
+    { text: 'Accessibility', value: 90, color: 'var(--gnome-blue-3, #3584e4)' },
+    { text: 'Performance', value: 75, color: 'var(--gnome-green-4, #2ec27e)' },
+  ]}
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `CloudChartDataItem[]` | — | `{ text: string; value: number; color?: string }[]` |
+| `height` | `number` | `300` | Minimum container height in px |
+| `minFontSize` | `number` | `12` | Font size for the lowest-value term |
+| `maxFontSize` | `number` | `48` | Font size for the highest-value term |
+
+### Guidelines
+
+- Use for keyword frequency, tag weights, or skill matrices.
+- Narrow the font range (`minFontSize=14, maxFontSize=28`) for more uniform visual weight.
+- The cloud wraps naturally — the container grows vertically if terms overflow.

--- a/packages/charts/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.stories.tsx
@@ -1,11 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { LineChart } from './LineChart';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof LineChart> = {
   title: 'Charts/LineChart',
   component: LineChart,
-  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: { description: { component: readme } },
+  },
 };
 
 export default meta;

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -45,7 +45,7 @@ const TOOLTIP_CONTENT_STYLE = {
   boxShadow: '0 2px 8px rgba(0,0,0,0.12)',
 };
 
-export function LineChart({
+export const LineChart = ({
   data,
   series,
   xAxisKey = 'name',
@@ -53,7 +53,7 @@ export function LineChart({
   showGrid = true,
   showLegend = false,
   className,
-}: LineChartProps) {
+}: LineChartProps) => {
   const formatNumber = useNumberFormatter().format;
 
   return (
@@ -108,4 +108,4 @@ export function LineChart({
       </ResponsiveContainer>
     </div>
   );
-}
+};

--- a/packages/charts/src/components/LineChart/README.md
+++ b/packages/charts/src/components/LineChart/README.md
@@ -1,0 +1,37 @@
+Line chart built on Recharts with GNOME design tokens for axes, grid, and tooltips.
+
+Supports multiple series rendered as colored lines, an optional horizontal grid, and a legend.
+
+```tsx
+import { LineChart } from '@gnome-ui/charts';
+
+<LineChart
+  data={[
+    { day: 'Mon', cpu: 42, memory: 68 },
+    { day: 'Tue', cpu: 58, memory: 72 },
+  ]}
+  series={[
+    { dataKey: 'cpu', name: 'CPU %' },
+    { dataKey: 'memory', name: 'Memory %' },
+  ]}
+  xAxisKey="day"
+  showLegend
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `Record<string, unknown>[]` | — | Array of data points |
+| `series` | `LineChartSeries[]` | — | Series definitions (`dataKey`, `name?`, `color?`) |
+| `xAxisKey` | `string` | `"name"` | Key used for the x-axis labels |
+| `height` | `number` | `300` | Chart height in px |
+| `showGrid` | `boolean` | `true` | Show horizontal grid lines |
+| `showLegend` | `boolean` | `false` | Show series legend |
+
+### Guidelines
+
+- Use for continuous data over time (metrics, trends, telemetry).
+- Pass `color` in each series to override the default GNOME palette.
+- For compact inline use, prefer `SparkLineChart`.

--- a/packages/charts/src/components/PieChart/PieChart.stories.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.stories.tsx
@@ -1,11 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { PieChart } from './PieChart';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof PieChart> = {
   title: 'Charts/PieChart',
   component: PieChart,
-  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: { description: { component: readme } },
+  },
 };
 
 export default meta;

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -39,14 +39,14 @@ const TOOLTIP_CONTENT_STYLE = {
 
 const RADIAN = Math.PI / 180;
 
-function SliceLabel(props: {
+const SliceLabel = (props: {
   cx?: number;
   cy?: number;
   midAngle?: number;
   outerRadius?: number;
   name?: string;
   percent?: number;
-}) {
+}) => {
   const { cx, cy, midAngle, outerRadius, name, percent } = props;
 
   if (
@@ -82,9 +82,9 @@ function SliceLabel(props: {
       {name}
     </text>
   );
-}
+};
 
-export function PieChart({
+export const PieChart = ({
   data,
   height = 400,
   donut = false,
@@ -92,7 +92,7 @@ export function PieChart({
   showLegend = false,
   className,
   'aria-label': ariaLabel,
-}: PieChartProps) {
+}: PieChartProps) => {
   const formatNumber = useNumberFormatter().format;
 
   const chartData = data.map((item, i) => ({
@@ -149,4 +149,4 @@ export function PieChart({
       </ResponsiveContainer>
     </div>
   );
-}
+};

--- a/packages/charts/src/components/PieChart/README.md
+++ b/packages/charts/src/components/PieChart/README.md
@@ -1,0 +1,33 @@
+Pie and donut chart built on Recharts for part-to-whole comparisons.
+
+Each data item maps to a slice. Enable `donut` to render a ring with a hollow center, `showLabels` to add percentage labels outside each slice, and `showLegend` for a color key.
+
+```tsx
+import { PieChart } from '@gnome-ui/charts';
+
+<PieChart
+  data={[
+    { label: 'Chrome', value: 62 },
+    { label: 'Firefox', value: 18 },
+    { label: 'Safari', value: 11 },
+  ]}
+  donut
+  showLegend
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `PieChartDataItem[]` | — | `{ label: string; value: number; color?: string }[]` |
+| `height` | `number` | `300` | Chart height in px |
+| `donut` | `boolean` | `false` | Render as donut (hollow center) |
+| `showLabels` | `boolean` | `false` | Show percentage labels outside slices |
+| `showLegend` | `boolean` | `false` | Show color legend |
+
+### Guidelines
+
+- Use donut mode when you want to add a central summary value via a custom overlay.
+- Slices smaller than 4 % suppress their label automatically to avoid clutter.
+- Pass `color` per item to use brand or semantic colors (success, error, warning).

--- a/packages/charts/src/components/RadarChart/README.md
+++ b/packages/charts/src/components/RadarChart/README.md
@@ -1,0 +1,38 @@
+Radar (spider) chart built on Recharts for comparing multiple attributes across one or more subjects.
+
+Each axis corresponds to a dimension in the data; each series traces a polygon across those axes. Enable `filled` to shade the polygon interior.
+
+```tsx
+import { RadarChart } from '@gnome-ui/charts';
+
+<RadarChart
+  data={[
+    { skill: 'TypeScript', alice: 90, bob: 70 },
+    { skill: 'React', alice: 85, bob: 80 },
+    { skill: 'CSS', alice: 60, bob: 75 },
+  ]}
+  series={[
+    { dataKey: 'alice', name: 'Alice' },
+    { dataKey: 'bob', name: 'Bob' },
+  ]}
+  angleKey="skill"
+  filled
+  showLegend
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `Record<string, unknown>[]` | — | Array of data points |
+| `series` | `RadarChartSeries[]` | — | Series definitions (`dataKey`, `name?`, `color?`) |
+| `angleKey` | `string` | `"name"` | Key for the angular dimension labels |
+| `height` | `number` | `400` | Chart height in px |
+| `filled` | `boolean` | `false` | Fill the polygon with a semi-transparent color |
+| `showLegend` | `boolean` | `false` | Show series legend |
+
+### Guidelines
+
+- Best with 3–8 axes. Too many axes make labels unreadable.
+- Use `filled` for single-subject charts; unfilled for multi-subject comparisons to avoid overlap.

--- a/packages/charts/src/components/RadarChart/RadarChart.stories.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.stories.tsx
@@ -1,11 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { RadarChart } from './RadarChart';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof RadarChart> = {
   title: 'Charts/RadarChart',
   component: RadarChart,
-  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: { description: { component: readme } },
+  },
 };
 
 export default meta;

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -45,7 +45,7 @@ const TOOLTIP_CONTENT_STYLE = {
   boxShadow: '0 2px 8px rgba(0,0,0,0.12)',
 };
 
-export function RadarChart({
+export const RadarChart = ({
   data,
   series,
   angleKey = 'name',
@@ -54,7 +54,7 @@ export function RadarChart({
   showLegend = false,
   className,
   'aria-label': ariaLabel,
-}: RadarChartProps) {
+}: RadarChartProps) => {
   return (
     <div
       role="img"
@@ -97,4 +97,4 @@ export function RadarChart({
       </ResponsiveContainer>
     </div>
   );
-}
+};

--- a/packages/charts/src/components/RadialBarChart/README.md
+++ b/packages/charts/src/components/RadialBarChart/README.md
@@ -1,0 +1,45 @@
+Radial bar chart built on Recharts. Each data item renders as a circular arc, useful for showing multiple metrics as circular progress rings.
+
+Enable `showLabels` to overlay category names on each arc, and `showLegend` for a color key. Increase `innerRadius` to create a donut-like gap at the center.
+
+```tsx
+import { RadialBarChart } from '@gnome-ui/charts';
+
+<RadialBarChart
+  data={[
+    { label: 'CPU', value: 72 },
+    { label: 'Memory', value: 58 },
+    { label: 'Disk', value: 41 },
+  ]}
+  showLegend
+/>
+```
+
+### Custom colors
+
+```tsx
+<RadialBarChart
+  data={[
+    { label: 'Completed', value: 90, color: 'var(--gnome-green-4, #2ec27e)' },
+    { label: 'In Progress', value: 60, color: 'var(--gnome-blue-3, #3584e4)' },
+    { label: 'Blocked', value: 25, color: 'var(--gnome-red-3, #e01b24)' },
+  ]}
+  showLabels
+  showLegend
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `RadialBarChartDataItem[]` | — | `{ label: string; value: number; color?: string }[]` |
+| `height` | `number` | `300` | Chart height in px |
+| `innerRadius` | `number \| string` | — | Inner radius of arcs (e.g. `"40%"`) |
+| `showLabels` | `boolean` | `false` | Overlay category labels on arcs |
+| `showLegend` | `boolean` | `false` | Show color legend |
+
+### Guidelines
+
+- Values are treated as percentages (0–100) — pass normalized numbers.
+- Use semantic colors per item for status dashboards (green/red/yellow).

--- a/packages/charts/src/components/RadialBarChart/RadialBarChart.stories.tsx
+++ b/packages/charts/src/components/RadialBarChart/RadialBarChart.stories.tsx
@@ -1,11 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { RadialBarChart } from './RadialBarChart';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof RadialBarChart> = {
   title: 'Charts/RadialBarChart',
   component: RadialBarChart,
-  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: { description: { component: readme } },
+  },
 };
 
 export default meta;

--- a/packages/charts/src/components/RadialBarChart/RadialBarChart.tsx
+++ b/packages/charts/src/components/RadialBarChart/RadialBarChart.tsx
@@ -35,14 +35,14 @@ const TOOLTIP_CONTENT_STYLE = {
   boxShadow: '0 2px 8px rgba(0,0,0,0.12)',
 };
 
-function ArcLabel(props: {
+const ArcLabel = (props: {
   cx?: number;
   cy?: number;
   midAngle?: number;
   innerRadius?: number;
   outerRadius?: number;
   name?: string;
-}) {
+}) => {
   const { cx, cy, midAngle, innerRadius, outerRadius, name } = props;
 
   if (
@@ -78,9 +78,9 @@ function ArcLabel(props: {
       {name}
     </text>
   );
-}
+};
 
-export function RadialBarChart({
+export const RadialBarChart = ({
   data,
   height = 400,
   innerRadius = '20%',
@@ -88,7 +88,7 @@ export function RadialBarChart({
   showLegend = false,
   className,
   'aria-label': ariaLabel,
-}: RadialBarChartProps) {
+}: RadialBarChartProps) => {
   const chartData = data.map((item, i) => ({
     name: item.label,
     value: item.value,
@@ -132,4 +132,4 @@ export function RadialBarChart({
       </ResponsiveContainer>
     </div>
   );
-}
+};

--- a/packages/charts/src/components/SparkAreaChart/SparkAreaChart.tsx
+++ b/packages/charts/src/components/SparkAreaChart/SparkAreaChart.tsx
@@ -30,7 +30,7 @@ function normalize(data: SparkData, key: string): Record<string, unknown>[] {
     : (data as Record<string, unknown>[]);
 }
 
-export function SparkAreaChart({
+export const SparkAreaChart = ({
   data,
   dataKey = 'value',
   color = 'var(--gnome-accent-color, #3584e4)',
@@ -40,7 +40,7 @@ export function SparkAreaChart({
   fillOpacity = 0.2,
   className,
   'aria-label': ariaLabel,
-}: SparkAreaChartProps) {
+}: SparkAreaChartProps) => {
   const normalized = normalize(data, dataKey);
   const gradId = `spark-area-${dataKey}`;
 
@@ -76,4 +76,4 @@ export function SparkAreaChart({
       </ResponsiveContainer>
     </div>
   );
-}
+};

--- a/packages/charts/src/components/SparkBarChart/SparkBarChart.tsx
+++ b/packages/charts/src/components/SparkBarChart/SparkBarChart.tsx
@@ -28,7 +28,7 @@ function normalize(data: SparkData, key: string): Record<string, unknown>[] {
     : (data as Record<string, unknown>[]);
 }
 
-export function SparkBarChart({
+export const SparkBarChart = ({
   data,
   dataKey = 'value',
   color = 'var(--gnome-accent-color, #3584e4)',
@@ -37,7 +37,7 @@ export function SparkBarChart({
   fillOpacity = 0.85,
   className,
   'aria-label': ariaLabel,
-}: SparkBarChartProps) {
+}: SparkBarChartProps) => {
   const normalized = normalize(data, dataKey);
 
   return (
@@ -69,4 +69,4 @@ export function SparkBarChart({
       </ResponsiveContainer>
     </div>
   );
-}
+};

--- a/packages/charts/src/components/SparkLineChart/SparkLineChart.tsx
+++ b/packages/charts/src/components/SparkLineChart/SparkLineChart.tsx
@@ -26,7 +26,7 @@ function normalize(data: SparkData, key: string): Record<string, unknown>[] {
     : (data as Record<string, unknown>[]);
 }
 
-export function SparkLineChart({
+export const SparkLineChart = ({
   data,
   dataKey = 'value',
   color = 'var(--gnome-accent-color, #3584e4)',
@@ -34,7 +34,7 @@ export function SparkLineChart({
   strokeWidth = 1.5,
   className,
   'aria-label': ariaLabel,
-}: SparkLineChartProps) {
+}: SparkLineChartProps) => {
   const normalized = normalize(data, dataKey);
 
   return (
@@ -59,4 +59,4 @@ export function SparkLineChart({
       </ResponsiveContainer>
     </div>
   );
-}
+};

--- a/packages/charts/src/components/TreeMap/README.md
+++ b/packages/charts/src/components/TreeMap/README.md
@@ -1,0 +1,41 @@
+Tree map built on Recharts. Displays hierarchical data as nested rectangles; area is proportional to each item's value.
+
+Items with the same `group` share a color. Items without a `group` are colored individually.
+
+```tsx
+import { TreeMap } from '@gnome-ui/charts';
+
+// Flat (no grouping)
+<TreeMap
+  data={[
+    { label: 'React', value: 4200 },
+    { label: 'Vue', value: 2100 },
+    { label: 'Angular', value: 1800 },
+  ]}
+  height={400}
+/>
+
+// Grouped
+<TreeMap
+  data={[
+    { label: 'React', value: 4200, group: 'Frontend' },
+    { label: 'Node.js', value: 3800, group: 'Backend' },
+    { label: 'Python', value: 5100, group: 'Backend' },
+  ]}
+  height={400}
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `TreeMapDataItem[]` | — | `{ label: string; value: number; group?: string }[]` |
+| `height` | `number` | — | Chart height in px |
+| `showLabels` | `boolean` | `true` | Show label + value inside each tile |
+
+### Guidelines
+
+- Labels are suppressed automatically on tiles narrower than 40 px or shorter than 24 px.
+- Use grouping to cluster related items under a shared color.
+- Best for showing relative proportions in a space-efficient way (file sizes, budget breakdowns).

--- a/packages/charts/src/components/TreeMap/TreeMap.stories.tsx
+++ b/packages/charts/src/components/TreeMap/TreeMap.stories.tsx
@@ -1,11 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import { TreeMap } from './TreeMap';
 
 const meta: Meta<typeof TreeMap> = {
   title: 'Charts/TreeMap',
   component: TreeMap,
-  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: { description: { component: readme } },
+  },
 };
 
 export default meta;

--- a/packages/charts/src/components/TreeMap/TreeMap.tsx
+++ b/packages/charts/src/components/TreeMap/TreeMap.tsx
@@ -55,7 +55,7 @@ interface TileProps {
   formatNumber: (value: number) => string;
 }
 
-function Tile({
+const Tile = ({
   x,
   y,
   width,
@@ -66,7 +66,7 @@ function Tile({
   colorMap,
   showLabels,
   formatNumber,
-}: TileProps) {
+}: TileProps) => {
   const colorKey = group ?? name;
   const fill = colorMap.get(colorKey) ?? GNOME_CHART_PALETTE[0];
   const showText = showLabels && width > 40 && height > 24;
@@ -118,9 +118,9 @@ function Tile({
       )}
     </g>
   );
-}
+};
 
-export function TreeMap({ data, height = 400, showLabels = true, className }: TreeMapProps) {
+export const TreeMap = ({ data, height = 400, showLabels = true, className }: TreeMapProps) => {
   const formatNumber = useNumberFormatter().format;
 
   const colorMap = buildColorMap(data);
@@ -163,4 +163,4 @@ export function TreeMap({ data, height = 400, showLabels = true, className }: Tr
       </ResponsiveContainer>
     </div>
   );
-}
+};

--- a/packages/charts/tsconfig.json
+++ b/packages/charts/tsconfig.json
@@ -7,6 +7,6 @@
     }
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "src/**/*.stories.tsx"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -91,7 +91,7 @@
     "jsdom": "^29.0.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "vite": "^8.0.3",
+    "vite": "^8.0.16",
     "vite-magic-tree-shaking": "^1.0.0",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.1.4"

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,11 +1,5 @@
-export * from './useBreakpoint';
-export * from './useClipboard';
-export * from './useColorScheme';
-export * from './useFileChooser';
-export * from './useHapticFeedback';
-export * from './useNativeEvent';
-export * from './useNotification';
-export * from './usePlatform';
-export * from './useRuntime';
-export * from './useSettings';
-export * from './useWindowState';
+export { type BreakpointInfo, useBreakpoint } from './useBreakpoint';
+export { useNativeEvent } from './useNativeEvent';
+export { type GnomeHapticEvent, type UseHapticFeedbackResult, useHapticFeedback } from './useHapticFeedback';
+export { type PlatformInfo, usePlatform } from './usePlatform';
+export { useRuntime } from './useRuntime';

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,5 +1,9 @@
 export { type BreakpointInfo, useBreakpoint } from './useBreakpoint';
+export {
+  type GnomeHapticEvent,
+  type UseHapticFeedbackResult,
+  useHapticFeedback,
+} from './useHapticFeedback';
 export { useNativeEvent } from './useNativeEvent';
-export { type GnomeHapticEvent, type UseHapticFeedbackResult, useHapticFeedback } from './useHapticFeedback';
 export { type PlatformInfo, usePlatform } from './usePlatform';
 export { useRuntime } from './useRuntime';

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -58,7 +58,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "storybook": "^10.3.3",
-    "vite": "^8.0.3",
+    "vite": "^8.0.16",
     "vite-magic-tree-shaking": "^1.0.0",
     "vite-plugin-dts": "^4.5.4"
   },

--- a/packages/icons/src/Icons.stories.tsx
+++ b/packages/icons/src/Icons.stories.tsx
@@ -12,7 +12,7 @@ interface IconProps {
   color?: string;
 }
 
-function Icon({ icon, size = 16, color = 'currentColor' }: IconProps) {
+const Icon = ({ icon, size = 16, color = 'currentColor' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -27,7 +27,7 @@ function Icon({ icon, size = 16, color = 'currentColor' }: IconProps) {
       ))}
     </svg>
   );
-}
+};
 
 // ─── Gallery component ────────────────────────────────────────────────────────
 
@@ -63,7 +63,7 @@ interface GalleryProps {
   surface: 'light' | 'dark';
 }
 
-function Gallery({ size, color, filter, surface }: GalleryProps) {
+const Gallery = ({ size, color, filter, surface }: GalleryProps) => {
   const filtered = filter
     ? iconEntries.filter(([name]) => name.toLowerCase().includes(filter.toLowerCase()))
     : iconEntries;
@@ -123,9 +123,9 @@ function Gallery({ size, color, filter, surface }: GalleryProps) {
       </div>
     </div>
   );
-}
+};
 
-function EntryGrid({
+const EntryGrid = ({
   entries,
   size,
   color,
@@ -133,7 +133,7 @@ function EntryGrid({
   entries: [string, IconDefinition][];
   size: number;
   color: string;
-}) {
+}) => {
   return (
     <div
       style={{
@@ -172,7 +172,7 @@ function EntryGrid({
       ))}
     </div>
   );
-}
+};
 
 // ─── Meta ─────────────────────────────────────────────────────────────────────
 
@@ -305,7 +305,7 @@ const categories: Record<string, string[]> = {
   ...githubOcticonCategories,
 };
 
-function CategoryGrid({
+const CategoryGrid = ({
   category,
   size,
   color,
@@ -313,7 +313,7 @@ function CategoryGrid({
   category: string;
   size: number;
   color: string;
-}) {
+}) => {
   const names = categories[category] ?? [];
   const entries = names
     .map((n) => [n, (icons as Record<string, IconDefinition>)[n]] as [string, IconDefinition])
@@ -352,9 +352,9 @@ function CategoryGrid({
       </div>
     </div>
   );
-}
+};
 
-function SectionedCategoryGrid({
+const SectionedCategoryGrid = ({
   title,
   groups,
   size,
@@ -364,7 +364,7 @@ function SectionedCategoryGrid({
   groups: Record<string, string[]>;
   size: number;
   color: string;
-}) {
+}) => {
   return (
     <div style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
       <h2 style={{ marginBottom: '1.25rem', fontSize: '1rem', color: '#333' }}>{title}</h2>
@@ -411,7 +411,7 @@ function SectionedCategoryGrid({
       </div>
     </div>
   );
-}
+};
 
 export const AdwaitaSymbolicIcons: Story = {
   name: 'Adwaita Symbolic',

--- a/packages/icons/src/Icons.stories.tsx
+++ b/packages/icons/src/Icons.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import * as icons from './icons/index.ts';
+import readme from './README.md?raw';
 import * as thirdParty from './third-party/index.ts';
 import type { IconDefinition } from './types.ts';
 
@@ -183,8 +184,7 @@ const meta = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component:
-          '`@gnome-ui/icons` exports framework-agnostic icon definitions. The main gallery separates Adwaita-style symbolic icons from GitHub Octicons and third-party brand/fullcolor previews.',
+        component: readme,
       },
     },
   },

--- a/packages/icons/src/README.md
+++ b/packages/icons/src/README.md
@@ -1,0 +1,36 @@
+`@gnome-ui/icons` exports framework-agnostic icon definitions. The main gallery separates Adwaita-style symbolic icons from GitHub Octicons and third-party brand/fullcolor previews.
+
+Each icon is an `IconDefinition` object (a set of SVG paths + viewBox). Pass it to `<Icon>` from `@gnome-ui/react`, or render it directly with any SVG renderer.
+
+```tsx
+import { Search, Settings } from '@gnome-ui/icons';
+import { Icon } from '@gnome-ui/react';
+
+<Icon icon={Search} size="md" />
+<Icon icon={Settings} size="lg" aria-label="Settings" />
+```
+
+### Icon families
+
+| Family | Import path | Count |
+|--------|-------------|-------|
+| Adwaita Symbolic | `@gnome-ui/icons` | 600+ |
+| GitHub Octicons (version control) | `@gnome-ui/icons` | 20 |
+| Third-party brand marks | `@gnome-ui/icons` | 5 (GitHub, GitLab, Bitbucket, X, npm) |
+
+### Third-party brand icons
+
+Brand marks follow the same `IconDefinition` shape and can be used with `<Icon>`. They are single-color glyphs — pass a `color` prop or style them with CSS.
+
+```tsx
+import { GitHub, GitLab, Npm } from '@gnome-ui/icons';
+import { Icon } from '@gnome-ui/react';
+
+<Icon icon={GitHub} size="md" color="#24292f" />
+```
+
+### Guidelines
+
+- Import only the icons you use — the package is tree-shakeable.
+- Use `aria-label` on `<Icon>` when the icon conveys meaning not available from surrounding context.
+- Pass `aria-hidden` when the icon is decorative and a sibling text label is present.

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -4,6 +4,6 @@
     "baseUrl": "."
   },
   "include": ["src"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -187,7 +187,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "storybook": "^10.3.3",
-    "vite": "^8.0.3",
+    "vite": "^8.0.16",
     "vite-magic-tree-shaking": "^1.0.0",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.1.4"

--- a/packages/layout/src/components/ActivityFeed/ActivityFeed.stories.tsx
+++ b/packages/layout/src/components/ActivityFeed/ActivityFeed.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ActivityFeed } from './ActivityFeed';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ActivityFeed> = {
   title: 'Layout/ActivityFeed',
@@ -10,21 +11,7 @@ const meta: Meta<typeof ActivityFeed> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Chronological list of recent events with relative timestamps, optional icons,
-skeleton loading state, and a "Show more" affordance.
-
-\`\`\`tsx
-import { ActivityFeed } from "@gnome-ui/layout";
-
-<ActivityFeed
-  items={[
-    { id: "1", label: "File uploaded", timestamp: new Date() },
-  ]}
-  maxItems={5}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/packages/layout/src/components/ActivityFeed/ActivityFeed.test.tsx
@@ -73,7 +73,9 @@ describe('ActivityFeed', () => {
 
   describe('timestamps', () => {
     it("shows 'now' for timestamps under 1 minute ago", () => {
-      renderWithLocale(<ActivityFeed items={[makeItem({ timestamp: new Date(NOW.getTime() - 30_000) })]} />);
+      renderWithLocale(
+        <ActivityFeed items={[makeItem({ timestamp: new Date(NOW.getTime() - 30_000) })]} />,
+      );
       expect(screen.getByText('now')).toBeInTheDocument();
     });
 
@@ -85,7 +87,9 @@ describe('ActivityFeed', () => {
     });
 
     it("shows singular 'minute' for exactly 1 minute ago", () => {
-      renderWithLocale(<ActivityFeed items={[makeItem({ timestamp: new Date(NOW.getTime() - 60_000) })]} />);
+      renderWithLocale(
+        <ActivityFeed items={[makeItem({ timestamp: new Date(NOW.getTime() - 60_000) })]} />,
+      );
       expect(screen.getByText('1 minute ago')).toBeInTheDocument();
     });
 

--- a/packages/layout/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/packages/layout/src/components/ActivityFeed/ActivityFeed.tsx
@@ -59,7 +59,7 @@ const SKELETON_COUNT = 4;
  *   maxItems={5}
  * />
  */
-export function ActivityFeed({
+export const ActivityFeed = ({
   items,
   maxItems,
   loading = false,
@@ -67,7 +67,7 @@ export function ActivityFeed({
   emptyState,
   className,
   ...props
-}: ActivityFeedProps) {
+}: ActivityFeedProps) => {
   const [expanded, setExpanded] = useState(false);
   const locale = useLocale();
   const rtf = useMemo(() => new Intl.RelativeTimeFormat(locale, { numeric: 'auto' }), [locale]);
@@ -158,4 +158,4 @@ export function ActivityFeed({
       )}
     </div>
   );
-}
+};

--- a/packages/layout/src/components/ActivityFeed/README.md
+++ b/packages/layout/src/components/ActivityFeed/README.md
@@ -1,0 +1,13 @@
+Chronological list of recent events with relative timestamps, optional icons,
+skeleton loading state, and a "Show more" affordance.
+
+```tsx
+import { ActivityFeed } from "@gnome-ui/layout";
+
+<ActivityFeed
+  items={[
+    { id: "1", label: "File uploaded", timestamp: new Date() },
+  ]}
+  maxItems={5}
+/>
+```

--- a/packages/layout/src/components/AdaptiveLayout/AdaptiveLayout.stories.tsx
+++ b/packages/layout/src/components/AdaptiveLayout/AdaptiveLayout.stories.tsx
@@ -16,6 +16,7 @@ import { UserCard } from '../UserCard';
 
 import type { AdaptiveNavItem, GnomeColor, GnomeColorShade } from './AdaptiveLayout';
 import { AdaptiveLayout } from './AdaptiveLayout';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof AdaptiveLayout> = {
   title: 'Adaptive/AdaptiveLayout',
@@ -63,22 +64,7 @@ const meta: Meta<typeof AdaptiveLayout> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Full-page adaptive shell that switches navigation automatically based on viewport width.
-Use the **viewport toolbar** to preview each breakpoint:
-
-- **Mobile** (< 480 px): \`ViewSwitcherBar\` pinned at the bottom.
-- **Tablet** (480–1023 px): \`ViewSwitcherSidebar\` collapsed to icon-only.
-- **Desktop** (≥ 1024 px): \`ViewSwitcherSidebar\` expanded with labels.
-
-Pass \`sidebarHeader\` for the user card (expanded) and \`sidebarHeaderCollapsed\`
-for the avatar-only version (collapsed). Grouped items (\`group\` field) become
-sidebar sections on tablet/desktop and a single slot + \`BottomSheet\` on mobile.
-When mobile bar slots exceed 4, the first 3 are shown and a **More** button handles
-the rest.
-
-Use \`bgColor\`, \`bgShade\` (1–5), and \`bgOpacity\` (0–1) to tint the shell background.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/AdaptiveLayout/AdaptiveLayout.tsx
+++ b/packages/layout/src/components/AdaptiveLayout/AdaptiveLayout.tsx
@@ -150,7 +150,7 @@ type BarSlot = ItemSlot | GroupSlot;
  * Mobile overflow: when there are more than 4 bar slots the first 3 are shown
  * and a "More" button opens a `BottomSheet` for the rest.
  */
-export function AdaptiveLayout({
+export const AdaptiveLayout = ({
   items,
   value,
   onValueChange,
@@ -170,7 +170,7 @@ export function AdaptiveLayout({
   showHeaderSeparator = true,
   showCollapseButtonSeparator = false,
   showFooterSeparator = true,
-}: AdaptiveLayoutProps) {
+}: AdaptiveLayoutProps) => {
   const { isMobile, isTablet } = useBreakpoint();
   const [userCollapsed, setUserCollapsed] = useState<boolean | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
@@ -442,4 +442,4 @@ export function AdaptiveLayout({
       </div>
     </div>
   );
-}
+};

--- a/packages/layout/src/components/AdaptiveLayout/README.md
+++ b/packages/layout/src/components/AdaptiveLayout/README.md
@@ -1,0 +1,14 @@
+Full-page adaptive shell that switches navigation automatically based on viewport width.
+Use the **viewport toolbar** to preview each breakpoint:
+
+- **Mobile** (< 480 px): `ViewSwitcherBar` pinned at the bottom.
+- **Tablet** (480–1023 px): `ViewSwitcherSidebar` collapsed to icon-only.
+- **Desktop** (≥ 1024 px): `ViewSwitcherSidebar` expanded with labels.
+
+Pass `sidebarHeader` for the user card (expanded) and `sidebarHeaderCollapsed`
+for the avatar-only version (collapsed). Grouped items (`group` field) become
+sidebar sections on tablet/desktop and a single slot + `BottomSheet` on mobile.
+When mobile bar slots exceed 4, the first 3 are shown and a **More** button handles
+the rest.
+
+Use `bgColor`, `bgShade` (1–5), and `bgOpacity` (0–1) to tint the shell background.

--- a/packages/layout/src/components/AppHeader/AppHeader.stories.tsx
+++ b/packages/layout/src/components/AppHeader/AppHeader.stories.tsx
@@ -6,6 +6,7 @@ import { PageContent } from '../PageContent';
 import { StatusBar } from '../StatusBar';
 
 import { AppHeader } from './AppHeader';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof AppHeader> = {
   title: 'Layout/AppHeader',
@@ -14,7 +15,7 @@ const meta: Meta<typeof AppHeader> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: 'GNOME application header with named shell slots.',
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/AppHeader/AppHeader.tsx
+++ b/packages/layout/src/components/AppHeader/AppHeader.tsx
@@ -27,7 +27,7 @@ export interface AppHeaderProps extends Omit<HTMLAttributes<HTMLElement>, 'title
  * map cleanly to application structure: leading controls, title, navigation,
  * search, and trailing actions.
  */
-export function AppHeader({
+export const AppHeader = ({
   title,
   subtitle,
   leading,
@@ -37,7 +37,7 @@ export function AppHeader({
   flat = false,
   className,
   ...props
-}: AppHeaderProps) {
+}: AppHeaderProps) => {
   const titleNode =
     typeof title === 'string' ? <WindowTitle title={title} subtitle={subtitle} /> : title;
 
@@ -67,4 +67,4 @@ export function AppHeader({
       {...props}
     />
   );
-}
+};

--- a/packages/layout/src/components/AppHeader/README.md
+++ b/packages/layout/src/components/AppHeader/README.md
@@ -1,0 +1,47 @@
+GNOME application header with named shell slots.
+
+Mirrors `AdwHeaderBar` — renders a sticky top bar with `leading`, `title`/`subtitle`, `navigation`, `search`, and `actions` slots. Place at the top of `Layout` or directly in a page shell.
+
+```tsx
+import { AppHeader } from '@gnome-ui/layout';
+import { Button, SearchBar } from '@gnome-ui/react';
+
+<AppHeader
+  title="Files"
+  subtitle="Home"
+  leading={<Button variant="flat" aria-label="Toggle sidebar">☰</Button>}
+  actions={<Button variant="flat">New Folder</Button>}
+/>
+```
+
+### With navigation and search
+
+```tsx
+<AppHeader
+  title="Documents"
+  navigation={
+    <ViewSwitcher aria-label="Document view">
+      <ViewSwitcherItem label="Recent" active />
+      <ViewSwitcherItem label="Starred" />
+    </ViewSwitcher>
+  }
+  search={<SearchBar inline open placeholder="Search documents" aria-label="Search documents" />}
+/>
+```
+
+### Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `title` | `string` | Primary window/page title |
+| `subtitle` | `string` | Secondary label shown below title |
+| `leading` | `ReactNode` | Left slot (back button, sidebar trigger) |
+| `navigation` | `ReactNode` | Center slot (view switcher, tabs) |
+| `search` | `ReactNode` | Inline search bar |
+| `actions` | `ReactNode` | Right slot (action buttons, menu) |
+
+### Guidelines
+
+- Use `SidebarTrigger` in the `leading` slot to wire sidebar collapse/open.
+- Place `ViewSwitcher` in `navigation` for multi-view apps.
+- Avoid putting more than 2–3 actions in the `actions` slot; use a menu for overflow.

--- a/packages/layout/src/components/ApplicationCard/ApplicationCard.stories.tsx
+++ b/packages/layout/src/components/ApplicationCard/ApplicationCard.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { IconBadge } from '../IconBadge';
 
 import { ApplicationCard } from './ApplicationCard';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ApplicationCard> = {
   title: 'Layout/ApplicationCard',
@@ -13,26 +14,7 @@ const meta: Meta<typeof ApplicationCard> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-App detail header with avatar, name, badge, description, stat row, and actions.
-Designed for the MyApps \`AppDetail\` view — use \`EntityCard\` for list rows.
-
-\`\`\`tsx
-import { ApplicationCard } from "@gnome-ui/layout";
-
-<ApplicationCard
-  avatar={<IconBadge color="blue" size="xl">⛅</IconBadge>}
-  name="GNOME Weather"
-  badge={<StatusBadge variant="success">published</StatusBadge>}
-  description="The official weather app for the GNOME desktop."
-  stats={[
-    { label: "Version", value: "v4.8.1" },
-    { label: "Builds",  value: "24" },
-  ]}
-  actions={<Button variant="suggested">New Release</Button>}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/packages/layout/src/components/ApplicationCard/ApplicationCard.tsx
@@ -29,7 +29,7 @@ export interface ApplicationCardProps extends HTMLAttributes<HTMLDivElement> {
   loadingType?: LoadingType;
 }
 
-export function ApplicationCard({
+export const ApplicationCard = ({
   avatar,
   name,
   badge,
@@ -40,7 +40,7 @@ export function ApplicationCard({
   loadingType = 'skeleton',
   className,
   ...props
-}: ApplicationCardProps) {
+}: ApplicationCardProps) => {
   if (loading) {
     const cardClass = [styles.card, className].filter(Boolean).join(' ');
 
@@ -114,4 +114,4 @@ export function ApplicationCard({
       {actions && <div className={styles.actions}>{actions}</div>}
     </Card>
   );
-}
+};

--- a/packages/layout/src/components/ApplicationCard/README.md
+++ b/packages/layout/src/components/ApplicationCard/README.md
@@ -1,0 +1,18 @@
+App detail header with avatar, name, badge, description, stat row, and actions.
+Designed for the MyApps `AppDetail` view — use `EntityCard` for list rows.
+
+```tsx
+import { ApplicationCard } from "@gnome-ui/layout";
+
+<ApplicationCard
+  avatar={<IconBadge color="blue" size="xl">⛅</IconBadge>}
+  name="GNOME Weather"
+  badge={<StatusBadge variant="success">published</StatusBadge>}
+  description="The official weather app for the GNOME desktop."
+  stats={[
+    { label: "Version", value: "v4.8.1" },
+    { label: "Builds",  value: "24" },
+  ]}
+  actions={<Button variant="suggested">New Release</Button>}
+/>
+```

--- a/packages/layout/src/components/Banner/Banner.stories.tsx
+++ b/packages/layout/src/components/Banner/Banner.stories.tsx
@@ -81,7 +81,7 @@ export const WithAction: Story = {
 
 export const Dismissible: Story = {
   render: () => {
-    function Demo() {
+    const Demo = () => {
       const [visible, setVisible] = useState(true);
 
       if (!visible) {
@@ -101,7 +101,7 @@ export const Dismissible: Story = {
           A new version of this app is available.
         </Banner>
       );
-    }
+    };
 
     return <Demo />;
   },

--- a/packages/layout/src/components/Banner/Banner.stories.tsx
+++ b/packages/layout/src/components/Banner/Banner.stories.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import type { BannerType } from './Banner';
 import { Banner } from './Banner';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Banner> = {
   title: 'Layout/Banner',
@@ -12,20 +13,7 @@ const meta: Meta<typeof Banner> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Persistent in-app message strip shown at the top of a view, following GNOME HIG banner guidelines.
-
-Use banners to communicate **ongoing states** — offline mode, read-only access, pending updates.
-They do not auto-dismiss. For individual events and short-lived messages, use \`Toast\` instead.
-
-\`\`\`tsx
-import { Banner } from "@gnome-ui/layout";
-
-<Banner type="warning" action={{ label: "Reconnect", onClick: retry }}>
-  Working offline — changes will sync when you reconnect
-</Banner>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/Banner/Banner.tsx
+++ b/packages/layout/src/components/Banner/Banner.tsx
@@ -40,14 +40,14 @@ const TYPE_ARIA: Record<BannerType, string> = {
 };
 
 // ─── Component ────────────────────────────────────────────────────────────────
-export function Banner({
+export const Banner = ({
   type = 'default',
   action,
   onDismiss,
   children,
   className,
   ...props
-}: BannerProps) {
+}: BannerProps) => {
   const icon = TYPE_ICONS[type];
 
   return (
@@ -78,4 +78,4 @@ export function Banner({
       )}
     </div>
   );
-}
+};

--- a/packages/layout/src/components/Banner/README.md
+++ b/packages/layout/src/components/Banner/README.md
@@ -1,0 +1,12 @@
+Persistent in-app message strip shown at the top of a view, following GNOME HIG banner guidelines.
+
+Use banners to communicate **ongoing states** — offline mode, read-only access, pending updates.
+They do not auto-dismiss. For individual events and short-lived messages, use `Toast` instead.
+
+```tsx
+import { Banner } from "@gnome-ui/layout";
+
+<Banner type="warning" action={{ label: "Reconnect", onClick: retry }}>
+  Working offline — changes will sync when you reconnect
+</Banner>
+```

--- a/packages/layout/src/components/CounterCard/CounterCard.stories.tsx
+++ b/packages/layout/src/components/CounterCard/CounterCard.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { CounterCard } from './CounterCard';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof CounterCard> = {
   title: 'Layout/CounterCard',
@@ -13,20 +14,7 @@ const meta: Meta<typeof CounterCard> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Metric card with an animated numeric counter.
-
-Wraps \`Card\` from \`@gnome-ui/react\` and counts up to \`value\` using an
-ease-out cubic curve on mount and whenever \`value\` changes.
-Respects \`prefers-reduced-motion\`.
-
-\`\`\`tsx
-import { CounterCard } from "@gnome-ui/layout";
-
-<CounterCard label="Documents" value={1248} suffix=" files" />
-<CounterCard label="Revenue"   value={9420} prefix="$" accent duration={1500} />
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/CounterCard/CounterCard.tsx
+++ b/packages/layout/src/components/CounterCard/CounterCard.tsx
@@ -128,7 +128,7 @@ export interface CounterCardProps extends HTMLAttributes<HTMLDivElement> {
   loadingType?: LoadingType;
 }
 
-export function CounterCard({
+export const CounterCard = ({
   label,
   value,
   prefix,
@@ -147,7 +147,7 @@ export function CounterCard({
   className,
   style,
   ...props
-}: CounterCardProps) {
+}: CounterCardProps) => {
   const raw = useCountUp(value, duration, animated && !loading);
   const numberFormat = useNumberFormatter({
     minimumFractionDigits: decimals,
@@ -242,4 +242,4 @@ export function CounterCard({
       )}
     </Card>
   );
-}
+};

--- a/packages/layout/src/components/CounterCard/README.md
+++ b/packages/layout/src/components/CounterCard/README.md
@@ -1,0 +1,12 @@
+Metric card with an animated numeric counter.
+
+Wraps `Card` from `@gnome-ui/react` and counts up to `value` using an
+ease-out cubic curve on mount and whenever `value` changes.
+Respects `prefers-reduced-motion`.
+
+```tsx
+import { CounterCard } from "@gnome-ui/layout";
+
+<CounterCard label="Documents" value={1248} suffix=" files" />
+<CounterCard label="Revenue"   value={9420} prefix="$" accent duration={1500} />
+```

--- a/packages/layout/src/components/DashboardGrid/DashboardGrid.stories.tsx
+++ b/packages/layout/src/components/DashboardGrid/DashboardGrid.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { DashboardGrid } from './DashboardGrid';
+import readme from './README.md?raw';
 
 const Placeholder = ({ label, height = 120 }: { label: string; height?: number }) => (
   <div
@@ -29,40 +30,7 @@ const meta: Meta<typeof DashboardGrid> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Responsive 12-column grid container for dashboard widgets and panels.
-
-## Breakpoints
-
-| Breakpoint | Min-width |
-|---|---|
-| xs | — (base) |
-| sm | 576px |
-| md | 768px |
-| lg | 992px |
-| xl | 1200px |
-| xxl | 1600px |
-
-## Usage
-
-\`\`\`tsx
-import { DashboardGrid } from "@gnome-ui/layout";
-
-// Static layout
-<DashboardGrid columns={12} gap="md">
-  <DashboardGrid.Item span={6} offset={3}>
-    <Card />
-  </DashboardGrid.Item>
-</DashboardGrid>
-
-// Responsive layout
-<DashboardGrid columns={{ xs: 1, sm: 2, md: 3, lg: 4 }} gap={{ xs: "sm", md: "md" }}>
-  <DashboardGrid.Item span={{ xs: 12, sm: 6, md: 4 }}>
-    <StatCard />
-  </DashboardGrid.Item>
-</DashboardGrid>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/layout/src/components/DashboardGrid/DashboardGrid.tsx
@@ -139,14 +139,14 @@ function buildSpanStyle(span: DashboardGridSpan): CSSProperties {
 }
 
 // ─── DashboardGridItem ────────────────────────────────────────────────────────
-function DashboardGridItem({
+const DashboardGridItem = ({
   span = 1,
   offset = 0,
   children,
   className,
   style,
   ...props
-}: DashboardGridItemProps) {
+}: DashboardGridItemProps) => {
   const itemStyle: CSSProperties = {
     ...buildSpanStyle(span),
     ...(offset > 0 ? ({ '--item-offset-xs': offset } as CSSProperties) : null),
@@ -164,10 +164,10 @@ function DashboardGridItem({
       {children}
     </div>
   );
-}
+};
 
 // ─── DashboardGrid ───────────────────────────────────────────────────────────
-export function DashboardGrid({
+export const DashboardGrid = ({
   columns = 'auto',
   gap = 'md',
   layout = 'grid',
@@ -175,7 +175,7 @@ export function DashboardGrid({
   className,
   style,
   ...props
-}: DashboardGridProps) {
+}: DashboardGridProps) => {
   const isResponsiveColumns = layout === 'grid' && isObject(columns);
 
   const gridStyle: CSSProperties = {
@@ -201,6 +201,6 @@ export function DashboardGrid({
       {children}
     </div>
   );
-}
+};
 
 DashboardGrid.Item = DashboardGridItem;

--- a/packages/layout/src/components/DashboardGrid/README.md
+++ b/packages/layout/src/components/DashboardGrid/README.md
@@ -1,0 +1,32 @@
+Responsive 12-column grid container for dashboard widgets and panels.
+
+## Breakpoints
+
+| Breakpoint | Min-width |
+|---|---|
+| xs | — (base) |
+| sm | 576px |
+| md | 768px |
+| lg | 992px |
+| xl | 1200px |
+| xxl | 1600px |
+
+## Usage
+
+```tsx
+import { DashboardGrid } from "@gnome-ui/layout";
+
+// Static layout
+<DashboardGrid columns={12} gap="md">
+  <DashboardGrid.Item span={6} offset={3}>
+    <Card />
+  </DashboardGrid.Item>
+</DashboardGrid>
+
+// Responsive layout
+<DashboardGrid columns={{ xs: 1, sm: 2, md: 3, lg: 4 }} gap={{ xs: "sm", md: "md" }}>
+  <DashboardGrid.Item span={{ xs: 12, sm: 6, md: 4 }}>
+    <StatCard />
+  </DashboardGrid.Item>
+</DashboardGrid>
+```

--- a/packages/layout/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/layout/src/components/EmptyState/EmptyState.stories.tsx
@@ -3,6 +3,7 @@ import { Button, Icon } from '@gnome-ui/react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EmptyState } from './EmptyState';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof EmptyState> = {
   title: 'Layout/EmptyState',
@@ -12,24 +13,7 @@ const meta: Meta<typeof EmptyState> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Centered empty-state illustration for views with no data.
-
-No card background or border — intended to fill its parent container.
-
-\`\`\`tsx
-import { EmptyState } from "@gnome-ui/layout";
-import { Icon } from "@gnome-ui/react";
-import { Folder } from "@gnome-ui/icons";
-
-<EmptyState
-  icon={<Icon icon={Folder} size="lg" />}
-  title="No files yet"
-  description="Files you add will appear here."
-  action={<Button variant="suggested">Add File</Button>}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/EmptyState/EmptyState.tsx
+++ b/packages/layout/src/components/EmptyState/EmptyState.tsx
@@ -14,14 +14,14 @@ export interface EmptyStateProps extends HTMLAttributes<HTMLDivElement> {
   action?: ReactNode;
 }
 
-export function EmptyState({
+export const EmptyState = ({
   icon,
   title,
   description,
   action,
   className,
   ...props
-}: EmptyStateProps) {
+}: EmptyStateProps) => {
   return (
     <div className={[styles.root, className].filter(Boolean).join(' ')} {...props}>
       {icon && (
@@ -40,4 +40,4 @@ export function EmptyState({
       {action && <div className={styles.action}>{action}</div>}
     </div>
   );
-}
+};

--- a/packages/layout/src/components/EmptyState/README.md
+++ b/packages/layout/src/components/EmptyState/README.md
@@ -1,0 +1,16 @@
+Centered empty-state illustration for views with no data.
+
+No card background or border — intended to fill its parent container.
+
+```tsx
+import { EmptyState } from "@gnome-ui/layout";
+import { Icon } from "@gnome-ui/react";
+import { Folder } from "@gnome-ui/icons";
+
+<EmptyState
+  icon={<Icon icon={Folder} size="lg" />}
+  title="No files yet"
+  description="Files you add will appear here."
+  action={<Button variant="suggested">Add File</Button>}
+/>
+```

--- a/packages/layout/src/components/EntityCard/EntityCard.stories.tsx
+++ b/packages/layout/src/components/EntityCard/EntityCard.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { IconBadge } from '../IconBadge';
 
 import { EntityCard } from './EntityCard';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof EntityCard> = {
   title: 'Layout/EntityCard',
@@ -13,22 +14,7 @@ const meta: Meta<typeof EntityCard> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Avatar/icon + title + meta card. Covers both compact grid cards (Following screen)
-and full-width list rows (MyApps screen) via additive optional props.
-
-\`\`\`tsx
-import { EntityCard } from "@gnome-ui/layout";
-import { IconBadge } from "@gnome-ui/layout";
-
-<EntityCard
-  avatar={<IconBadge color="blue" size="md">🌤</IconBadge>}
-  title="GNOME Weather"
-  subtitle="@alice_dev"
-  meta={["v4.8.0", "⭐ 203"]}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/EntityCard/EntityCard.tsx
+++ b/packages/layout/src/components/EntityCard/EntityCard.tsx
@@ -31,7 +31,7 @@ export interface EntityCardProps extends HTMLAttributes<HTMLDivElement> {
   loadingType?: LoadingType;
 }
 
-export function EntityCard({
+export const EntityCard = ({
   avatar,
   title,
   badge,
@@ -44,7 +44,7 @@ export function EntityCard({
   loadingType = 'skeleton',
   className,
   ...props
-}: EntityCardProps) {
+}: EntityCardProps) => {
   const hasMeta = meta && (meta[0] || meta[1]);
 
   if (loading) {
@@ -121,4 +121,4 @@ export function EntityCard({
       )}
     </Card>
   );
-}
+};

--- a/packages/layout/src/components/EntityCard/README.md
+++ b/packages/layout/src/components/EntityCard/README.md
@@ -1,0 +1,14 @@
+Avatar/icon + title + meta card. Covers both compact grid cards (Following screen)
+and full-width list rows (MyApps screen) via additive optional props.
+
+```tsx
+import { EntityCard } from "@gnome-ui/layout";
+import { IconBadge } from "@gnome-ui/layout";
+
+<EntityCard
+  avatar={<IconBadge color="blue" size="md">🌤</IconBadge>}
+  title="GNOME Weather"
+  subtitle="@alice_dev"
+  meta={["v4.8.0", "⭐ 203"]}
+/>
+```

--- a/packages/layout/src/components/ErrorState/ErrorState.stories.tsx
+++ b/packages/layout/src/components/ErrorState/ErrorState.stories.tsx
@@ -2,6 +2,7 @@ import { Button } from '@gnome-ui/react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ErrorState } from './ErrorState';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ErrorState> = {
   title: 'Layout/ErrorState',
@@ -11,23 +12,7 @@ const meta: Meta<typeof ErrorState> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Error state with four presets that set a default icon and title.
-All defaults can be overridden via \`icon\` and \`title\` props.
-
-Icon color uses \`--gnome-warning-color\` for \`generic\`/\`network\`
-and \`--gnome-error-color\` for \`permission\`/\`not-found\`.
-
-\`\`\`tsx
-import { ErrorState } from "@gnome-ui/layout";
-
-<ErrorState
-  type="network"
-  description="Check your connection and try again."
-  action={<Button variant="suggested" onClick={retry}>Try again</Button>}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/ErrorState/ErrorState.tsx
+++ b/packages/layout/src/components/ErrorState/ErrorState.tsx
@@ -42,7 +42,7 @@ const PRESETS: Record<ErrorStateType, { icon: ReactNode; title: string }> = {
   },
 };
 
-export function ErrorState({
+export const ErrorState = ({
   type = 'generic',
   icon,
   title,
@@ -50,7 +50,7 @@ export function ErrorState({
   action,
   className,
   ...props
-}: ErrorStateProps) {
+}: ErrorStateProps) => {
   const preset = PRESETS[type];
   const resolvedIcon = icon ?? preset.icon;
   const resolvedTitle = title ?? preset.title;
@@ -71,4 +71,4 @@ export function ErrorState({
       {action && <div className={styles.action}>{action}</div>}
     </div>
   );
-}
+};

--- a/packages/layout/src/components/ErrorState/README.md
+++ b/packages/layout/src/components/ErrorState/README.md
@@ -1,0 +1,15 @@
+Error state with four presets that set a default icon and title.
+All defaults can be overridden via `icon` and `title` props.
+
+Icon color uses `--gnome-warning-color` for `generic`/`network`
+and `--gnome-error-color` for `permission`/`not-found`.
+
+```tsx
+import { ErrorState } from "@gnome-ui/layout";
+
+<ErrorState
+  type="network"
+  description="Check your connection and try again."
+  action={<Button variant="suggested" onClick={retry}>Try again</Button>}
+/>
+```

--- a/packages/layout/src/components/FileManager/FileManager.stories.tsx
+++ b/packages/layout/src/components/FileManager/FileManager.stories.tsx
@@ -121,7 +121,7 @@ function segmentsForPath(path: string): PathBarSegment[] {
 
 // ─── Inline file icons ─────────────────────────────────────────────────────────
 
-function FolderIcon() {
+const FolderIcon = () => {
   return (
     <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden>
       <path
@@ -130,9 +130,9 @@ function FolderIcon() {
       />
     </svg>
   );
-}
+};
 
-function DocumentIcon() {
+const DocumentIcon = () => {
   return (
     <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden>
       <rect
@@ -153,9 +153,9 @@ function DocumentIcon() {
       />
     </svg>
   );
-}
+};
 
-function ImageIcon() {
+const ImageIcon = () => {
   return (
     <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden>
       <rect x="6" y="6" width="28" height="28" rx="4" fill="#c084fc" />
@@ -169,9 +169,9 @@ function ImageIcon() {
       />
     </svg>
   );
-}
+};
 
-function ArchiveIcon() {
+const ArchiveIcon = () => {
   return (
     <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden>
       <rect
@@ -186,9 +186,9 @@ function ArchiveIcon() {
       <rect x="14" y="18" width="12" height="7" rx="1.5" fill="white" opacity="0.8" />
     </svg>
   );
-}
+};
 
-function FileIcon({ type }: { type: FileEntry['type'] }) {
+const FileIcon = ({ type }: { type: FileEntry['type'] }) => {
   switch (type) {
     case 'folder':
       return <FolderIcon />;
@@ -199,7 +199,7 @@ function FileIcon({ type }: { type: FileEntry['type'] }) {
     case 'archive':
       return <ArchiveIcon />;
   }
-}
+};
 
 // ─── Dual header bar ───────────────────────────────────────────────────────────
 //
@@ -215,7 +215,7 @@ const userActions = [
   { label: 'Sign Out', onClick: () => {}, variant: 'destructive' as const },
 ];
 
-function DualHeaderBar({
+const DualHeaderBar = ({
   sidebarCollapsed,
   onToggleSidebar,
   segments,
@@ -233,7 +233,7 @@ function DualHeaderBar({
   canGoForward: boolean;
   onBack: () => void;
   onForward: () => void;
-}) {
+}) => {
   const sidebarW = sidebarCollapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH;
 
   return (
@@ -358,11 +358,11 @@ function DualHeaderBar({
       </Toolbar>
     </div>
   );
-}
+};
 
 // ─── Sidebar ───────────────────────────────────────────────────────────────────
 
-function FileManagerSidebar({
+const FileManagerSidebar = ({
   collapsed,
   currentPath,
   onNavigate,
@@ -370,7 +370,7 @@ function FileManagerSidebar({
   collapsed: boolean;
   currentPath: string;
   onNavigate: (path: string) => void;
-}) {
+}) => {
   const places = [
     { id: '/home', label: 'Home', icon: GoHome },
     { id: '/home/documents', label: 'Documents', icon: ViewSidebar },
@@ -411,11 +411,11 @@ function FileManagerSidebar({
       </SidebarSection>
     </Sidebar>
   );
-}
+};
 
 // ─── File views ────────────────────────────────────────────────────────────────
 
-function FileGrid({ files, onOpen }: { files: FileEntry[]; onOpen: (f: FileEntry) => void }) {
+const FileGrid = ({ files, onOpen }: { files: FileEntry[]; onOpen: (f: FileEntry) => void }) => {
   return (
     <div
       style={{
@@ -480,9 +480,9 @@ function FileGrid({ files, onOpen }: { files: FileEntry[]; onOpen: (f: FileEntry
       ))}
     </div>
   );
-}
+};
 
-function FileList({ files, onOpen }: { files: FileEntry[]; onOpen: (f: FileEntry) => void }) {
+const FileList = ({ files, onOpen }: { files: FileEntry[]; onOpen: (f: FileEntry) => void }) => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       {files.map((file, i) => (
@@ -538,11 +538,11 @@ function FileList({ files, onOpen }: { files: FileEntry[]; onOpen: (f: FileEntry
       ))}
     </div>
   );
-}
+};
 
 // ─── Full app ──────────────────────────────────────────────────────────────────
 
-function FileManagerApp({ startMobileOpen = false }: { startMobileOpen?: boolean }) {
+const FileManagerApp = ({ startMobileOpen = false }: { startMobileOpen?: boolean }) => {
   const [currentPath, setCurrentPath] = useState('/home');
   const [history, setHistory] = useState(['/home']);
   const [historyIndex, setHistoryIndex] = useState(0);
@@ -664,7 +664,7 @@ function FileManagerApp({ startMobileOpen = false }: { startMobileOpen?: boolean
       </div>
     </Layout>
   );
-}
+};
 
 // ─── Meta ──────────────────────────────────────────────────────────────────────
 

--- a/packages/layout/src/components/FileManager/FileManager.stories.tsx
+++ b/packages/layout/src/components/FileManager/FileManager.stories.tsx
@@ -45,6 +45,7 @@ import { useState } from 'react';
 
 import { Layout } from '../Layout/Layout';
 import { UserCard } from '../UserCard';
+import readme from './README.md?raw';
 
 // ─── Constants ─────────────────────────────────────────────────────────────────
 
@@ -675,24 +676,7 @@ const meta: Meta = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-GNOME Files (Nautilus)–style file browser assembled from **\`@gnome-ui/layout\`**
-and **\`@gnome-ui/react\`** components.
-
-### Dual-headerbar pattern
-
-The top bar is split into two sections that sit side-by-side:
-
-| Section | Width | Contents |
-|---------|-------|----------|
-| Sidebar header | 240 px (56 px collapsed) | Search · Title · Toggle button |
-| Content header | \`flex: 1\` | Back/Forward · **PathBar** · Refresh · More · Avatar |
-
-This mirrors the \`AdwOverlaySplitView\` dual-\`AdwHeaderBar\` pattern used in GNOME Files.
-
-**Closes:** [#16](https://github.com/ElJijuna/gnome-ui/issues/16)
-**Depends on:** [#17 PathBar](https://github.com/ElJijuna/gnome-ui/issues/17)
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/FileManager/README.md
+++ b/packages/layout/src/components/FileManager/README.md
@@ -1,0 +1,16 @@
+GNOME Files (Nautilus)–style file browser assembled from **`@gnome-ui/layout`**
+and **`@gnome-ui/react`** components.
+
+### Dual-headerbar pattern
+
+The top bar is split into two sections that sit side-by-side:
+
+| Section | Width | Contents |
+|---------|-------|----------|
+| Sidebar header | 240 px (56 px collapsed) | Search · Title · Toggle button |
+| Content header | `flex: 1` | Back/Forward · **PathBar** · Refresh · More · Avatar |
+
+This mirrors the `AdwOverlaySplitView` dual-`AdwHeaderBar` pattern used in GNOME Files.
+
+**Closes:** [#16](https://github.com/ElJijuna/gnome-ui/issues/16)
+**Depends on:** [#17 PathBar](https://github.com/ElJijuna/gnome-ui/issues/17)

--- a/packages/layout/src/components/IconBadge/IconBadge.stories.tsx
+++ b/packages/layout/src/components/IconBadge/IconBadge.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import type { IconBadgeColor, IconBadgeSize } from './IconBadge';
 import { IconBadge } from './IconBadge';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof IconBadge> = {
   title: 'Layout/IconBadge',
@@ -13,17 +14,7 @@ const meta: Meta<typeof IconBadge> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Rounded-square tinted icon container. Accepts the seven gnome-ui named colors or any hex value (\`#rgb\` / \`#rrggbb\`). In both cases the background is rendered at 15% opacity via \`color-mix\`.
-
-\`\`\`tsx
-import { IconBadge } from "@gnome-ui/layout";
-
-<IconBadge color="blue" size="lg">🚀</IconBadge>
-<IconBadge color="#6c8ebf" size="md"><Icon icon={GoHome} /></IconBadge>
-<IconBadge size="sm">📄</IconBadge>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/IconBadge/IconBadge.tsx
+++ b/packages/layout/src/components/IconBadge/IconBadge.tsx
@@ -12,14 +12,14 @@ export interface IconBadgeProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
 }
 
-export function IconBadge({
+export const IconBadge = ({
   color,
   size = 'md',
   className,
   style,
   children,
   ...props
-}: IconBadgeProps) {
+}: IconBadgeProps) => {
   const isHex = color ? /^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/.test(color) : false;
 
   return (
@@ -44,4 +44,4 @@ export function IconBadge({
       {children}
     </div>
   );
-}
+};

--- a/packages/layout/src/components/IconBadge/README.md
+++ b/packages/layout/src/components/IconBadge/README.md
@@ -1,0 +1,9 @@
+Rounded-square tinted icon container. Accepts the seven gnome-ui named colors or any hex value (`#rgb` / `#rrggbb`). In both cases the background is rendered at 15% opacity via `color-mix`.
+
+```tsx
+import { IconBadge } from "@gnome-ui/layout";
+
+<IconBadge color="blue" size="lg">🚀</IconBadge>
+<IconBadge color="#6c8ebf" size="md"><Icon icon={GoHome} /></IconBadge>
+<IconBadge size="sm">📄</IconBadge>
+```

--- a/packages/layout/src/components/Layout/Layout.stories.tsx
+++ b/packages/layout/src/components/Layout/Layout.stories.tsx
@@ -56,7 +56,7 @@ function isSidebarOverlay(breakpoint: keyof typeof sidebarBreakpointQuery = 'nar
 
 // ─── Sub-components ────────────────────────────────────────────────────────────
 
-function AppHeader({
+const AppHeader = ({
   sidebarCollapsed,
   onToggleSidebar,
   searchQuery,
@@ -66,7 +66,7 @@ function AppHeader({
   onToggleSidebar: () => void;
   searchQuery: string;
   onSearchChange: (v: string) => void;
-}) {
+}) => {
   return (
     <Toolbar style={{ minHeight: 48, padding: '0 8px' }}>
       <Button
@@ -176,9 +176,9 @@ function AppHeader({
       </Popover>
     </Toolbar>
   );
-}
+};
 
-function AppSidebar({
+const AppSidebar = ({
   collapsed,
   activeNav,
   onNavChange,
@@ -186,7 +186,7 @@ function AppSidebar({
   collapsed: boolean;
   activeNav: string;
   onNavChange: (id: string) => void;
-}) {
+}) => {
   const navItems = [
     { id: 'home', label: 'Home', icon: GoHome, badge: null },
     { id: 'starred', label: 'Starred', icon: Star, badge: 3 },
@@ -210,9 +210,9 @@ function AppSidebar({
       </SidebarSection>
     </Sidebar>
   );
-}
+};
 
-function AppContent({
+const AppContent = ({
   activeNav,
   contentView,
   onViewChange,
@@ -220,7 +220,7 @@ function AppContent({
   activeNav: string;
   contentView: string;
   onViewChange: (v: string) => void;
-}) {
+}) => {
   const titles: Record<string, string> = {
     home: 'Home',
     starred: 'Starred',
@@ -330,9 +330,9 @@ function AppContent({
       )}
     </div>
   );
-}
+};
 
-function AppStatusBar() {
+const AppStatusBar = () => {
   return (
     <Toolbar style={{ minHeight: 36, padding: '0 16px' }}>
       <Text variant="caption" color="dim">
@@ -344,9 +344,9 @@ function AppStatusBar() {
       </Text>
     </Toolbar>
   );
-}
+};
 
-function CookbookHeader({
+const CookbookHeader = ({
   title = 'Documents',
   subtitle,
   leading,
@@ -356,7 +356,7 @@ function CookbookHeader({
   subtitle?: string;
   leading?: ReactNode;
   onToggleSidebar?: () => void;
-}) {
+}) => {
   return (
     <ShellAppHeader
       title={title}
@@ -372,15 +372,15 @@ function CookbookHeader({
       actions={<Button variant="flat">New</Button>}
     />
   );
-}
+};
 
-function CookbookSidebar({
+const CookbookSidebar = ({
   collapsed = false,
   onNavigate,
 }: {
   collapsed?: boolean;
   onNavigate?: () => void;
-}) {
+}) => {
   return (
     <SidebarShell
       collapsed={collapsed}
@@ -400,9 +400,9 @@ function CookbookSidebar({
       </SidebarSection>
     </SidebarShell>
   );
-}
+};
 
-function CookbookContent({ title = 'Overview', rows = 12 }: { title?: string; rows?: number }) {
+const CookbookContent = ({ title = 'Overview', rows = 12 }: { title?: string; rows?: number }) => {
   return (
     <PageContent as="section" maxWidth="lg">
       <Text variant="title-2">{title}</Text>
@@ -421,11 +421,11 @@ function CookbookContent({ title = 'Overview', rows = 12 }: { title?: string; ro
       </BoxedList>
     </PageContent>
   );
-}
+};
 
 // ─── Full app composition ──────────────────────────────────────────────────────
 
-function FilesApp({ startMobileOpen = false }: { startMobileOpen?: boolean }) {
+const FilesApp = ({ startMobileOpen = false }: { startMobileOpen?: boolean }) => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(startMobileOpen);
   const [activeNav, setActiveNav] = useState('home');
@@ -471,7 +471,7 @@ function FilesApp({ startMobileOpen = false }: { startMobileOpen?: boolean }) {
       <AppContent activeNav={activeNav} contentView={contentView} onViewChange={setContentView} />
     </Layout>
   );
-}
+};
 
 // ─── Meta ──────────────────────────────────────────────────────────────────────
 

--- a/packages/layout/src/components/Layout/Layout.stories.tsx
+++ b/packages/layout/src/components/Layout/Layout.stories.tsx
@@ -33,6 +33,7 @@ import { StatusBar } from '../StatusBar';
 import { UserCard } from '../UserCard';
 
 import { Layout } from './Layout';
+import readme from './README.md?raw';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -483,36 +484,7 @@ const meta: Meta<typeof Layout> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Full-page application shell from **\`@gnome-ui/layout\`** that composes four
-named zones following the GNOME Human Interface Guidelines.
-
-| Zone | Prop | Behaviour |
-|------|------|-----------|
-| Header | \`header\` / \`topBar\` | Pinned header — never scrolls |
-| Sidebar | \`sidebar\` | Fixed-width lateral navigation, overlay, or rail |
-| Content | \`children\` | Scrollable main area |
-| Footer | \`footer\` / \`bottomBar\` | Pinned footer — never scrolls |
-
-**Install:**
-\`\`\`bash
-npm install @gnome-ui/layout
-\`\`\`
-
-**Usage:**
-\`\`\`tsx
-import { Layout } from "@gnome-ui/layout";
-import "@gnome-ui/layout/styles";
-
-<Layout header={<AppHeader />} sidebar={<AppSidebar />} footer={<AppStatusBar />}>
-  <AppContent />
-</Layout>
-\`\`\`
-
-The shell supports pinned headers and footers, scroll-contained content,
-sidebar overlays, rail collapse, right-side placement, GNOME breakpoints, and
-the project's \`--gnome-*\` design tokens.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/Layout/Layout.test.tsx
+++ b/packages/layout/src/components/Layout/Layout.test.tsx
@@ -321,7 +321,7 @@ describe('Layout', () => {
     });
 
     it('restores focus when the open sidebar closes', async () => {
-      function ControlledLayout() {
+      const ControlledLayout = () => {
         const [open, setOpen] = useState(false);
 
         return (
@@ -338,7 +338,7 @@ describe('Layout', () => {
             </Layout>
           </>
         );
-      }
+      };
 
       render(<ControlledLayout />);
       const trigger = screen.getByRole('button', { name: 'Trigger' });
@@ -400,7 +400,7 @@ describe('Layout', () => {
     });
 
     it('custom trigger collapses and expands a rail sidebar', () => {
-      function ControlledLayout() {
+      const ControlledLayout = () => {
         const [collapsed, setCollapsed] = useState(false);
 
         return (
@@ -417,7 +417,7 @@ describe('Layout', () => {
             </Layout>
           </>
         );
-      }
+      };
 
       const { container } = render(<ControlledLayout />);
       const body = () => container.querySelector("[class*='body']") as HTMLElement;
@@ -430,7 +430,7 @@ describe('Layout', () => {
     });
 
     it('can close the mobile sidebar when a navigation item is selected', async () => {
-      function ControlledLayout() {
+      const ControlledLayout = () => {
         const [open, setOpen] = useState(true);
 
         return (
@@ -446,7 +446,7 @@ describe('Layout', () => {
             <p>Content</p>
           </Layout>
         );
-      }
+      };
 
       const { container } = render(<ControlledLayout />);
       const body = () => container.querySelector("[class*='body']") as HTMLElement;

--- a/packages/layout/src/components/Layout/Layout.tsx
+++ b/packages/layout/src/components/Layout/Layout.tsx
@@ -157,7 +157,7 @@ export interface LayoutProps extends Omit<HTMLAttributes<HTMLDivElement>, 'heigh
  * @see https://developer.gnome.org/hig/patterns/containers/header-bars.html
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ToolbarView.html
  */
-export function Layout({
+export const Layout = ({
   topBar,
   header,
   sidebar,
@@ -177,7 +177,7 @@ export function Layout({
   scroll = 'content',
   className,
   ...props
-}: LayoutProps) {
+}: LayoutProps) => {
   const sidebarRef = useRef<HTMLElement>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
   const [sidebarMatchesOverlayBreakpoint, setSidebarMatchesOverlayBreakpoint] = useState(false);
@@ -350,4 +350,4 @@ export function Layout({
       {resolvedFooter && <footer className={styles.bottomBar}>{resolvedFooter}</footer>}
     </div>
   );
-}
+};

--- a/packages/layout/src/components/Layout/README.md
+++ b/packages/layout/src/components/Layout/README.md
@@ -1,0 +1,28 @@
+Full-page application shell from **`@gnome-ui/layout`** that composes four
+named zones following the GNOME Human Interface Guidelines.
+
+| Zone | Prop | Behaviour |
+|------|------|-----------|
+| Header | `header` / `topBar` | Pinned header — never scrolls |
+| Sidebar | `sidebar` | Fixed-width lateral navigation, overlay, or rail |
+| Content | `children` | Scrollable main area |
+| Footer | `footer` / `bottomBar` | Pinned footer — never scrolls |
+
+**Install:**
+```bash
+npm install @gnome-ui/layout
+```
+
+**Usage:**
+```tsx
+import { Layout } from "@gnome-ui/layout";
+import "@gnome-ui/layout/styles";
+
+<Layout header={<AppHeader />} sidebar={<AppSidebar />} footer={<AppStatusBar />}>
+  <AppContent />
+</Layout>
+```
+
+The shell supports pinned headers and footers, scroll-contained content,
+sidebar overlays, rail collapse, right-side placement, GNOME breakpoints, and
+the project's `--gnome-*` design tokens.

--- a/packages/layout/src/components/MasonryGrid/MasonryGrid.stories.tsx
+++ b/packages/layout/src/components/MasonryGrid/MasonryGrid.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { MasonryGrid } from './MasonryGrid';
+import readme from './README.md?raw';
 
 const HEIGHTS = [180, 120, 260, 100, 200, 140, 300, 160, 220, 90, 170, 240];
 
@@ -31,25 +32,7 @@ const meta: Meta<typeof MasonryGrid> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Masonry layout that distributes variable-height items across columns using a
-**shortest-column-first** algorithm — each new item is placed in the column
-with the least accumulated height, minimising gaps.
-
-Layout is computed in JavaScript via \`ResizeObserver\`, so it adapts automatically
-when the container or any item changes size. Enable \`fresh\` to continuously
-monitor individual item heights.
-
-\`\`\`tsx
-import { MasonryGrid } from "@gnome-ui/layout";
-
-<MasonryGrid columns={{ xs: 1, sm: 2, md: 3 }} gap="md">
-  <Card />
-  <Card />
-  <Card />
-</MasonryGrid>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/MasonryGrid/MasonryGrid.tsx
+++ b/packages/layout/src/components/MasonryGrid/MasonryGrid.tsx
@@ -126,7 +126,7 @@ function computeLayout(
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
-export function MasonryGrid({
+export const MasonryGrid = ({
   columns = 3,
   gap = 'md',
   fresh = false,
@@ -134,7 +134,7 @@ export function MasonryGrid({
   className,
   style,
   ...props
-}: MasonryGridProps) {
+}: MasonryGridProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
   const prevSerialRef = useRef<string>('');
@@ -273,4 +273,4 @@ export function MasonryGrid({
       })}
     </div>
   );
-}
+};

--- a/packages/layout/src/components/MasonryGrid/README.md
+++ b/packages/layout/src/components/MasonryGrid/README.md
@@ -1,0 +1,17 @@
+Masonry layout that distributes variable-height items across columns using a
+**shortest-column-first** algorithm — each new item is placed in the column
+with the least accumulated height, minimising gaps.
+
+Layout is computed in JavaScript via `ResizeObserver`, so it adapts automatically
+when the container or any item changes size. Enable `fresh` to continuously
+monitor individual item heights.
+
+```tsx
+import { MasonryGrid } from "@gnome-ui/layout";
+
+<MasonryGrid columns={{ xs: 1, sm: 2, md: 3 }} gap="md">
+  <Card />
+  <Card />
+  <Card />
+</MasonryGrid>
+```

--- a/packages/layout/src/components/PageContent/PageContent.stories.tsx
+++ b/packages/layout/src/components/PageContent/PageContent.stories.tsx
@@ -2,6 +2,7 @@ import { ActionRow, BoxedList, Text } from '@gnome-ui/react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { PageContent } from './PageContent';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof PageContent> = {
   title: 'Layout/PageContent',
@@ -10,7 +11,7 @@ const meta: Meta<typeof PageContent> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: 'Page content container with GNOME spacing and optional clamp.',
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/PageContent/PageContent.tsx
+++ b/packages/layout/src/components/PageContent/PageContent.tsx
@@ -49,14 +49,14 @@ function resolveMaxWidth(maxWidth: PageContentMaxWidth) {
  * It provides the GNOME page padding rhythm and optional Adwaita `Clamp`
  * behaviour for readable content widths.
  */
-export function PageContent({
+export const PageContent = ({
   as: Component = 'main',
   maxWidth = 'none',
   padding = 'normal',
   children,
   className,
   ...props
-}: PageContentProps) {
+}: PageContentProps) => {
   const maximumSize = resolveMaxWidth(maxWidth);
 
   return (
@@ -80,4 +80,4 @@ export function PageContent({
       )}
     </Component>
   );
-}
+};

--- a/packages/layout/src/components/PageContent/README.md
+++ b/packages/layout/src/components/PageContent/README.md
@@ -1,0 +1,32 @@
+Page content container with GNOME spacing and optional width clamping.
+
+Centers content within the viewport, applies consistent horizontal padding, and optionally clamps the maximum content width. Use inside the main content area of `Layout`.
+
+```tsx
+import { PageContent } from '@gnome-ui/layout';
+import { Text } from '@gnome-ui/react';
+
+// Clamped to a readable width
+<PageContent maxWidth="md">
+  <Text variant="title-2">Settings</Text>
+</PageContent>
+
+// Full-width with spacious padding
+<PageContent maxWidth="none" padding="spacious">
+  <Text variant="title-2">Dashboard</Text>
+</PageContent>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `maxWidth` | `"sm" \| "md" \| "lg" \| "xl" \| "none"` | `"lg"` | Maximum content width |
+| `padding` | `"default" \| "spacious"` | `"default"` | Horizontal padding size |
+| `as` | `ElementType` | `"div"` | Override the rendered HTML element |
+
+### Guidelines
+
+- Use `maxWidth="md"` for settings pages and forms — matches GNOME HIG readable line length.
+- Use `maxWidth="none"` for dashboards and full-bleed data views.
+- Nest inside `Layout`'s main area or directly inside a scrollable container.

--- a/packages/layout/src/components/PanelCard/PanelCard.stories.tsx
+++ b/packages/layout/src/components/PanelCard/PanelCard.stories.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from 'react';
 
 import type { PanelCardHandle } from './PanelCard';
 import { PanelCard } from './PanelCard';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof PanelCard> = {
   title: 'Layout/PanelCard',
@@ -14,35 +15,7 @@ const meta: Meta<typeof PanelCard> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Card with a structured **header / body / footer** layout and built-in
-collapse/expand behaviour.
-
-The expanded state lives inside the component. Use a \`ref\` to drive it
-imperatively from the outside:
-
-\`\`\`tsx
-import { useRef } from "react";
-import { PanelCard } from "@gnome-ui/layout";
-import type { PanelCardHandle } from "@gnome-ui/layout";
-
-const ref = useRef<PanelCardHandle>(null);
-
-<button onClick={() => ref.current?.toggle()}>Toggle</button>
-
-<PanelCard
-  ref={ref}
-  icon={<Icon icon={DocumentOpen} />}
-  title="My Panel"
-  headerActions={<Button variant="flat">Edit</Button>}
-  onExpandedChange={(open) => console.log(open)}
-  footer={<Text variant="caption" color="dim">Saved 2 min ago</Text>}
-  footerActions={<Button variant="suggested">Save</Button>}
->
-  Panel body content
-</PanelCard>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/PanelCard/README.md
+++ b/packages/layout/src/components/PanelCard/README.md
@@ -1,0 +1,27 @@
+Card with a structured **header / body / footer** layout and built-in
+collapse/expand behaviour.
+
+The expanded state lives inside the component. Use a `ref` to drive it
+imperatively from the outside:
+
+```tsx
+import { useRef } from "react";
+import { PanelCard } from "@gnome-ui/layout";
+import type { PanelCardHandle } from "@gnome-ui/layout";
+
+const ref = useRef<PanelCardHandle>(null);
+
+<button onClick={() => ref.current?.toggle()}>Toggle</button>
+
+<PanelCard
+  ref={ref}
+  icon={<Icon icon={DocumentOpen} />}
+  title="My Panel"
+  headerActions={<Button variant="flat">Edit</Button>}
+  onExpandedChange={(open) => console.log(open)}
+  footer={<Text variant="caption" color="dim">Saved 2 min ago</Text>}
+  footerActions={<Button variant="suggested">Save</Button>}
+>
+  Panel body content
+</PanelCard>
+```

--- a/packages/layout/src/components/ProfileCard/ProfileCard.stories.tsx
+++ b/packages/layout/src/components/ProfileCard/ProfileCard.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ProfileCard } from './ProfileCard';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ProfileCard> = {
   title: 'Layout/ProfileCard',
@@ -10,33 +11,7 @@ const meta: Meta<typeof ProfileCard> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Dashboard card for displaying a user profile — avatar, name, handle, optional status dot, optional stats row, and an optional decorative background chart.
-
-\`\`\`tsx
-import { ProfileCard } from "@gnome-ui/layout";
-
-<ProfileCard
-  name="rcronald"
-  username="@rcronald"
-  status="online"
-  stats={[
-    { label: "posts", value: 127 },
-    { label: "followers", value: "2.4k" },
-  ]}
-/>
-\`\`\`
-
-Pass any \`ReactNode\` as \`backgroundChart\` — e.g. a \`SparkAreaChart\` from \`@gnome-ui/charts\`:
-
-\`\`\`tsx
-<ProfileCard
-  name="rcronald"
-  username="@rcronald"
-  backgroundChart={<SparkAreaChart data={activityData} height={80} />}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/ProfileCard/ProfileCard.tsx
+++ b/packages/layout/src/components/ProfileCard/ProfileCard.tsx
@@ -38,7 +38,7 @@ export interface ProfileCardProps extends HTMLAttributes<HTMLDivElement> {
   onClick?: () => void;
 }
 
-export function ProfileCard({
+export const ProfileCard = ({
   name,
   username,
   avatarSrc,
@@ -50,7 +50,7 @@ export function ProfileCard({
   loadingType = 'skeleton',
   className,
   ...props
-}: ProfileCardProps) {
+}: ProfileCardProps) => {
   if (loading) {
     const rootClass = [styles.card, className].filter(Boolean).join(' ');
 
@@ -128,4 +128,4 @@ export function ProfileCard({
       </div>
     </Card>
   );
-}
+};

--- a/packages/layout/src/components/ProfileCard/README.md
+++ b/packages/layout/src/components/ProfileCard/README.md
@@ -1,0 +1,25 @@
+Dashboard card for displaying a user profile — avatar, name, handle, optional status dot, optional stats row, and an optional decorative background chart.
+
+```tsx
+import { ProfileCard } from "@gnome-ui/layout";
+
+<ProfileCard
+  name="rcronald"
+  username="@rcronald"
+  status="online"
+  stats={[
+    { label: "posts", value: 127 },
+    { label: "followers", value: "2.4k" },
+  ]}
+/>
+```
+
+Pass any `ReactNode` as `backgroundChart` — e.g. a `SparkAreaChart` from `@gnome-ui/charts`:
+
+```tsx
+<ProfileCard
+  name="rcronald"
+  username="@rcronald"
+  backgroundChart={<SparkAreaChart data={activityData} height={80} />}
+/>
+```

--- a/packages/layout/src/components/QuickActions/QuickActions.stories.tsx
+++ b/packages/layout/src/components/QuickActions/QuickActions.stories.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@gnome-ui/react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { QuickActions } from './QuickActions';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof QuickActions> = {
   title: 'Layout/QuickActions',
@@ -12,20 +13,7 @@ const meta: Meta<typeof QuickActions> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Grid of shortcut action buttons for dashboards, file managers, and control panels.
-
-\`\`\`tsx
-import { QuickActions } from "@gnome-ui/layout";
-
-<QuickActions
-  actions={[
-    { id: "new-file", label: "New File", icon: <AddIcon />, onActivate: createFile },
-    { id: "share", label: "Share", icon: <ShareIcon />, onActivate: share },
-  ]}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/QuickActions/QuickActions.tsx
+++ b/packages/layout/src/components/QuickActions/QuickActions.tsx
@@ -49,13 +49,13 @@ function findLastEnabledIndex(actions: QuickAction[]) {
   return -1;
 }
 
-export function QuickActions({
+export const QuickActions = ({
   actions,
   columns = 4,
   className,
   style,
   ...props
-}: QuickActionsProps) {
+}: QuickActionsProps) => {
   const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const firstEnabledIndex = useMemo(
     () => actions.findIndex((action) => !action.disabled),
@@ -131,4 +131,4 @@ export function QuickActions({
       ))}
     </div>
   );
-}
+};

--- a/packages/layout/src/components/QuickActions/README.md
+++ b/packages/layout/src/components/QuickActions/README.md
@@ -1,0 +1,12 @@
+Grid of shortcut action buttons for dashboards, file managers, and control panels.
+
+```tsx
+import { QuickActions } from "@gnome-ui/layout";
+
+<QuickActions
+  actions={[
+    { id: "new-file", label: "New File", icon: <AddIcon />, onActivate: createFile },
+    { id: "share", label: "Share", icon: <ShareIcon />, onActivate: share },
+  ]}
+/>
+```

--- a/packages/layout/src/components/SectionHeader/README.md
+++ b/packages/layout/src/components/SectionHeader/README.md
@@ -1,0 +1,11 @@
+Title row for dashboard sections with optional subtitle and trailing action slot.
+
+```tsx
+import { SectionHeader } from "@gnome-ui/layout";
+
+<SectionHeader
+  title="Recent Activity"
+  subtitle="Last 24 hours"
+  action={<Button variant="flat" size="sm">View all</Button>}
+/>
+```

--- a/packages/layout/src/components/SectionHeader/SectionHeader.stories.tsx
+++ b/packages/layout/src/components/SectionHeader/SectionHeader.stories.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@gnome-ui/react';
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import { SectionHeader } from './SectionHeader';
 
 const meta: Meta<typeof SectionHeader> = {
@@ -11,19 +11,7 @@ const meta: Meta<typeof SectionHeader> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Title row for dashboard sections with optional subtitle and trailing action slot.
-
-\`\`\`tsx
-import { SectionHeader } from "@gnome-ui/layout";
-
-<SectionHeader
-  title="Recent Activity"
-  subtitle="Last 24 hours"
-  action={<Button variant="flat" size="sm">View all</Button>}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/SectionHeader/SectionHeader.tsx
+++ b/packages/layout/src/components/SectionHeader/SectionHeader.tsx
@@ -22,13 +22,13 @@ export interface SectionHeaderProps extends HTMLAttributes<HTMLDivElement> {
  *   action={<Button variant="flat" size="sm">View all</Button>}
  * />
  */
-export function SectionHeader({
+export const SectionHeader = ({
   title,
   subtitle,
   action,
   className,
   ...props
-}: SectionHeaderProps) {
+}: SectionHeaderProps) => {
   return (
     <div className={[styles.root, className].filter(Boolean).join(' ')} {...props}>
       <div className={styles.text}>
@@ -44,4 +44,4 @@ export function SectionHeader({
       {action && <div className={styles.action}>{action}</div>}
     </div>
   );
-}
+};

--- a/packages/layout/src/components/Settings/README.md
+++ b/packages/layout/src/components/Settings/README.md
@@ -1,0 +1,12 @@
+GNOME Settings–style preferences app assembled from **`@gnome-ui/layout`** and **`@gnome-ui/react`**.
+
+Demonstrates the dual-headerbar + sidebar navigation pattern with sub-page drill-down.
+
+| Component | Role |
+|-----------|------|
+| `Layout` | Full-page shell |
+| `Sidebar` / `SidebarItem` | Category navigation |
+| `PreferencesGroup` | Titled section wrapper |
+| `BoxedList` | Rounded settings list |
+| `SwitchRow` | Toggle setting row |
+| `ActionRow` | Navigable / value row |

--- a/packages/layout/src/components/Settings/Settings.stories.tsx
+++ b/packages/layout/src/components/Settings/Settings.stories.tsx
@@ -41,6 +41,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { Layout } from '../Layout/Layout';
+import readme from './README.md?raw';
 
 // ─── Nav structure ─────────────────────────────────────────────────────────────
 
@@ -397,20 +398,7 @@ const meta: Meta = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-GNOME Settings–style preferences app assembled from **\`@gnome-ui/layout\`** and **\`@gnome-ui/react\`**.
-
-Demonstrates the dual-headerbar + sidebar navigation pattern with sub-page drill-down.
-
-| Component | Role |
-|-----------|------|
-| \`Layout\` | Full-page shell |
-| \`Sidebar\` / \`SidebarItem\` | Category navigation |
-| \`PreferencesGroup\` | Titled section wrapper |
-| \`BoxedList\` | Rounded settings list |
-| \`SwitchRow\` | Toggle setting row |
-| \`ActionRow\` | Navigable / value row |
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/Settings/Settings.stories.tsx
+++ b/packages/layout/src/components/Settings/Settings.stories.tsx
@@ -85,7 +85,7 @@ const NAV_ITEMS: NavItem[] = [
 
 // ─── Sub-page: Accessibility → Seeing ─────────────────────────────────────────
 
-function SeeingPage() {
+const SeeingPage = () => {
   return (
     <div style={{ padding: '16px 16px 32px', display: 'flex', flexDirection: 'column', gap: 24 }}>
       {/* Screen Reader */}
@@ -176,11 +176,11 @@ function SeeingPage() {
       </PreferencesGroup>
     </div>
   );
-}
+};
 
 // ─── Placeholder for other pages ───────────────────────────────────────────────
 
-function PlaceholderPage({ title }: { title: string }) {
+const PlaceholderPage = ({ title }: { title: string }) => {
   return (
     <div
       style={{
@@ -196,11 +196,11 @@ function PlaceholderPage({ title }: { title: string }) {
       </Text>
     </div>
   );
-}
+};
 
 // ─── Dual header (same pattern as FileManager) ─────────────────────────────────
 
-function DualHeader({
+const DualHeader = ({
   sidebarCollapsed,
   onToggleSidebar,
   activeLabel,
@@ -212,7 +212,7 @@ function DualHeader({
   activeLabel: string;
   subPage: string | null;
   onBack: () => void;
-}) {
+}) => {
   const sidebarW = sidebarCollapsed ? 56 : 240;
 
   return (
@@ -324,11 +324,11 @@ function DualHeader({
       </div>
     </div>
   );
-}
+};
 
 // ─── Full app ──────────────────────────────────────────────────────────────────
 
-function SettingsApp() {
+const SettingsApp = () => {
   const [active, setActive] = useState<NavId>('accessibility');
   const [subPage, setSubPage] = useState<string | null>('Seeing');
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -386,7 +386,7 @@ function SettingsApp() {
       )}
     </Layout>
   );
-}
+};
 
 // ─── Meta ──────────────────────────────────────────────────────────────────────
 

--- a/packages/layout/src/components/SidebarShell/README.md
+++ b/packages/layout/src/components/SidebarShell/README.md
@@ -1,0 +1,35 @@
+Full-height GNOME sidebar with fixed header/footer and scrollable navigation area.
+
+Wraps `@gnome-ui/react`'s `Sidebar` with named slots for a sticky `header`, scrollable `children`, and a fixed `footer`. Supports collapsed rail mode and an optional search bar.
+
+```tsx
+import { SidebarShell } from '@gnome-ui/layout';
+import { Button, SidebarItem, SidebarSection, Text } from '@gnome-ui/react';
+import { GoHome, Settings, Star } from '@gnome-ui/icons';
+
+<SidebarShell
+  header={<Text variant="heading">Files</Text>}
+  footer={<Button variant="flat" style={{ width: '100%' }}>Preferences</Button>}
+  aria-label="Files navigation"
+>
+  <SidebarSection>
+    <SidebarItem label="Home" icon={GoHome} active />
+    <SidebarItem label="Starred" icon={Star} />
+    <SidebarItem label="Settings" icon={Settings} />
+  </SidebarSection>
+</SidebarShell>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `header` | `ReactNode` | — | Sticky top area (app name, avatar…) |
+| `footer` | `ReactNode` | — | Fixed bottom area (account, preferences…) |
+| `collapsed` | `boolean` | `false` | Render as a narrow icon rail |
+| `searchable` | `boolean` | `false` | Show an inline search bar to filter items |
+
+### Guidelines
+
+- Use with `SidebarTrigger` in `AppHeader` to wire open/collapse state.
+- Wrap in `SidebarShellContext` if you need to share sidebar state across the layout.

--- a/packages/layout/src/components/SidebarShell/SidebarShell.stories.tsx
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.stories.tsx
@@ -1,7 +1,7 @@
 import { GoHome, Settings, Star } from '@gnome-ui/icons';
 import { Button, SidebarItem, SidebarSection, Text } from '@gnome-ui/react';
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import { SidebarShell } from './SidebarShell';
 
 const meta: Meta<typeof SidebarShell> = {
@@ -11,7 +11,7 @@ const meta: Meta<typeof SidebarShell> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: 'Full-height GNOME sidebar with fixed header/footer and scrollable navigation.',
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/SidebarShell/SidebarShell.tsx
+++ b/packages/layout/src/components/SidebarShell/SidebarShell.tsx
@@ -16,14 +16,14 @@ export interface SidebarShellProps extends Omit<SidebarProps, 'children'> {
  * Full-height sidebar composition with fixed header/footer and scrollable
  * GNOME `Sidebar` navigation in the middle.
  */
-export function SidebarShell({
+export const SidebarShell = ({
   header,
   children,
   footer,
   collapsed,
   className,
   ...sidebarProps
-}: SidebarShellProps) {
+}: SidebarShellProps) => {
   return (
     <div
       className={[styles.shell, collapsed ? styles.collapsed : null, className]
@@ -37,4 +37,4 @@ export function SidebarShell({
       {footer && <div className={styles.footer}>{footer}</div>}
     </div>
   );
-}
+};

--- a/packages/layout/src/components/SidebarTrigger/README.md
+++ b/packages/layout/src/components/SidebarTrigger/README.md
@@ -1,0 +1,23 @@
+Header button that opens overlay sidebars on narrow screens and toggles rail collapse on wider screens.
+
+Renders the appropriate icon based on the current sidebar state (`open`, `collapsed`). Designed to be placed in the leading slot of `AppHeader`.
+
+```tsx
+import { SidebarTrigger } from '@gnome-ui/layout';
+
+const [open, setOpen] = useState(false);
+const [collapsed, setCollapsed] = useState(false);
+
+<SidebarTrigger
+  sidebarOpen={open}
+  sidebarCollapsed={collapsed}
+  onSidebarOpenChange={setOpen}
+  onSidebarCollapsedChange={setCollapsed}
+/>
+```
+
+### Guidelines
+
+- Use inside `AppHeader`'s `leading` slot alongside a `SidebarShell`.
+- On mobile breakpoints, `open/onSidebarOpenChange` controls an overlay drawer.
+- On desktop breakpoints, `collapsed/onSidebarCollapsedChange` controls rail vs. full width.

--- a/packages/layout/src/components/SidebarTrigger/SidebarTrigger.stories.tsx
+++ b/packages/layout/src/components/SidebarTrigger/SidebarTrigger.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-
+import readme from './README.md?raw';
 import { SidebarTrigger } from './SidebarTrigger';
 
 const meta: Meta<typeof SidebarTrigger> = {
@@ -9,8 +9,7 @@ const meta: Meta<typeof SidebarTrigger> = {
   parameters: {
     docs: {
       description: {
-        component:
-          'Header button that opens overlay sidebars on narrow screens and toggles rail collapse on wider screens.',
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/SidebarTrigger/SidebarTrigger.tsx
+++ b/packages/layout/src/components/SidebarTrigger/SidebarTrigger.tsx
@@ -38,7 +38,7 @@ export interface SidebarTriggerProps extends Omit<ButtonProps, 'onClick'> {
  * On overlay breakpoints it opens/closes the sidebar. On wider screens it
  * toggles icon-only rail collapse.
  */
-export function SidebarTrigger({
+export const SidebarTrigger = ({
   sidebarOpen,
   sidebarCollapsed,
   sidebarBreakpoint = 'narrow',
@@ -48,7 +48,7 @@ export function SidebarTrigger({
   'aria-label': ariaLabel,
   variant = 'flat',
   ...props
-}: SidebarTriggerProps) {
+}: SidebarTriggerProps) => {
   const [overlay, setOverlay] = useState(() => matchesSidebarOverlay(sidebarBreakpoint));
   const sidebarVisible = overlay ? sidebarOpen : !sidebarCollapsed;
 
@@ -87,4 +87,4 @@ export function SidebarTrigger({
       {children}
     </Button>
   );
-}
+};

--- a/packages/layout/src/components/StatCard/README.md
+++ b/packages/layout/src/components/StatCard/README.md
@@ -1,0 +1,23 @@
+Metric card for dashboards with optional unit, trend indicator, icon, background chart, and loading state.
+
+```tsx
+import { StatCard } from "@gnome-ui/layout";
+
+<StatCard
+  label="Active Users"
+  value={1284}
+  unit="users"
+  trend={{ direction: "up", value: 12, period: "vs last week" }}
+/>
+```
+
+Pass a spark chart as a decorative background without coupling the card to a
+specific chart type:
+
+```tsx
+<StatCard
+  label="Requests"
+  value="24.8k"
+  backgroundChart={<SparkAreaChart data={requestTrend} height={96} />}
+/>
+```

--- a/packages/layout/src/components/StatCard/StatCard.stories.tsx
+++ b/packages/layout/src/components/StatCard/StatCard.stories.tsx
@@ -1,7 +1,7 @@
 import { Applications, Error, Person, Refresh } from '@gnome-ui/icons';
 import { Icon } from '@gnome-ui/react';
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import { StatCard } from './StatCard';
 
 const meta: Meta<typeof StatCard> = {
@@ -12,31 +12,7 @@ const meta: Meta<typeof StatCard> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Metric card for dashboards with optional unit, trend indicator, icon, background chart, and loading state.
-
-\`\`\`tsx
-import { StatCard } from "@gnome-ui/layout";
-
-<StatCard
-  label="Active Users"
-  value={1284}
-  unit="users"
-  trend={{ direction: "up", value: 12, period: "vs last week" }}
-/>
-\`\`\`
-
-Pass a spark chart as a decorative background without coupling the card to a
-specific chart type:
-
-\`\`\`tsx
-<StatCard
-  label="Requests"
-  value="24.8k"
-  backgroundChart={<SparkAreaChart data={requestTrend} height={96} />}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/StatCard/StatCard.tsx
+++ b/packages/layout/src/components/StatCard/StatCard.tsx
@@ -38,7 +38,7 @@ const TREND_SYMBOL: Record<StatCardTrendDirection, string> = {
   neutral: 'steady',
 };
 
-export function StatCard({
+export const StatCard = ({
   label,
   value,
   unit,
@@ -49,7 +49,7 @@ export function StatCard({
   loadingType = 'skeleton',
   className,
   ...props
-}: StatCardProps) {
+}: StatCardProps) => {
   const numberFormat = useNumberFormatter();
 
   if (loading) {
@@ -132,4 +132,4 @@ export function StatCard({
       </div>
     </Card>
   );
-}
+};

--- a/packages/layout/src/components/StatusBar/README.md
+++ b/packages/layout/src/components/StatusBar/README.md
@@ -1,0 +1,26 @@
+Compact footer/status bar for application shells.
+
+Renders a thin bar at the bottom of the layout. Accepts arbitrary children for the leading side and a `trailing` slot for right-aligned content (version strings, connection status, etc.).
+
+```tsx
+import { StatusBar } from '@gnome-ui/layout';
+import { Text } from '@gnome-ui/react';
+
+<StatusBar
+  trailing={
+    <Text variant="caption" color="dim">
+      GNOME Files 48.0
+    </Text>
+  }
+>
+  <Text variant="caption" color="dim">
+    1,248 items
+  </Text>
+</StatusBar>
+```
+
+### Guidelines
+
+- Place in the `footer` slot of `Layout`.
+- Keep content concise — captions and short status strings only.
+- Use `color="dim"` on `Text` to match the subtle status bar aesthetic.

--- a/packages/layout/src/components/StatusBar/StatusBar.stories.tsx
+++ b/packages/layout/src/components/StatusBar/StatusBar.stories.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@gnome-ui/react';
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import { StatusBar } from './StatusBar';
 
 const meta: Meta<typeof StatusBar> = {
@@ -10,7 +10,7 @@ const meta: Meta<typeof StatusBar> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: 'Compact footer/status bar for application shells.',
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/StatusBar/StatusBar.tsx
+++ b/packages/layout/src/components/StatusBar/StatusBar.tsx
@@ -13,7 +13,7 @@ export interface StatusBarProps extends HTMLAttributes<HTMLDivElement> {
 /**
  * Compact footer/status bar for `Layout.footer`.
  */
-export function StatusBar({ children, trailing, className, ...props }: StatusBarProps) {
+export const StatusBar = ({ children, trailing, className, ...props }: StatusBarProps) => {
   return (
     <Toolbar className={[styles.statusBar, className].filter(Boolean).join(' ')} {...props}>
       {children}
@@ -25,4 +25,4 @@ export function StatusBar({ children, trailing, className, ...props }: StatusBar
       )}
     </Toolbar>
   );
-}
+};

--- a/packages/layout/src/components/StatusIndicator/README.md
+++ b/packages/layout/src/components/StatusIndicator/README.md
@@ -1,0 +1,13 @@
+Status dot for communicating the health of a service, connection, or resource.
+
+Colors follow Adwaita tokens (`--gnome-success-color`, `--gnome-warning-color`,
+`--gnome-error-color`). The `loading` status pulses via CSS animation and
+respects `prefers-reduced-motion`.
+
+```tsx
+import { StatusIndicator } from "@gnome-ui/layout";
+
+<StatusIndicator status="online"  label="Database" />
+<StatusIndicator status="warning" label="API Gateway" description="High latency" />
+<StatusIndicator status="offline" label="Backup Service" />
+```

--- a/packages/layout/src/components/StatusIndicator/StatusIndicator.stories.tsx
+++ b/packages/layout/src/components/StatusIndicator/StatusIndicator.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import { StatusIndicator } from './StatusIndicator';
 
 const meta: Meta<typeof StatusIndicator> = {
@@ -10,21 +10,7 @@ const meta: Meta<typeof StatusIndicator> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Status dot for communicating the health of a service, connection, or resource.
-
-Colors follow Adwaita tokens (\`--gnome-success-color\`, \`--gnome-warning-color\`,
-\`--gnome-error-color\`). The \`loading\` status pulses via CSS animation and
-respects \`prefers-reduced-motion\`.
-
-\`\`\`tsx
-import { StatusIndicator } from "@gnome-ui/layout";
-
-<StatusIndicator status="online"  label="Database" />
-<StatusIndicator status="warning" label="API Gateway" description="High latency" />
-<StatusIndicator status="offline" label="Backup Service" />
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/StatusIndicator/StatusIndicator.tsx
+++ b/packages/layout/src/components/StatusIndicator/StatusIndicator.tsx
@@ -26,14 +26,14 @@ const STATUS_LABELS: Record<StatusIndicatorStatus, string> = {
   loading: 'Loading',
 };
 
-export function StatusIndicator({
+export const StatusIndicator = ({
   status,
   label,
   description,
   size = 'md',
   className,
   ...props
-}: StatusIndicatorProps) {
+}: StatusIndicatorProps) => {
   return (
     <div className={[styles.root, className].filter(Boolean).join(' ')} {...props}>
       <div
@@ -53,4 +53,4 @@ export function StatusIndicator({
       </div>
     </div>
   );
-}
+};

--- a/packages/layout/src/components/Toast/README.md
+++ b/packages/layout/src/components/Toast/README.md
@@ -1,0 +1,25 @@
+In-app notifications following the GNOME Human Interface Guidelines.
+
+Toasts are **transient** messages shown at the bottom-center of the window.
+They auto-dismiss after a configurable delay and support a single action button.
+Use them for individual events, not for persistent or ongoing states — for those, use `Banner`.
+
+## Setup
+
+Wrap your app (or the relevant subtree) with `ToastProvider` once, then call
+`useToast().show()` from any descendant:
+
+```tsx
+// main.tsx
+import { ToastProvider } from "@gnome-ui/layout";
+
+<ToastProvider>
+  <App />
+</ToastProvider>
+
+// Anywhere inside the tree
+import { useToast } from "@gnome-ui/layout";
+
+const { show, dismiss } = useToast();
+show({ title: "File saved", action: { label: "Undo", onClick: undo } });
+```

--- a/packages/layout/src/components/Toast/Toast.stories.tsx
+++ b/packages/layout/src/components/Toast/Toast.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-
+import readme from './README.md?raw';
 import type { ToastOptions, ToastType } from './Toast';
 import { ToastProvider, useToast } from './Toast';
 
@@ -10,33 +10,7 @@ const meta: Meta = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-In-app notifications following the GNOME Human Interface Guidelines.
-
-Toasts are **transient** messages shown at the bottom-center of the window.
-They auto-dismiss after a configurable delay and support a single action button.
-Use them for individual events, not for persistent or ongoing states — for those, use \`Banner\`.
-
-## Setup
-
-Wrap your app (or the relevant subtree) with \`ToastProvider\` once, then call
-\`useToast().show()\` from any descendant:
-
-\`\`\`tsx
-// main.tsx
-import { ToastProvider } from "@gnome-ui/layout";
-
-<ToastProvider>
-  <App />
-</ToastProvider>
-
-// Anywhere inside the tree
-import { useToast } from "@gnome-ui/layout";
-
-const { show, dismiss } = useToast();
-show({ title: "File saved", action: { label: "Undo", onClick: undo } });
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/Toast/Toast.stories.tsx
+++ b/packages/layout/src/components/Toast/Toast.stories.tsx
@@ -46,7 +46,7 @@ export default meta;
 type Story = StoryObj;
 
 // ─── Interactive demo ────────────────────────────────────────────────────────
-function Demo({ options }: { options: ToastOptions }) {
+const Demo = ({ options }: { options: ToastOptions }) => {
   const { show } = useToast();
 
   return (
@@ -65,7 +65,7 @@ function Demo({ options }: { options: ToastOptions }) {
       Show toast
     </button>
   );
-}
+};
 
 export const Default: Story = {
   render: () => (
@@ -105,7 +105,7 @@ export const Types: Story = {
       { type: 'error', title: 'Connection failed' },
     ];
 
-    function TypeButtons() {
+    const TypeButtons = () => {
       const { show } = useToast();
 
       return (
@@ -129,7 +129,7 @@ export const Types: Story = {
           ))}
         </div>
       );
-    }
+    };
 
     return (
       <ToastProvider>
@@ -172,7 +172,7 @@ export const Persistent: Story = {
 
 export const Queue: Story = {
   render: () => {
-    function QueueDemo() {
+    const QueueDemo = () => {
       const { show, dismissAll } = useToast();
       const [count, setCount] = useState(0);
 
@@ -214,7 +214,7 @@ export const Queue: Story = {
           </button>
         </div>
       );
-    }
+    };
 
     return (
       <ToastProvider>

--- a/packages/layout/src/components/Toast/Toast.test.tsx
+++ b/packages/layout/src/components/Toast/Toast.test.tsx
@@ -6,13 +6,13 @@ import type { ToastContextValue, ToastOptions } from './Toast';
 import { ToastProvider, useToast } from './Toast';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-function Trigger({
+const Trigger = ({
   options,
   onReady,
 }: {
   options: ToastOptions;
   onReady?: (ctx: ToastContextValue) => void;
-}) {
+}) => {
   const ctx = useToast();
 
   useEffect(() => {
@@ -20,7 +20,7 @@ function Trigger({
   }, [onReady, ctx]);
 
   return <button onClick={() => ctx.show(options)}>Show</button>;
-}
+};
 
 function wrap(ui: ReactNode) {
   return render(<ToastProvider>{ui}</ToastProvider>);
@@ -96,7 +96,7 @@ describe('toast queue', () => {
   });
 
   it('queues subsequent toasts and shows them in order', () => {
-    function MultiTrigger() {
+    const MultiTrigger = () => {
       const { show } = useToast();
 
       return (
@@ -105,7 +105,7 @@ describe('toast queue', () => {
           <button onClick={() => show({ title: 'Second', timeout: 0 })}>B</button>
         </>
       );
-    }
+    };
 
     render(
       <ToastProvider>
@@ -161,13 +161,13 @@ describe('toast queue', () => {
   });
 
   it('deduplicates toasts with the same id', () => {
-    function DedupTrigger() {
+    const DedupTrigger = () => {
       const { show } = useToast();
 
       return (
         <button onClick={() => show({ id: 'stable', title: 'Same', timeout: 0 })}>Show</button>
       );
-    }
+    };
 
     render(
       <ToastProvider>

--- a/packages/layout/src/components/Toast/Toast.tsx
+++ b/packages/layout/src/components/Toast/Toast.tsx
@@ -80,7 +80,7 @@ interface ToastCardProps {
   onDismiss: () => void;
 }
 
-function ToastCard({ entry, exiting, onDismiss }: ToastCardProps) {
+const ToastCard = ({ entry, exiting, onDismiss }: ToastCardProps) => {
   const handleAction = () => {
     entry.action?.onClick();
     onDismiss();
@@ -110,10 +110,10 @@ function ToastCard({ entry, exiting, onDismiss }: ToastCardProps) {
       </button>
     </div>
   );
-}
+};
 
 // ─── Provider ────────────────────────────────────────────────────────────────
-export function ToastProvider({ children }: ToastProviderProps) {
+export const ToastProvider = ({ children }: ToastProviderProps) => {
   const [items, setItems] = useState<ToastEntry[]>([]);
   const [exitingId, setExitingId] = useState<string | null>(null);
 
@@ -239,7 +239,7 @@ export function ToastProvider({ children }: ToastProviderProps) {
         )}
     </ToastContext.Provider>
   );
-}
+};
 
 // ─── Hook ────────────────────────────────────────────────────────────────────
 // eslint-disable-next-line react-refresh/only-export-components

--- a/packages/layout/src/components/UserCard/README.md
+++ b/packages/layout/src/components/UserCard/README.md
@@ -1,0 +1,22 @@
+User identity panel for popovers, sidebar footers, and profile pages.
+
+Renders an `Avatar`, a display name, an optional sub-line (e-mail, role…),
+and a list of action buttons. A separator is automatically inserted before
+any `"destructive"` action.
+
+The component has **no card chrome** — place it inside a `Popover` or wrap
+it in `<Card>` depending on context.
+
+```tsx
+import { UserCard } from "@gnome-ui/layout";
+
+<UserCard
+  name="Ada Lovelace"
+  email="ada@gnome.org"
+  actions={[
+    { label: "View Profile",     onClick: () => {} },
+    { label: "Account Settings", onClick: () => {} },
+    { label: "Sign Out",         onClick: () => {}, variant: "destructive" },
+  ]}
+/>
+```

--- a/packages/layout/src/components/UserCard/UserCard.stories.tsx
+++ b/packages/layout/src/components/UserCard/UserCard.stories.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Card, Popover } from '@gnome-ui/react';
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import { UserCard } from './UserCard';
 
 const meta: Meta<typeof UserCard> = {
@@ -11,30 +11,7 @@ const meta: Meta<typeof UserCard> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-User identity panel for popovers, sidebar footers, and profile pages.
-
-Renders an \`Avatar\`, a display name, an optional sub-line (e-mail, role…),
-and a list of action buttons. A separator is automatically inserted before
-any \`"destructive"\` action.
-
-The component has **no card chrome** — place it inside a \`Popover\` or wrap
-it in \`<Card>\` depending on context.
-
-\`\`\`tsx
-import { UserCard } from "@gnome-ui/layout";
-
-<UserCard
-  name="Ada Lovelace"
-  email="ada@gnome.org"
-  actions={[
-    { label: "View Profile",     onClick: () => {} },
-    { label: "Account Settings", onClick: () => {} },
-    { label: "Sign Out",         onClick: () => {}, variant: "destructive" },
-  ]}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/layout/src/components/UserCard/UserCard.tsx
+++ b/packages/layout/src/components/UserCard/UserCard.tsx
@@ -78,7 +78,7 @@ export interface UserCardProps extends HTMLAttributes<HTMLDivElement> {
  */
 const AVATAR_PX: Record<AvatarSize, number> = { sm: 24, md: 32, lg: 48, xl: 64 };
 
-export function UserCard({
+export const UserCard = ({
   name,
   email,
   avatarSrc,
@@ -92,7 +92,7 @@ export function UserCard({
   className,
   style,
   ...props
-}: UserCardProps) {
+}: UserCardProps) => {
   const isVertical = orientation === 'vertical';
   const avatarPx = AVATAR_PX[avatarSize] ?? 32;
 
@@ -191,4 +191,4 @@ export function UserCard({
       )}
     </div>
   );
-}
+};

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -30,7 +30,7 @@
     "@vitest/coverage-v8": "^4.1.4",
     "jsdom": "^29.0.2",
     "vitest": "^4.1.4",
-    "vite": "^8.0.3",
+    "vite": "^8.0.16",
     "vite-plugin-dts": "^4.5.4"
   },
   "author": "pilmee <pilmee@gmail.com> (https://github.com/ElJijuna)",

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -9,7 +9,7 @@ import { INITIAL_VIEWPORTS } from 'storybook/viewport';
 
 import { GnomeProvider } from '../src/components/GnomeProvider/GnomeProvider';
 
-function CenteredDecorator({ children }: { children: ReactNode }) {
+const CenteredDecorator = ({ children }: { children: ReactNode }) => {
   return (
     <div
       style={{
@@ -29,7 +29,7 @@ function CenteredDecorator({ children }: { children: ReactNode }) {
       <div style={{ flex: '1 1 0%', minWidth: 0 }}>{children}</div>
     </div>
   );
-}
+};
 
 const preview: Preview = {
   globalTypes: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -481,7 +481,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "storybook": "^10.3.3",
-    "vite": "^8.0.3",
+    "vite": "^8.0.16",
     "vite-magic-tree-shaking": "^1.0.0",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.1.4"

--- a/packages/react/src/components/AboutDialog/AboutDialog.stories.tsx
+++ b/packages/react/src/components/AboutDialog/AboutDialog.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Button } from '../Button';
 
 import { AboutDialog } from './AboutDialog';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof AboutDialog> = {
   title: 'Components/AboutDialog',
@@ -12,15 +13,7 @@ const meta: Meta<typeof AboutDialog> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Standard app info dialog with details, credits, and legal tabs.
-Mirrors \`AdwAboutDialog\`.
-
-Provide \`applicationName\` plus any combination of \`version\`, \`comments\`,
-\`developerName\`, \`website\`, \`developers\`, \`designers\`, \`artists\`,
-\`copyright\`, \`licenseType\`, and \`licenseText\`.
-Credits and Legal tabs appear automatically when their content is supplied.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/AboutDialog/AboutDialog.tsx
+++ b/packages/react/src/components/AboutDialog/AboutDialog.tsx
@@ -67,7 +67,7 @@ const ABOUT_TAB_LABEL: Record<AboutTab, string> = {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.AboutDialog.html
  */
-export function AboutDialog({
+export const AboutDialog = ({
   open,
   onClose,
   applicationName,
@@ -84,7 +84,7 @@ export function AboutDialog({
   licenseType,
   licenseText,
   links,
-}: AboutDialogProps) {
+}: AboutDialogProps) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   const titleId = useId();
   const previouslyFocused = useRef<Element | null>(null);
@@ -264,4 +264,4 @@ export function AboutDialog({
   }
 
   return createPortal(node, document.body);
-}
+};

--- a/packages/react/src/components/AboutDialog/README.md
+++ b/packages/react/src/components/AboutDialog/README.md
@@ -1,0 +1,7 @@
+Standard app info dialog with details, credits, and legal tabs.
+Mirrors `AdwAboutDialog`.
+
+Provide `applicationName` plus any combination of `version`, `comments`,
+`developerName`, `website`, `developers`, `designers`, `artists`,
+`copyright`, `licenseType`, and `licenseText`.
+Credits and Legal tabs appear automatically when their content is supplied.

--- a/packages/react/src/components/ActionRow/ActionRow.stories.tsx
+++ b/packages/react/src/components/ActionRow/ActionRow.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from '../Button';
 import { Switch } from '../Switch';
 
 import { ActionRow } from './ActionRow';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ActionRow> = {
   title: 'Components/ActionRow',
@@ -13,18 +14,7 @@ const meta: Meta<typeof ActionRow> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Standard settings row with title, optional subtitle, leading icon, and trailing widget.
-
-Mirrors the Adwaita \`AdwActionRow\` pattern — the fundamental building block inside a \`BoxedList\`.
-
-### Guidelines
-- Always provide a \`title\`. Use \`subtitle\` for secondary context (current value, description).
-- Use \`trailing\` for the primary control: \`Switch\`, \`Button\`, a value label, or a chevron icon.
-- Use \`interactive\` for rows that navigate or trigger an action (renders as \`<button>\`).
-- Avoid putting interactive elements inside an \`interactive\` row — they create nested buttons.
-- Wrap in \`BoxedList\` for the canonical GNOME settings appearance.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ActionRow/ActionRow.tsx
+++ b/packages/react/src/components/ActionRow/ActionRow.tsx
@@ -38,7 +38,7 @@ export interface ActionRowProps extends HTMLAttributes<HTMLDivElement> {
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ActionRow.html
  * @see https://developer.gnome.org/hig/patterns/containers.html
  */
-export function ActionRow({
+export const ActionRow = ({
   title,
   subtitle,
   leading,
@@ -47,7 +47,7 @@ export function ActionRow({
   variant = 'default',
   className,
   ...props
-}: ActionRowProps) {
+}: ActionRowProps) => {
   const Tag = interactive ? 'button' : 'div';
   const property = variant === 'property';
 
@@ -74,4 +74,4 @@ export function ActionRow({
       {trailing && <span className={styles.trailing}>{trailing}</span>}
     </Tag>
   );
-}
+};

--- a/packages/react/src/components/ActionRow/README.md
+++ b/packages/react/src/components/ActionRow/README.md
@@ -1,0 +1,10 @@
+Standard settings row with title, optional subtitle, leading icon, and trailing widget.
+
+Mirrors the Adwaita `AdwActionRow` pattern — the fundamental building block inside a `BoxedList`.
+
+### Guidelines
+- Always provide a `title`. Use `subtitle` for secondary context (current value, description).
+- Use `trailing` for the primary control: `Switch`, `Button`, a value label, or a chevron icon.
+- Use `interactive` for rows that navigate or trigger an action (renders as `<button>`).
+- Avoid putting interactive elements inside an `interactive` row — they create nested buttons.
+- Wrap in `BoxedList` for the canonical GNOME settings appearance.

--- a/packages/react/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/Avatar/Avatar.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Text } from '../Text';
 
 import { Avatar } from './Avatar';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Avatar> = {
   title: 'Components/Avatar',
@@ -11,15 +12,7 @@ const meta: Meta<typeof Avatar> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Circular avatar following the Adwaita \`AdwAvatar\` pattern.
-
-### Guidelines
-- Provide a \`name\` whenever possible — it generates the initials fallback and a deterministic background color.
-- Use \`src\` for a real photo; the initials layer is hidden automatically.
-- Always ensure the \`name\` or \`alt\` prop conveys who the avatar represents for screen readers.
-- Prefer \`"md"\` (32 px) in lists and \`"lg"\`/\`"xl"\` in profile headers.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Avatar/Avatar.tsx
+++ b/packages/react/src/components/Avatar/Avatar.tsx
@@ -83,7 +83,7 @@ function getInitials(name: string): string {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Avatar.html
  */
-export function Avatar({
+export const Avatar = ({
   name = '',
   src,
   alt,
@@ -91,7 +91,7 @@ export function Avatar({
   color,
   className,
   ...props
-}: AvatarProps) {
+}: AvatarProps) => {
   const resolvedColor = color ?? (name ? nameToColor(name) : 'blue');
   const initials = getInitials(name);
 
@@ -115,4 +115,4 @@ export function Avatar({
       )}
     </span>
   );
-}
+};

--- a/packages/react/src/components/Avatar/README.md
+++ b/packages/react/src/components/Avatar/README.md
@@ -1,0 +1,7 @@
+Circular avatar following the Adwaita `AdwAvatar` pattern.
+
+### Guidelines
+- Provide a `name` whenever possible — it generates the initials fallback and a deterministic background color.
+- Use `src` for a real photo; the initials layer is hidden automatically.
+- Always ensure the `name` or `alt` prop conveys who the avatar represents for screen readers.
+- Prefer `"md"` (32 px) in lists and `"lg"`/`"xl"` in profile headers.

--- a/packages/react/src/components/AvatarRotator/AvatarRotator.stories.tsx
+++ b/packages/react/src/components/AvatarRotator/AvatarRotator.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Text } from '../Text';
 
 import { AvatarRotator } from './AvatarRotator';
+import readme from './README.md?raw';
 
 const avatarSources = [
   'https://i.pravatar.cc/128?img=5',
@@ -18,14 +19,7 @@ const meta: Meta<typeof AvatarRotator> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Single avatar surface that crossfades through multiple image sources.
-
-### Guidelines
-- Use when one person or entity has several possible avatar images and the UI should keep a single avatar footprint.
-- Keep the rotation interval calm enough that it does not distract from adjacent content.
-- Provide \`name\` or \`alt\` so the rotating surface has a stable accessible label.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/AvatarRotator/AvatarRotator.tsx
+++ b/packages/react/src/components/AvatarRotator/AvatarRotator.tsx
@@ -68,7 +68,7 @@ function usePrefersReducedMotion() {
  * Keeps `Avatar` focused on rendering one identity, while this component owns
  * timing, crossfade animation, and pause behavior.
  */
-export function AvatarRotator({
+export const AvatarRotator = ({
   name = '',
   avatars = [],
   alt,
@@ -87,7 +87,7 @@ export function AvatarRotator({
   onFocus,
   onBlur,
   ...props
-}: AvatarRotatorProps) {
+}: AvatarRotatorProps) => {
   const sources = useMemo(() => avatars.map((src) => src.trim()).filter(Boolean), [avatars]);
   const isControlled = activeIndex !== undefined;
   const [internalIndex, setInternalIndex] = useState(defaultActiveIndex);
@@ -200,4 +200,4 @@ export function AvatarRotator({
       ))}
     </span>
   );
-}
+};

--- a/packages/react/src/components/AvatarRotator/README.md
+++ b/packages/react/src/components/AvatarRotator/README.md
@@ -1,0 +1,6 @@
+Single avatar surface that crossfades through multiple image sources.
+
+### Guidelines
+- Use when one person or entity has several possible avatar images and the UI should keep a single avatar footprint.
+- Keep the rotation interval calm enough that it does not distract from adjacent content.
+- Provide `name` or `alt` so the rotating surface has a stable accessible label.

--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 
 import { Badge } from './Badge';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Badge> = {
   title: 'Components/Badge',
@@ -13,16 +14,7 @@ const meta: Meta<typeof Badge> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Counter or status indicator, optionally overlaid on another element.
-
-### Guidelines
-- Use for unread counts, notification numbers, or status indicators.
-- Keep the label to **1–3 characters** — use "99+" for large numbers.
-- Use \`dot\` for binary presence (online, unread) when a count is not needed.
-- Use \`anchor\` to overlay the badge on a button, avatar, or icon.
-- Choose the \`variant\` that matches the meaning: counts → \`accent\`, errors → \`error\`, online → \`success\`.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Badge/Badge.tsx
+++ b/packages/react/src/components/Badge/Badge.tsx
@@ -33,14 +33,14 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
  *
  * @see https://developer.gnome.org/hig/patterns/feedback/badges.html
  */
-export function Badge({
+export const Badge = ({
   variant = 'accent',
   dot = false,
   children,
   anchor,
   className,
   ...props
-}: BadgeProps) {
+}: BadgeProps) => {
   const badgeEl = (
     <span
       className={[
@@ -68,4 +68,4 @@ export function Badge({
   }
 
   return badgeEl;
-}
+};

--- a/packages/react/src/components/Badge/README.md
+++ b/packages/react/src/components/Badge/README.md
@@ -1,0 +1,8 @@
+Counter or status indicator, optionally overlaid on another element.
+
+### Guidelines
+- Use for unread counts, notification numbers, or status indicators.
+- Keep the label to **1–3 characters** — use "99+" for large numbers.
+- Use `dot` for binary presence (online, unread) when a count is not needed.
+- Use `anchor` to overlay the badge on a button, avatar, or icon.
+- Choose the `variant` that matches the meaning: counts → `accent`, errors → `error`, online → `success`.

--- a/packages/react/src/components/Banner/Banner.stories.tsx
+++ b/packages/react/src/components/Banner/Banner.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { Banner } from './Banner';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Banner> = {
   title: 'Components/Banner',
@@ -10,19 +11,7 @@ const meta: Meta<typeof Banner> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Persistent message strip displayed at the top of a view.
-
-Mirrors the Adwaita \`AdwBanner\` pattern.
-
-### Guidelines
-- Place at the very top of the content area, below the header bar.
-- Keep the message short — one sentence. Use a **Dialog** for longer explanations.
-- Provide an \`actionLabel\` only when there is a clear, single action the user can take.
-- Use \`dismissible\` when the message is informational and non-critical.
-- Choose the \`variant\` that matches the severity: \`info\` → \`warning\` → \`error\`.
-- Don't stack multiple banners — show only the most important one at a time.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Banner/Banner.tsx
+++ b/packages/react/src/components/Banner/Banner.tsx
@@ -40,7 +40,7 @@ export interface BannerProps extends HTMLAttributes<HTMLDivElement> {
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Banner.html
  * @see https://developer.gnome.org/hig/patterns/feedback/banners.html
  */
-export function Banner({
+export const Banner = ({
   variant = 'info',
   children,
   actionLabel,
@@ -49,7 +49,7 @@ export function Banner({
   onDismiss,
   className,
   ...props
-}: BannerProps) {
+}: BannerProps) => {
   return (
     <div
       role="status"
@@ -95,4 +95,4 @@ export function Banner({
       )}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Banner/README.md
+++ b/packages/react/src/components/Banner/README.md
@@ -1,0 +1,11 @@
+Persistent message strip displayed at the top of a view.
+
+Mirrors the Adwaita `AdwBanner` pattern.
+
+### Guidelines
+- Place at the very top of the content area, below the header bar.
+- Keep the message short — one sentence. Use a **Dialog** for longer explanations.
+- Provide an `actionLabel` only when there is a clear, single action the user can take.
+- Use `dismissible` when the message is informational and non-critical.
+- Choose the `variant` that matches the severity: `info` → `warning` → `error`.
+- Don't stack multiple banners — show only the most important one at a time.

--- a/packages/react/src/components/Bin/Bin.stories.tsx
+++ b/packages/react/src/components/Bin/Bin.stories.tsx
@@ -4,6 +4,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 
 import { Bin } from './Bin';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Bin> = {
   title: 'Components/Bin',
@@ -12,19 +13,7 @@ const meta: Meta<typeof Bin> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Single-child container with no visual styling.
-
-A transparent wrapper that constrains its content to one child while
-forwarding all HTML \`div\` attributes. Useful as a base for custom components
-that need a neutral container without introducing visual chrome.
-
-Mirrors \`AdwBin\`.
-
-### Usage
-- Use when you need to apply CSS classes, layout, or size constraints to a single child.
-- Does not add any background, border, or padding.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Bin/Bin.tsx
+++ b/packages/react/src/components/Bin/Bin.tsx
@@ -17,6 +17,6 @@ export interface BinProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Bin.html
  */
-export function Bin({ children, ...props }: BinProps) {
+export const Bin = ({ children, ...props }: BinProps) => {
   return <div {...props}>{children}</div>;
-}
+};

--- a/packages/react/src/components/Bin/README.md
+++ b/packages/react/src/components/Bin/README.md
@@ -1,0 +1,11 @@
+Single-child container with no visual styling.
+
+A transparent wrapper that constrains its content to one child while
+forwarding all HTML `div` attributes. Useful as a base for custom components
+that need a neutral container without introducing visual chrome.
+
+Mirrors `AdwBin`.
+
+### Usage
+- Use when you need to apply CSS classes, layout, or size constraints to a single child.
+- Does not add any background, border, or padding.

--- a/packages/react/src/components/Blockquote/Blockquote.stories.tsx
+++ b/packages/react/src/components/Blockquote/Blockquote.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Blockquote } from './Blockquote';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Blockquote> = {
   title: 'Components/Blockquote',
@@ -9,20 +10,7 @@ const meta: Meta<typeof Blockquote> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Styled pull-quote with semantic \`<blockquote>\` markup.
-
-Use it to highlight quoted text, callouts, or editorial notes inline within
-content. Five visual variants map to the same severity scale used by
-\`Banner\` and \`Badge\`.
-
-### Guidelines
-- Keep the quoted text short — one to three sentences.
-- Provide a \`cite\` whenever the source is known.
-- Use \`variant="default"\` for neutral quotations; reserve coloured variants
-  for callouts that match a clear intent (tip, caution, error, confirmation).
-- Supply an \`icon\` only when it meaningfully reinforces the variant intent.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Blockquote/Blockquote.tsx
+++ b/packages/react/src/components/Blockquote/Blockquote.tsx
@@ -47,14 +47,14 @@ export interface BlockquoteProps extends HTMLAttributes<HTMLQuoteElement> {
  * </Blockquote>
  * ```
  */
-export function Blockquote({
+export const Blockquote = ({
   variant = 'default',
   icon,
   cite,
   children,
   className,
   ...props
-}: BlockquoteProps) {
+}: BlockquoteProps) => {
   return (
     <blockquote
       className={[styles.blockquote, styles[variant], className].filter(Boolean).join(' ')}
@@ -76,4 +76,4 @@ export function Blockquote({
       )}
     </blockquote>
   );
-}
+};

--- a/packages/react/src/components/Blockquote/README.md
+++ b/packages/react/src/components/Blockquote/README.md
@@ -1,0 +1,12 @@
+Styled pull-quote with semantic `<blockquote>` markup.
+
+Use it to highlight quoted text, callouts, or editorial notes inline within
+content. Five visual variants map to the same severity scale used by
+`Banner` and `Badge`.
+
+### Guidelines
+- Keep the quoted text short — one to three sentences.
+- Provide a `cite` whenever the source is known.
+- Use `variant="default"` for neutral quotations; reserve coloured variants
+  for callouts that match a clear intent (tip, caution, error, confirmation).
+- Supply an `icon` only when it meaningfully reinforces the variant intent.

--- a/packages/react/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -7,6 +7,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 
 import { BottomSheet } from './BottomSheet';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof BottomSheet> = {
   title: 'Components/BottomSheet',
@@ -15,17 +16,7 @@ const meta: Meta<typeof BottomSheet> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Slide-up panel that overlays content from the bottom edge.
-
-Mirrors \`AdwBottomSheet\` (libadwaita 1.6+). Renders into a portal on
-\`document.body\`. Traps focus, closes on Escape or backdrop click (configurable).
-
-### Guidelines
-- Use for actions or supplementary content on mobile/narrow viewports.
-- Keep content concise — the sheet should not exceed ~90 % of the viewport height.
-- Provide an \`onClose\` handler to close the sheet on Escape and backdrop tap.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.tsx
@@ -41,7 +41,7 @@ export interface BottomSheetProps extends Omit<HTMLAttributes<HTMLDivElement>, '
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.BottomSheet.html
  */
-export function BottomSheet({
+export const BottomSheet = ({
   open,
   title,
   children,
@@ -49,7 +49,7 @@ export function BottomSheet({
   closeOnBackdrop = true,
   className,
   ...props
-}: BottomSheetProps) {
+}: BottomSheetProps) => {
   const sheetRef = useRef<HTMLDivElement>(null);
   const titleId = useId();
   const previouslyFocused = useRef<Element | null>(null);
@@ -149,4 +149,4 @@ export function BottomSheet({
   }
 
   return createPortal(node, document.body);
-}
+};

--- a/packages/react/src/components/BottomSheet/README.md
+++ b/packages/react/src/components/BottomSheet/README.md
@@ -1,0 +1,9 @@
+Slide-up panel that overlays content from the bottom edge.
+
+Mirrors `AdwBottomSheet` (libadwaita 1.6+). Renders into a portal on
+`document.body`. Traps focus, closes on Escape or backdrop click (configurable).
+
+### Guidelines
+- Use for actions or supplementary content on mobile/narrow viewports.
+- Keep content concise — the sheet should not exceed ~90 % of the viewport height.
+- Provide an `onClose` handler to close the sheet on Escape and backdrop tap.

--- a/packages/react/src/components/Box/Box.tsx
+++ b/packages/react/src/components/Box/Box.tsx
@@ -80,7 +80,7 @@ export interface BoxProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://developer.gnome.org/hig/guidelines/spacing.html
  */
-export function Box({
+export const Box = ({
   orientation = 'vertical',
   spacing = 6,
   align,
@@ -90,7 +90,7 @@ export function Box({
   style,
   children,
   ...props
-}: BoxProps) {
+}: BoxProps) => {
   const defaultAlign: BoxAlign = orientation === 'horizontal' ? 'center' : 'stretch';
 
   const resolvedStyle: CSSProperties = {
@@ -110,4 +110,4 @@ export function Box({
       {children}
     </div>
   );
-}
+};

--- a/packages/react/src/components/BoxedList/BoxedList.stories.tsx
+++ b/packages/react/src/components/BoxedList/BoxedList.stories.tsx
@@ -8,6 +8,7 @@ import { Text } from '../Text';
 import { WrapBox } from '../WrapBox';
 
 import { BoxedList } from './BoxedList';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof BoxedList> = {
   title: 'Components/BoxedList',
@@ -16,18 +17,7 @@ const meta: Meta<typeof BoxedList> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Rounded bordered list — the most common container pattern in GNOME settings and detail views.
-
-Mirrors the Adwaita \`.boxed-list\` style class on \`GtkListBox\`.
-
-### Guidelines
-- Use to group a set of related settings or items inside a view.
-- Separators between rows are inserted automatically.
-- Pair with \`ActionRow\` for the canonical GNOME settings pattern.
-- Keep lists focused: 3–8 rows is typical. Split long lists into labelled sections.
-- Don't nest \`BoxedList\` inside another \`BoxedList\`.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/BoxedList/BoxedList.tsx
+++ b/packages/react/src/components/BoxedList/BoxedList.tsx
@@ -29,7 +29,12 @@ export interface BoxedListProps extends HTMLAttributes<HTMLUListElement> {
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/style-classes.html#boxed-lists-cards
  * @see https://developer.gnome.org/hig/patterns/containers.html
  */
-export function BoxedList({ children, variant = 'default', className, ...props }: BoxedListProps) {
+export const BoxedList = ({
+  children,
+  variant = 'default',
+  className,
+  ...props
+}: BoxedListProps) => {
   const items = Children.toArray(children).filter(Boolean);
   const separate = variant === 'separate';
 
@@ -48,4 +53,4 @@ export function BoxedList({ children, variant = 'default', className, ...props }
       ))}
     </ul>
   );
-}
+};

--- a/packages/react/src/components/BoxedList/README.md
+++ b/packages/react/src/components/BoxedList/README.md
@@ -1,0 +1,10 @@
+Rounded bordered list — the most common container pattern in GNOME settings and detail views.
+
+Mirrors the Adwaita `.boxed-list` style class on `GtkListBox`.
+
+### Guidelines
+- Use to group a set of related settings or items inside a view.
+- Separators between rows are inserted automatically.
+- Pair with `ActionRow` for the canonical GNOME settings pattern.
+- Keep lists focused: 3–8 rows is typical. Split long lists into labelled sections.
+- Don't nest `BoxedList` inside another `BoxedList`.

--- a/packages/react/src/components/BreakpointBin/BreakpointBin.stories.tsx
+++ b/packages/react/src/components/BreakpointBin/BreakpointBin.stories.tsx
@@ -8,6 +8,7 @@ import { Switch } from '../Switch';
 import { Text } from '../Text';
 
 import { BreakpointBin } from './BreakpointBin';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof BreakpointBin> = {
   title: 'Adaptive/BreakpointBin',
@@ -16,29 +17,7 @@ const meta: Meta<typeof BreakpointBin> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Container that fires layout changes when **its own width** crosses defined
-thresholds — the CSS container-query equivalent of \`AdwBreakpointBin\`
-(libadwaita 1.9 / GNOME 50).
-
-### vs \`useBreakpoint\`
-| | \`useBreakpoint\` | \`BreakpointBin\` |
-|---|---|---|
-| Watches | Viewport (\`window.innerWidth\`) | Container (\`ResizeObserver\`) |
-| Use when | Layout depends on screen size | Layout depends on available space |
-| Pattern | Hook — use inside components | Component — wraps content |
-
-### How it works
-- Breakpoints are sorted by \`maxWidth\` ascending.
-- The **active breakpoint** is the smallest \`maxWidth\` ≥ the container's current width.
-- Exposed as \`data-breakpoint\` on the wrapper \`<div>\` for CSS targeting.
-- When wider than all thresholds, \`activeBreakpoint\` is \`null\`.
-
-### CSS targeting
-\`\`\`css
-.myCard[data-breakpoint="compact"] .layout { flex-direction: column; }
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/BreakpointBin/BreakpointBin.tsx
+++ b/packages/react/src/components/BreakpointBin/BreakpointBin.tsx
@@ -78,13 +78,13 @@ export interface BreakpointBinProps extends Omit<HTMLAttributes<HTMLDivElement>,
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.BreakpointBin.html
  */
-export function BreakpointBin({
+export const BreakpointBin = ({
   breakpoints,
   children,
   className,
   style,
   ...props
-}: BreakpointBinProps) {
+}: BreakpointBinProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [state, setState] = useState<BreakpointBinState>({
     activeBreakpoint: null,
@@ -146,4 +146,4 @@ export function BreakpointBin({
       {children(state)}
     </div>
   );
-}
+};

--- a/packages/react/src/components/BreakpointBin/README.md
+++ b/packages/react/src/components/BreakpointBin/README.md
@@ -1,0 +1,21 @@
+Container that fires layout changes when **its own width** crosses defined
+thresholds — the CSS container-query equivalent of `AdwBreakpointBin`
+(libadwaita 1.9 / GNOME 50).
+
+### vs `useBreakpoint`
+| | `useBreakpoint` | `BreakpointBin` |
+|---|---|---|
+| Watches | Viewport (`window.innerWidth`) | Container (`ResizeObserver`) |
+| Use when | Layout depends on screen size | Layout depends on available space |
+| Pattern | Hook — use inside components | Component — wraps content |
+
+### How it works
+- Breakpoints are sorted by `maxWidth` ascending.
+- The **active breakpoint** is the smallest `maxWidth` ≥ the container's current width.
+- Exposed as `data-breakpoint` on the wrapper `<div>` for CSS targeting.
+- When wider than all thresholds, `activeBreakpoint` is `null`.
+
+### CSS targeting
+```css
+.myCard[data-breakpoint="compact"] .layout { flex-direction: column; }
+```

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from './Button';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Button',
@@ -9,16 +10,7 @@ const meta: Meta<typeof Button> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Button component following the [GNOME Human Interface Guidelines](https://developer.gnome.org/hig/patterns/controls/buttons.html).
-
-### Guidelines
-- Use **suggested** for the single primary/affirmative action in a view. Never use more than one per screen.
-- Use **destructive** only for irreversible or dangerous actions (e.g. "Delete", "Format").
-- Use **flat** inside header bars and toolbars where a border would add visual clutter.
-- Button labels must use **imperative verbs** with **Header Capitalization** (e.g. "Save Changes", "Cancel").
-- Avoid buttons that mix an icon and a label outside of header bars.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Button/README.md
+++ b/packages/react/src/components/Button/README.md
@@ -1,0 +1,8 @@
+Button component following the [GNOME Human Interface Guidelines](https://developer.gnome.org/hig/patterns/controls/buttons.html).
+
+### Guidelines
+- Use **suggested** for the single primary/affirmative action in a view. Never use more than one per screen.
+- Use **destructive** only for irreversible or dangerous actions (e.g. "Delete", "Format").
+- Use **flat** inside header bars and toolbars where a border would add visual clutter.
+- Button labels must use **imperative verbs** with **Header Capitalization** (e.g. "Save Changes", "Cancel").
+- Avoid buttons that mix an icon and a label outside of header bars.

--- a/packages/react/src/components/ButtonContent/ButtonContent.stories.tsx
+++ b/packages/react/src/components/ButtonContent/ButtonContent.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from '../Button';
 import { Icon } from '../Icon';
 
 import { ButtonContent } from './ButtonContent';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ButtonContent> = {
   title: 'Components/ButtonContent',
@@ -13,18 +14,7 @@ const meta: Meta<typeof ButtonContent> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Icon + label layout helper for buttons that contain both an icon and text.
-
-Pass as the \`children\` of a \`Button\` to get the correct Adwaita spacing
-between the icon and the label (6 px gap, icon vertically centred with the text).
-
-Mirrors \`AdwButtonContent\`.
-
-### Usage
-- Use inside \`<Button>\` when you need both icon and text.
-- Set \`iconPosition="end"\` to place the icon after the label.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ButtonContent/ButtonContent.tsx
+++ b/packages/react/src/components/ButtonContent/ButtonContent.tsx
@@ -31,13 +31,13 @@ export interface ButtonContentProps extends HTMLAttributes<HTMLSpanElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ButtonContent.html
  */
-export function ButtonContent({
+export const ButtonContent = ({
   icon,
   label,
   iconPosition = 'start',
   className,
   ...props
-}: ButtonContentProps) {
+}: ButtonContentProps) => {
   return (
     <span
       className={[styles.content, iconPosition === 'end' ? styles.iconEnd : null, className]
@@ -58,4 +58,4 @@ export function ButtonContent({
       )}
     </span>
   );
-}
+};

--- a/packages/react/src/components/ButtonContent/README.md
+++ b/packages/react/src/components/ButtonContent/README.md
@@ -1,0 +1,10 @@
+Icon + label layout helper for buttons that contain both an icon and text.
+
+Pass as the `children` of a `Button` to get the correct Adwaita spacing
+between the icon and the label (6 px gap, icon vertically centred with the text).
+
+Mirrors `AdwButtonContent`.
+
+### Usage
+- Use inside `<Button>` when you need both icon and text.
+- Set `iconPosition="end"` to place the icon after the label.

--- a/packages/react/src/components/ButtonRow/ButtonRow.stories.tsx
+++ b/packages/react/src/components/ButtonRow/ButtonRow.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { BoxedList } from '../BoxedList';
 
 import { ButtonRow } from './ButtonRow';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ButtonRow> = {
   title: 'Components/ButtonRow',
@@ -11,20 +12,7 @@ const meta: Meta<typeof ButtonRow> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Full-width activatable row styled as a button inside a \`BoxedList\`.
-
-Mirrors \`AdwButtonRow\` — use when an entire list row should trigger a single
-action with a centered label. Supports \`suggested\` and \`destructive\` variants
-that colour the title text accordingly.
-
-### Guidelines
-- Always wrap in \`BoxedList\` for the canonical GNOME settings appearance.
-- Use \`suggested\` for primary affirmative actions (e.g. "Save", "Apply").
-- Use \`destructive\` for irreversible or dangerous actions (e.g. "Delete Account").
-- Use \`leading\` / \`trailing\` for optional icons flanking the label.
-- Prefer \`ActionRow\` with \`interactive\` when the row needs title + subtitle layout.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ButtonRow/ButtonRow.tsx
+++ b/packages/react/src/components/ButtonRow/ButtonRow.tsx
@@ -24,14 +24,14 @@ export interface ButtonRowProps extends ButtonHTMLAttributes<HTMLButtonElement> 
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ButtonRow.html
  */
-export function ButtonRow({
+export const ButtonRow = ({
   title,
   variant = 'default',
   leading,
   trailing,
   className,
   ...props
-}: ButtonRowProps) {
+}: ButtonRowProps) => {
   const classes = [styles.row, styles[variant], className].filter(Boolean).join(' ');
 
   return (
@@ -41,4 +41,4 @@ export function ButtonRow({
       {trailing && <span className={styles.trailing}>{trailing}</span>}
     </button>
   );
-}
+};

--- a/packages/react/src/components/ButtonRow/README.md
+++ b/packages/react/src/components/ButtonRow/README.md
@@ -1,0 +1,12 @@
+Full-width activatable row styled as a button inside a `BoxedList`.
+
+Mirrors `AdwButtonRow` — use when an entire list row should trigger a single
+action with a centered label. Supports `suggested` and `destructive` variants
+that colour the title text accordingly.
+
+### Guidelines
+- Always wrap in `BoxedList` for the canonical GNOME settings appearance.
+- Use `suggested` for primary affirmative actions (e.g. "Save", "Apply").
+- Use `destructive` for irreversible or dangerous actions (e.g. "Delete Account").
+- Use `leading` / `trailing` for optional icons flanking the label.
+- Prefer `ActionRow` with `interactive` when the row needs title + subtitle layout.

--- a/packages/react/src/components/Card/Card.stories.tsx
+++ b/packages/react/src/components/Card/Card.stories.tsx
@@ -4,6 +4,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 
 import { Card } from './Card';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Card> = {
   title: 'Components/Card',
@@ -12,16 +13,7 @@ const meta: Meta<typeof Card> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Card component following the [GNOME HIG containers](https://developer.gnome.org/hig/patterns/containers.html) and the Adwaita \`.card\` style class.
-
-### Guidelines
-- Use cards to group related content on an elevated surface.
-- Use \`interactive\` for clickable cards (grid items, settings shortcuts). They render as \`<button>\` for accessibility.
-- Avoid nesting interactive elements (buttons, links) inside an \`interactive\` card — it creates nested interactive elements.
-- Cards work at any width; let the layout dictate their size.
-- Prefer \`padding="md"\` (24px) for most cases; \`"sm"\` for compact UIs.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Card/Card.tsx
+++ b/packages/react/src/components/Card/Card.tsx
@@ -26,14 +26,14 @@ export interface CardProps extends HTMLAttributes<HTMLElement> {
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/style-classes.html
  * @see https://developer.gnome.org/hig/patterns/containers.html
  */
-export function Card({
+export const Card = ({
   interactive = false,
   padding = 'md',
   as,
   className,
   children,
   ...props
-}: CardProps) {
+}: CardProps) => {
   const Tag: ElementType = as ?? (interactive ? 'button' : 'div');
 
   const classes = [
@@ -50,4 +50,4 @@ export function Card({
       {children}
     </Tag>
   );
-}
+};

--- a/packages/react/src/components/Card/README.md
+++ b/packages/react/src/components/Card/README.md
@@ -1,0 +1,8 @@
+Card component following the [GNOME HIG containers](https://developer.gnome.org/hig/patterns/containers.html) and the Adwaita `.card` style class.
+
+### Guidelines
+- Use cards to group related content on an elevated surface.
+- Use `interactive` for clickable cards (grid items, settings shortcuts). They render as `<button>` for accessibility.
+- Avoid nesting interactive elements (buttons, links) inside an `interactive` card — it creates nested interactive elements.
+- Cards work at any width; let the layout dictate their size.
+- Prefer `padding="md"` (24px) for most cases; `"sm"` for compact UIs.

--- a/packages/react/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/react/src/components/Carousel/Carousel.stories.tsx
@@ -51,7 +51,7 @@ type Story = StoryObj<typeof Carousel>;
 const COLORS = ['#3584e4', '#e01b24', '#33d17a', '#ff7800', '#9141ac'];
 const LABELS = ['Blue', 'Red', 'Green', 'Orange', 'Purple'];
 
-function SlidePlaceholder({ label, color }: { label: string; color: string }) {
+const SlidePlaceholder = ({ label, color }: { label: string; color: string }) => {
   return (
     <div
       style={{
@@ -70,7 +70,7 @@ function SlidePlaceholder({ label, color }: { label: string; color: string }) {
       {label}
     </div>
   );
-}
+};
 
 // ─── With dots ─────────────────────────────────────────────────────────────────
 

--- a/packages/react/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/react/src/components/Carousel/Carousel.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { Carousel, CarouselIndicatorDots, CarouselIndicatorLines } from './Carousel';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Carousel> = {
   title: 'Components/Carousel',
@@ -10,19 +11,7 @@ const meta: Meta<typeof Carousel> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Swipeable content carousel.
-
-Mirrors \`AdwCarousel\`. Uses CSS scroll-snapping for smooth, native-feeling
-page transitions. Supports keyboard navigation (←/→ or ↑/↓), touch, and mouse drag.
-
-Pair with \`CarouselIndicatorDots\` or \`CarouselIndicatorLines\` for pagination UI.
-
-### Guidelines
-- Keep page count low (3–6). More pages need a compact indicator like lines.
-- Use \`orientation="vertical"\` for feed-style layouts.
-- Use \`loop\` for image galleries where wrap-around is expected.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Carousel/Carousel.tsx
+++ b/packages/react/src/components/Carousel/Carousel.tsx
@@ -26,13 +26,13 @@ export interface CarouselIndicatorDotsProps extends HTMLAttributes<HTMLDivElemen
  * Dot-style page indicator for `Carousel`.
  * Mirrors `AdwCarouselIndicatorDots`.
  */
-export function CarouselIndicatorDots({
+export const CarouselIndicatorDots = ({
   pages,
   currentPage,
   onPageSelected,
   className,
   ...props
-}: CarouselIndicatorDotsProps) {
+}: CarouselIndicatorDotsProps) => {
   return (
     <div
       className={[styles.indicatorDots, className].filter(Boolean).join(' ')}
@@ -55,7 +55,7 @@ export function CarouselIndicatorDots({
       ))}
     </div>
   );
-}
+};
 
 // ─── CarouselIndicatorLines ───────────────────────────────────────────────────
 
@@ -72,13 +72,13 @@ export interface CarouselIndicatorLinesProps extends HTMLAttributes<HTMLDivEleme
  * Line-style page indicator for `Carousel`.
  * Mirrors `AdwCarouselIndicatorLines`.
  */
-export function CarouselIndicatorLines({
+export const CarouselIndicatorLines = ({
   pages,
   currentPage,
   onPageSelected,
   className,
   ...props
-}: CarouselIndicatorLinesProps) {
+}: CarouselIndicatorLinesProps) => {
   return (
     <div
       className={[styles.indicatorLines, className].filter(Boolean).join(' ')}
@@ -101,7 +101,7 @@ export function CarouselIndicatorLines({
       ))}
     </div>
   );
-}
+};
 
 // ─── Carousel ─────────────────────────────────────────────────────────────────
 
@@ -142,7 +142,7 @@ export interface CarouselProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Carousel.html
  */
-export function Carousel({
+export const Carousel = ({
   children,
   orientation = 'horizontal',
   spacing = 0,
@@ -151,7 +151,7 @@ export function Carousel({
   page: controlledPage,
   className,
   ...props
-}: CarouselProps) {
+}: CarouselProps) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const pageCount = Children.count(children);
   const [internalPage, setInternalPage] = useState(0);
@@ -275,4 +275,4 @@ export function Carousel({
       ))}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Carousel/README.md
+++ b/packages/react/src/components/Carousel/README.md
@@ -1,0 +1,11 @@
+Swipeable content carousel.
+
+Mirrors `AdwCarousel`. Uses CSS scroll-snapping for smooth, native-feeling
+page transitions. Supports keyboard navigation (←/→ or ↑/↓), touch, and mouse drag.
+
+Pair with `CarouselIndicatorDots` or `CarouselIndicatorLines` for pagination UI.
+
+### Guidelines
+- Keep page count low (3–6). More pages need a compact indicator like lines.
+- Use `orientation="vertical"` for feed-style layouts.
+- Use `loop` for image galleries where wrap-around is expected.

--- a/packages/react/src/components/CheckRow/CheckRow.stories.tsx
+++ b/packages/react/src/components/CheckRow/CheckRow.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { BoxedList } from '../BoxedList';
 
 import { CheckRow } from './CheckRow';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof CheckRow> = {
   title: 'Components/CheckRow',
@@ -12,17 +13,7 @@ const meta: Meta<typeof CheckRow> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Activatable row with an integrated checkbox.
-
-The entire row is a button — clicking anywhere toggles the checkbox. Use inside a
-\`BoxedList\` when a user must select or deselect individual items in a list.
-
-### Guidelines
-- Use for multi-select scenarios (e.g., selecting files, features, or permissions).
-- For a single on/off setting, prefer \`SwitchRow\`.
-- Supports controlled (\`checked\`) and uncontrolled (\`defaultChecked\`) modes.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/CheckRow/CheckRow.tsx
+++ b/packages/react/src/components/CheckRow/CheckRow.tsx
@@ -29,7 +29,7 @@ export interface CheckRowProps extends Omit<HTMLAttributes<HTMLButtonElement>, '
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.CheckButton.html
  */
-export function CheckRow({
+export const CheckRow = ({
   title,
   subtitle,
   leading,
@@ -40,7 +40,7 @@ export function CheckRow({
   className,
   onClick,
   ...props
-}: CheckRowProps) {
+}: CheckRowProps) => {
   const isControlled = controlledChecked !== undefined;
   const [uncontrolledChecked, setUncontrolledChecked] = useState(defaultChecked);
   const checked = isControlled ? controlledChecked : uncontrolledChecked;
@@ -106,4 +106,4 @@ export function CheckRow({
       </span>
     </button>
   );
-}
+};

--- a/packages/react/src/components/CheckRow/README.md
+++ b/packages/react/src/components/CheckRow/README.md
@@ -1,0 +1,9 @@
+Activatable row with an integrated checkbox.
+
+The entire row is a button — clicking anywhere toggles the checkbox. Use inside a
+`BoxedList` when a user must select or deselect individual items in a list.
+
+### Guidelines
+- Use for multi-select scenarios (e.g., selecting files, features, or permissions).
+- For a single on/off setting, prefer `SwitchRow`.
+- Supports controlled (`checked`) and uncontrolled (`defaultChecked`) modes.

--- a/packages/react/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Text } from '../Text';
 
 import { Checkbox } from './Checkbox';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Checkbox> = {
   title: 'Components/Checkbox',
@@ -12,16 +13,7 @@ const meta: Meta<typeof Checkbox> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Checkbox for multi-selection, following the GNOME HIG and Adwaita style.
-
-### Guidelines
-- Use for multi-selection where multiple items can be active at once.
-- Prefer \`Switch\` over \`Checkbox\` for settings that take effect immediately.
-- Use the \`indeterminate\` state for "select all" controls when only some items are selected.
-- Always pair with a visible label or supply \`aria-label\`.
-- Changes should not take effect until the user confirms (e.g. a Save button).
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -23,7 +23,7 @@ export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement
  *
  * @see https://developer.gnome.org/hig/patterns/controls/checkboxes.html
  */
-export function Checkbox({ indeterminate = false, className, ...props }: CheckboxProps) {
+export const Checkbox = ({ indeterminate = false, className, ...props }: CheckboxProps) => {
   const ref = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -40,4 +40,4 @@ export function Checkbox({ indeterminate = false, className, ...props }: Checkbo
       {...props}
     />
   );
-}
+};

--- a/packages/react/src/components/Checkbox/README.md
+++ b/packages/react/src/components/Checkbox/README.md
@@ -1,0 +1,8 @@
+Checkbox for multi-selection, following the GNOME HIG and Adwaita style.
+
+### Guidelines
+- Use for multi-selection where multiple items can be active at once.
+- Prefer `Switch` over `Checkbox` for settings that take effect immediately.
+- Use the `indeterminate` state for "select all" controls when only some items are selected.
+- Always pair with a visible label or supply `aria-label`.
+- Changes should not take effect until the user confirms (e.g. a Save button).

--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -6,6 +6,7 @@ import { Text } from '../Text';
 import { WrapBox } from '../WrapBox';
 
 import { Chip } from './Chip';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Chip> = {
   title: 'Components/Chip',
@@ -14,17 +15,7 @@ const meta: Meta<typeof Chip> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Compact pill-shaped label for tags, filters, and selection states.
-
-Three usage modes:
-
-- **Static** — visual label only. No interaction.
-- **Removable** — add \`onRemove\` to show a × button that removes the chip.
-- **Selectable** — add \`selectable\` + \`selected\` + \`onToggle\` for toggle behaviour.
-
-Pair with \`WrapBox\` for multi-chip layouts.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Chip/Chip.tsx
+++ b/packages/react/src/components/Chip/Chip.tsx
@@ -42,7 +42,7 @@ export interface ChipProps extends HTMLAttributes<HTMLElement> {
  *
  * Pair with `WrapBox` for multi-chip layouts.
  */
-export function Chip({
+export const Chip = ({
   label,
   icon,
   onRemove,
@@ -52,7 +52,7 @@ export function Chip({
   disabled = false,
   className,
   ...props
-}: ChipProps) {
+}: ChipProps) => {
   const isInteractive = selectable && !onRemove;
 
   const chipClasses = [
@@ -113,4 +113,4 @@ export function Chip({
       {content}
     </span>
   );
-}
+};

--- a/packages/react/src/components/Chip/README.md
+++ b/packages/react/src/components/Chip/README.md
@@ -1,0 +1,9 @@
+Compact pill-shaped label for tags, filters, and selection states.
+
+Three usage modes:
+
+- **Static** — visual label only. No interaction.
+- **Removable** — add `onRemove` to show a × button that removes the chip.
+- **Selectable** — add `selectable` + `selected` + `onToggle` for toggle behaviour.
+
+Pair with `WrapBox` for multi-chip layouts.

--- a/packages/react/src/components/Clamp/Clamp.stories.tsx
+++ b/packages/react/src/components/Clamp/Clamp.stories.tsx
@@ -6,6 +6,7 @@ import { Switch } from '../Switch';
 import { Text } from '../Text';
 
 import { Clamp } from './Clamp';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Clamp> = {
   title: 'Adaptive/Clamp',
@@ -14,15 +15,7 @@ const meta: Meta<typeof Clamp> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Constrains its child to a maximum width while allowing it to shrink freely on narrow screens — mirroring the Adwaita \`AdwClamp\` widget.
-
-### Guidelines
-- Use on settings pages and forms so content never becomes too wide to read comfortably.
-- The default \`maximumSize\` is **600 px** — the Adwaita recommended narrow-content width.
-- The element is always centred horizontally.
-- Does not add any padding — wrap content in its own padded container as needed.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Clamp/Clamp.tsx
+++ b/packages/react/src/components/Clamp/Clamp.tsx
@@ -33,7 +33,7 @@ export interface ClampProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Clamp.html
  */
-export function Clamp({ maximumSize = 600, children, className, style, ...props }: ClampProps) {
+export const Clamp = ({ maximumSize = 600, children, className, style, ...props }: ClampProps) => {
   return (
     <div
       className={[styles.clamp, className].filter(Boolean).join(' ')}
@@ -43,4 +43,4 @@ export function Clamp({ maximumSize = 600, children, className, style, ...props 
       {children}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Clamp/README.md
+++ b/packages/react/src/components/Clamp/README.md
@@ -1,0 +1,7 @@
+Constrains its child to a maximum width while allowing it to shrink freely on narrow screens — mirroring the Adwaita `AdwClamp` widget.
+
+### Guidelines
+- Use on settings pages and forms so content never becomes too wide to read comfortably.
+- The default `maximumSize` is **600 px** — the Adwaita recommended narrow-content width.
+- The element is always centred horizontally.
+- Does not add any padding — wrap content in its own padded container as needed.

--- a/packages/react/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -5,6 +5,7 @@ import { Avatar } from '../Avatar';
 import { Text } from '../Text';
 
 import { ColorPicker, ColorSwatch, GNOME_PALETTE } from './ColorPicker';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ColorPicker> = {
   title: 'Components/ColorPicker',
@@ -14,31 +15,7 @@ const meta: Meta<typeof ColorPicker> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Color palette picker following the Adwaita \`GtkColorButton\` + swatch pattern.
-
-Renders a row of circular \`ColorSwatch\` items backed by a \`radiogroup\`.
-Arrow keys move focus and selection. Optionally adds a "Custom…" button
-backed by a hidden native \`<input type="color">\`.
-
-The default palette matches the 9 Adwaita named colors (also used by \`Avatar\`).
-
-\`\`\`tsx
-import { ColorPicker, GNOME_PALETTE } from "@gnome-ui/react";
-
-const [color, setColor] = useState("#3584e4");
-
-<ColorPicker value={color} onChange={setColor} />
-<ColorPicker value={color} onChange={setColor} allowCustom />
-\`\`\`
-
-### Keyboard
-| Key | Action |
-|-----|--------|
-| \`Arrow Right / Down\` | Next swatch |
-| \`Arrow Left / Up\` | Previous swatch |
-| \`Space / Enter\` | Select focused swatch |
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.tsx
@@ -27,7 +27,7 @@ export interface ColorSwatchProps
  * Can be used standalone or composed inside `ColorPicker`.
  * Shows a white checkmark when `selected`.
  */
-export function ColorSwatch({
+export const ColorSwatch = ({
   color,
   selected = false,
   size = 'md',
@@ -37,7 +37,7 @@ export function ColorSwatch({
   style,
   'aria-label': ariaLabel,
   ...props
-}: ColorSwatchProps) {
+}: ColorSwatchProps) => {
   return (
     <button
       type="button"
@@ -70,7 +70,7 @@ export function ColorSwatch({
       )}
     </button>
   );
-}
+};
 
 // ─── ColorPicker ─────────────────────────────────────────────────────────────
 
@@ -135,7 +135,7 @@ export interface ColorPickerProps extends Omit<HTMLAttributes<HTMLDivElement>, '
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ColorButton.html
  */
-export function ColorPicker({
+export const ColorPicker = ({
   value,
   onChange,
   colors = GNOME_PALETTE,
@@ -145,7 +145,7 @@ export function ColorPicker({
   style,
   'aria-label': ariaLabel,
   ...props
-}: ColorPickerProps) {
+}: ColorPickerProps) => {
   const customInputRef = useRef<HTMLInputElement>(null);
 
   // Roving tabindex: only the selected (or first) swatch is in the tab order.
@@ -256,4 +256,4 @@ export function ColorPicker({
       )}
     </div>
   );
-}
+};

--- a/packages/react/src/components/ColorPicker/README.md
+++ b/packages/react/src/components/ColorPicker/README.md
@@ -1,0 +1,23 @@
+Color palette picker following the Adwaita `GtkColorButton` + swatch pattern.
+
+Renders a row of circular `ColorSwatch` items backed by a `radiogroup`.
+Arrow keys move focus and selection. Optionally adds a "Custom…" button
+backed by a hidden native `<input type="color">`.
+
+The default palette matches the 9 Adwaita named colors (also used by `Avatar`).
+
+```tsx
+import { ColorPicker, GNOME_PALETTE } from "@gnome-ui/react";
+
+const [color, setColor] = useState("#3584e4");
+
+<ColorPicker value={color} onChange={setColor} />
+<ColorPicker value={color} onChange={setColor} allowCustom />
+```
+
+### Keyboard
+| Key | Action |
+|-----|--------|
+| `Arrow Right / Down` | Next swatch |
+| `Arrow Left / Up` | Previous swatch |
+| `Space / Enter` | Select focused swatch |

--- a/packages/react/src/components/ColumnView/ColumnView.stories.tsx
+++ b/packages/react/src/components/ColumnView/ColumnView.stories.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import type { ColumnDef, ColumnViewSortState, SortDirection } from './ColumnView';
 import { ColumnView } from './ColumnView';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ColumnView> = {
   title: 'Data Display/ColumnView',
@@ -12,17 +13,7 @@ const meta: Meta<typeof ColumnView> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Multi-column sortable data table styled with Adwaita design tokens.
-
-Mirrors \`GtkColumnView\` / \`AdwColumnView\` — the canonical GNOME widget for tabular data in file managers, settings lists, and dashboards.
-
-**Guidelines (GNOME HIG):**
-- Use for datasets where users benefit from comparing values across columns.
-- Prefer \`selectionMode="single"\` for navigation (open on click) and \`"multiple"\` for batch operations.
-- Always provide an \`ariaLabel\` describing the data set.
-- Set \`height\` when the dataset may exceed the viewport — this enables vertical scroll with a sticky header.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ColumnView/ColumnView.tsx
+++ b/packages/react/src/components/ColumnView/ColumnView.tsx
@@ -48,7 +48,7 @@ const ALIGN: Record<string, string> = {
   end: styles.alignEnd,
 };
 
-function SortChevron({ direction }: { direction: SortDirection | null }) {
+const SortChevron = ({ direction }: { direction: SortDirection | null }) => {
   return (
     <svg
       width="10"
@@ -69,9 +69,9 @@ function SortChevron({ direction }: { direction: SortDirection | null }) {
       )}
     </svg>
   );
-}
+};
 
-export function ColumnView<TRow extends object = Record<string, unknown>>({
+export const ColumnView = <TRow extends object = Record<string, unknown>>({
   columns,
   rows,
   rowKey,
@@ -84,7 +84,7 @@ export function ColumnView<TRow extends object = Record<string, unknown>>({
   emptyState,
   className,
   ariaLabel,
-}: ColumnViewProps<TRow>) {
+}: ColumnViewProps<TRow>) => {
   const tbodyRef = useRef<HTMLTableSectionElement>(null);
   const [focusedIndex, setFocusedIndex] = useState(0);
   const selectedSet = new Set(selectedRows);
@@ -282,4 +282,4 @@ export function ColumnView<TRow extends object = Record<string, unknown>>({
       </div>
     </div>
   );
-}
+};

--- a/packages/react/src/components/ColumnView/README.md
+++ b/packages/react/src/components/ColumnView/README.md
@@ -1,0 +1,9 @@
+Multi-column sortable data table styled with Adwaita design tokens.
+
+Mirrors `GtkColumnView` / `AdwColumnView` — the canonical GNOME widget for tabular data in file managers, settings lists, and dashboards.
+
+**Guidelines (GNOME HIG):**
+- Use for datasets where users benefit from comparing values across columns.
+- Prefer `selectionMode="single"` for navigation (open on click) and `"multiple"` for batch operations.
+- Always provide an `ariaLabel` describing the data set.
+- Set `height` when the dataset may exceed the viewport — this enables vertical scroll with a sticky header.

--- a/packages/react/src/components/ComboRow/ComboRow.stories.tsx
+++ b/packages/react/src/components/ComboRow/ComboRow.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { BoxedList } from '../BoxedList';
 
 import { ComboRow } from './ComboRow';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ComboRow> = {
   title: 'Components/ComboRow',
@@ -12,17 +13,7 @@ const meta: Meta<typeof ComboRow> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Settings row with an inline combo selector at the trailing edge.
-
-Mirrors \`AdwComboRow\` — a standard row layout with a dropdown for choosing among a set of options.
-Use when the current value of a setting should be visible at a glance in the row.
-
-### Guidelines
-- Keep option labels short so they fit inside the trailing button.
-- Provide a \`subtitle\` to clarify what the setting controls when the title alone is ambiguous.
-- Supports controlled (\`value\`) and uncontrolled (\`defaultValue\`) modes.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ComboRow/ComboRow.tsx
+++ b/packages/react/src/components/ComboRow/ComboRow.tsx
@@ -46,7 +46,7 @@ export interface ComboRowProps<V extends string = string>
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ComboRow.html
  */
-export function ComboRow<V extends string = string>({
+export const ComboRow = <V extends string = string>({
   title,
   subtitle,
   leading,
@@ -57,7 +57,7 @@ export function ComboRow<V extends string = string>({
   disabled = false,
   className,
   ...props
-}: ComboRowProps<V>) {
+}: ComboRowProps<V>) => {
   const isControlled = controlledValue !== undefined;
   const [uncontrolledValue, setUncontrolledValue] = useState<V | undefined>(defaultValue);
   const value = isControlled ? controlledValue : uncontrolledValue;
@@ -330,4 +330,4 @@ export function ComboRow<V extends string = string>({
       </div>
     </div>
   );
-}
+};

--- a/packages/react/src/components/ComboRow/README.md
+++ b/packages/react/src/components/ComboRow/README.md
@@ -1,0 +1,9 @@
+Settings row with an inline combo selector at the trailing edge.
+
+Mirrors `AdwComboRow` — a standard row layout with a dropdown for choosing among a set of options.
+Use when the current value of a setting should be visible at a glance in the row.
+
+### Guidelines
+- Keep option labels short so they fit inside the trailing button.
+- Provide a `subtitle` to clarify what the setting controls when the title alone is ambiguous.
+- Supports controlled (`value`) and uncontrolled (`defaultValue`) modes.

--- a/packages/react/src/components/ContributionGraph/ContributionGraph.stories.tsx
+++ b/packages/react/src/components/ContributionGraph/ContributionGraph.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import type { ContributionDay } from './ContributionGraph';
 import { ContributionGraph } from './ContributionGraph';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ContributionGraph> = {
   title: 'Data Display/ContributionGraph',
@@ -11,17 +12,7 @@ const meta: Meta<typeof ContributionGraph> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-A responsive activity heatmap calendar styled with Adwaita design tokens.
-Colour intensity represents activity count per day.
-
-**Guidelines (GNOME HIG):**
-- Use inside a \`Card\` to frame the graph on a dashboard or profile page.
-- Cells use the named accent colour token family from \`GnomeProvider\`; CSS accent values without token variants fall back to green.
-- Cells expand to use available width and narrow layouts show fewer recent weeks before cells become too small.
-- Dark mode is handled automatically via CSS custom properties — no extra configuration needed.
-- Keyboard users can navigate every cell with arrow keys (\`role="grid"\`).
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ContributionGraph/ContributionGraph.tsx
+++ b/packages/react/src/components/ContributionGraph/ContributionGraph.tsx
@@ -121,7 +121,7 @@ interface GridCell {
   future: boolean;
 }
 
-export function ContributionGraph({
+export const ContributionGraph = ({
   data,
   maxLevel = 4,
   cellSize = 12,
@@ -138,7 +138,7 @@ export function ContributionGraph({
   onDayClick,
   tooltipContent,
   className,
-}: ContributionGraphProps) {
+}: ContributionGraphProps) => {
   const monthFormatter = useDateTimeFormatter({ month: 'short' });
   const weekdayFormatter = useDateTimeFormatter({ weekday: 'short' });
   const fullDateFormatter = useDateTimeFormatter({
@@ -549,4 +549,4 @@ export function ContributionGraph({
       )}
     </div>
   );
-}
+};

--- a/packages/react/src/components/ContributionGraph/README.md
+++ b/packages/react/src/components/ContributionGraph/README.md
@@ -1,0 +1,9 @@
+A responsive activity heatmap calendar styled with Adwaita design tokens.
+Colour intensity represents activity count per day.
+
+**Guidelines (GNOME HIG):**
+- Use inside a `Card` to frame the graph on a dashboard or profile page.
+- Cells use the named accent colour token family from `GnomeProvider`; CSS accent values without token variants fall back to green.
+- Cells expand to use available width and narrow layouts show fewer recent weeks before cells become too small.
+- Dark mode is handled automatically via CSS custom properties — no extra configuration needed.
+- Keyboard users can navigate every cell with arrow keys (`role="grid"`).

--- a/packages/react/src/components/CountDownTimer/CountDownTimer.stories.tsx
+++ b/packages/react/src/components/CountDownTimer/CountDownTimer.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { CountDownTimer } from './CountDownTimer';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof CountDownTimer> = {
   title: 'Components/CountDownTimer',
@@ -9,16 +10,7 @@ const meta: Meta<typeof CountDownTimer> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Displays a countdown timer showing the remaining time until a specified end date.
-
-### Guidelines
-- Use \`format="time"\` to display countdown in HH:MM:SS format.
-- Use \`format="date"\` to display the target end date.
-- Provide an \`action\` callback that executes when the countdown reaches zero.
-- Choose the \`variant\` that matches the urgency: \`accent\` → neutral, \`success\` → positive, \`warning\` → caution, \`destructive\` → urgent.
-- The component automatically switches to destructive styling when time runs out.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/CountDownTimer/CountDownTimer.tsx
+++ b/packages/react/src/components/CountDownTimer/CountDownTimer.tsx
@@ -33,7 +33,7 @@ interface TimeRemaining {
  *
  * @see https://developer.gnome.org/hig/patterns/
  */
-export function CountDownTimer({
+export const CountDownTimer = ({
   start: _start,
   end,
   format = 'time',
@@ -41,7 +41,7 @@ export function CountDownTimer({
   action,
   className,
   ...props
-}: CountDownTimerProps) {
+}: CountDownTimerProps) => {
   const dateFormatter = useDateTimeFormatter();
   const [timeRemaining, setTimeRemaining] = useState<TimeRemaining | null>(null);
   const [hasExecutedAction, setHasExecutedAction] = useState(false);
@@ -145,4 +145,4 @@ export function CountDownTimer({
       <span className={styles.value}>{formatTime()}</span>
     </div>
   );
-}
+};

--- a/packages/react/src/components/CountDownTimer/README.md
+++ b/packages/react/src/components/CountDownTimer/README.md
@@ -1,0 +1,8 @@
+Displays a countdown timer showing the remaining time until a specified end date.
+
+### Guidelines
+- Use `format="time"` to display countdown in HH:MM:SS format.
+- Use `format="date"` to display the target end date.
+- Provide an `action` callback that executes when the countdown reaches zero.
+- Choose the `variant` that matches the urgency: `accent` → neutral, `success` → positive, `warning` → caution, `destructive` → urgent.
+- The component automatically switches to destructive styling when time runs out.

--- a/packages/react/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/Dialog/Dialog.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 
 import { Dialog } from './Dialog';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Dialog> = {
   title: 'Components/Dialog',
@@ -14,17 +15,7 @@ const meta: Meta<typeof Dialog> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Blocking modal dialog — two modes in one component.
-
-**Standard** — \`title\` + \`children\` + \`buttons[]\`.
-
-**Alert** (\`role="alertdialog"\` + \`responses[]\` + \`onResponse\`) — for confirmations
-and destructive-action warnings. Screen readers announce it immediately.
-Escape / backdrop fire the first non-destructive response. Mirrors \`AdwAlertDialog\`.
-
-For the app-info dialog, use \`<AboutDialog />\` instead.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -101,7 +101,7 @@ export interface DialogProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Dialog.html
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.AlertDialog.html
  */
-export function Dialog({
+export const Dialog = ({
   open,
   title,
   children,
@@ -113,7 +113,7 @@ export function Dialog({
   onResponse,
   className,
   ...props
-}: DialogProps) {
+}: DialogProps) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   const titleId = useId();
   const previouslyFocused = useRef<Element | null>(null);
@@ -245,4 +245,4 @@ export function Dialog({
   }
 
   return createPortal(node, document.body);
-}
+};

--- a/packages/react/src/components/Dialog/README.md
+++ b/packages/react/src/components/Dialog/README.md
@@ -1,0 +1,9 @@
+Blocking modal dialog — two modes in one component.
+
+**Standard** — `title` + `children` + `buttons[]`.
+
+**Alert** (`role="alertdialog"` + `responses[]` + `onResponse`) — for confirmations
+and destructive-action warnings. Screen readers announce it immediately.
+Escape / backdrop fire the first non-destructive response. Mirrors `AdwAlertDialog`.
+
+For the app-info dialog, use `<AboutDialog />` instead.

--- a/packages/react/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react/src/components/Drawer/Drawer.stories.tsx
@@ -7,6 +7,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 
 import { Drawer } from './Drawer';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Drawer> = {
   title: 'Components/Drawer',
@@ -15,11 +16,7 @@ const meta: Meta<typeof Drawer> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Slide-over panel for supplementary React content. Use \`side\` to open from the
-left or right, \`size\` for classic or wide widths, and pass the body through
-\`children\` or the \`content\` prop.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Drawer/Drawer.tsx
+++ b/packages/react/src/components/Drawer/Drawer.tsx
@@ -43,7 +43,7 @@ export interface DrawerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'conte
  * The drawer is controlled through `open`, renders into `document.body`, and
  * accepts its body as either `content` or `children`.
  */
-export function Drawer({
+export const Drawer = ({
   open,
   side = 'right',
   size = 'classic',
@@ -54,7 +54,7 @@ export function Drawer({
   closeOnBackdrop = true,
   className,
   ...props
-}: DrawerProps) {
+}: DrawerProps) => {
   const drawerRef = useRef<HTMLDivElement>(null);
   const titleId = useId();
   const previouslyFocused = useRef<Element | null>(null);
@@ -139,4 +139,4 @@ export function Drawer({
   }
 
   return createPortal(node, document.body);
-}
+};

--- a/packages/react/src/components/Drawer/README.md
+++ b/packages/react/src/components/Drawer/README.md
@@ -1,0 +1,3 @@
+Slide-over panel for supplementary React content. Use `side` to open from the
+left or right, `size` for classic or wide widths, and pass the body through
+`children` or the `content` prop.

--- a/packages/react/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 
 import { Dropdown } from './Dropdown';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Dropdown> = {
   title: 'Components/Dropdown',
@@ -13,17 +14,7 @@ const meta: Meta<typeof Dropdown> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Expandable option list following the Adwaita combo-row / drop-down style.
-
-### Guidelines
-- Use when the user must pick exactly one option from a list of 4 or more.
-- For 2–3 options prefer **Radio Buttons** (all choices visible at once).
-- Keep labels short — one to three words.
-- Provide a meaningful \`placeholder\` that describes what to select.
-- The list flips above the trigger when there is not enough space below.
-- Keyboard: Space / Enter / ↓ opens; ↑↓ navigates; Enter selects; Escape closes.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -50,7 +50,7 @@ export interface DropdownProps<V extends string = string>
  *
  * @see https://developer.gnome.org/hig/patterns/controls/drop-down-lists.html
  */
-export function Dropdown<V extends string = string>({
+export const Dropdown = <V extends string = string>({
   options,
   value,
   onChange,
@@ -58,7 +58,7 @@ export function Dropdown<V extends string = string>({
   disabled,
   className,
   ...props
-}: DropdownProps<V>) {
+}: DropdownProps<V>) => {
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number>(-1);
   const [flipUp, setFlipUp] = useState(false);
@@ -294,4 +294,4 @@ export function Dropdown<V extends string = string>({
       )}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Dropdown/README.md
+++ b/packages/react/src/components/Dropdown/README.md
@@ -1,0 +1,9 @@
+Expandable option list following the Adwaita combo-row / drop-down style.
+
+### Guidelines
+- Use when the user must pick exactly one option from a list of 4 or more.
+- For 2–3 options prefer **Radio Buttons** (all choices visible at once).
+- Keep labels short — one to three words.
+- Provide a meaningful `placeholder` that describes what to select.
+- The list flips above the trigger when there is not enough space below.
+- Keyboard: Space / Enter / ↓ opens; ↑↓ navigates; Enter selects; Escape closes.

--- a/packages/react/src/components/EntryRow/EntryRow.stories.tsx
+++ b/packages/react/src/components/EntryRow/EntryRow.stories.tsx
@@ -5,6 +5,7 @@ import { BoxedList } from '../BoxedList';
 import { Button } from '../Button';
 
 import { EntryRow } from './EntryRow';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof EntryRow> = {
   title: 'Components/EntryRow',
@@ -13,19 +14,7 @@ const meta: Meta<typeof EntryRow> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Row with an inline text entry field.
-
-Mirrors \`AdwEntryRow\` — the \`title\` acts as a floating label that rises above the
-input when the field is focused or has content. Use inside a \`BoxedList\` for
-settings that require free-form text input.
-
-### Guidelines
-- Use \`title\` as the label, not as a placeholder — it is always visible.
-- Add \`trailing\` widgets for actions like copy, clear, or reveal-password.
-- For passwords, set \`type="password"\` and provide a trailing reveal button.
-- Supports controlled (\`value\`) and uncontrolled (\`defaultValue\`) modes.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/EntryRow/EntryRow.tsx
+++ b/packages/react/src/components/EntryRow/EntryRow.tsx
@@ -32,7 +32,7 @@ export interface EntryRowProps extends InputHTMLAttributes<HTMLInputElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.EntryRow.html
  */
-export function EntryRow({
+export const EntryRow = ({
   title,
   value: controlledValue,
   defaultValue = '',
@@ -44,7 +44,7 @@ export function EntryRow({
   id: externalId,
   onChange,
   ...props
-}: EntryRowProps) {
+}: EntryRowProps) => {
   const generatedId = useId();
   const inputId = externalId ?? generatedId;
 
@@ -103,4 +103,4 @@ export function EntryRow({
       {trailing && <span className={styles.trailing}>{trailing}</span>}
     </div>
   );
-}
+};

--- a/packages/react/src/components/EntryRow/README.md
+++ b/packages/react/src/components/EntryRow/README.md
@@ -1,0 +1,11 @@
+Row with an inline text entry field.
+
+Mirrors `AdwEntryRow` — the `title` acts as a floating label that rises above the
+input when the field is focused or has content. Use inside a `BoxedList` for
+settings that require free-form text input.
+
+### Guidelines
+- Use `title` as the label, not as a placeholder — it is always visible.
+- Add `trailing` widgets for actions like copy, clear, or reveal-password.
+- For passwords, set `type="password"` and provide a trailing reveal button.
+- Supports controlled (`value`) and uncontrolled (`defaultValue`) modes.

--- a/packages/react/src/components/ExpanderRow/ExpanderRow.stories.tsx
+++ b/packages/react/src/components/ExpanderRow/ExpanderRow.stories.tsx
@@ -7,6 +7,7 @@ import { Button } from '../Button';
 import { Switch } from '../Switch';
 
 import { ExpanderRow } from './ExpanderRow';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ExpanderRow> = {
   title: 'Components/ExpanderRow',
@@ -15,20 +16,7 @@ const meta: Meta<typeof ExpanderRow> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Collapsible \`ActionRow\` that reveals nested rows on activation.
-
-Mirrors \`AdwExpanderRow\` — clicking the header row toggles a smooth reveal
-animation exposing child rows. Supports both **controlled** and **uncontrolled**
-expand state.
-
-### Guidelines
-- Always wrap in \`BoxedList\` for the canonical GNOME appearance.
-- Use for settings groups where sub-options only make sense when a parent option is relevant.
-- Nest \`ActionRow\`, \`ButtonRow\`, or any row-shaped element as children — separators are inserted automatically.
-- Use \`trailing\` for a value label or status indicator; stop event propagation inside interactive trailing widgets.
-- Do not nest \`ExpanderRow\` more than one level deep.
-      `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ExpanderRow/ExpanderRow.tsx
+++ b/packages/react/src/components/ExpanderRow/ExpanderRow.tsx
@@ -38,7 +38,7 @@ export interface ExpanderRowProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ExpanderRow.html
  */
-export function ExpanderRow({
+export const ExpanderRow = ({
   title,
   subtitle,
   leading,
@@ -49,7 +49,7 @@ export function ExpanderRow({
   onExpandedChange,
   className,
   ...props
-}: ExpanderRowProps) {
+}: ExpanderRowProps) => {
   const isControlled = controlledExpanded !== undefined;
   const [uncontrolledExpanded, setUncontrolledExpanded] = useState(defaultExpanded);
   const expanded = isControlled ? controlledExpanded : uncontrolledExpanded;
@@ -131,4 +131,4 @@ export function ExpanderRow({
       </div>
     </div>
   );
-}
+};

--- a/packages/react/src/components/ExpanderRow/README.md
+++ b/packages/react/src/components/ExpanderRow/README.md
@@ -1,0 +1,12 @@
+Collapsible `ActionRow` that reveals nested rows on activation.
+
+Mirrors `AdwExpanderRow` — clicking the header row toggles a smooth reveal
+animation exposing child rows. Supports both **controlled** and **uncontrolled**
+expand state.
+
+### Guidelines
+- Always wrap in `BoxedList` for the canonical GNOME appearance.
+- Use for settings groups where sub-options only make sense when a parent option is relevant.
+- Nest `ActionRow`, `ButtonRow`, or any row-shaped element as children — separators are inserted automatically.
+- Use `trailing` for a value label or status indicator; stop event propagation inside interactive trailing widgets.
+- Do not nest `ExpanderRow` more than one level deep.

--- a/packages/react/src/components/Footer/Footer.stories.tsx
+++ b/packages/react/src/components/Footer/Footer.stories.tsx
@@ -4,6 +4,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 
 import { Footer } from './Footer';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Footer> = {
   title: 'Components/Footer',
@@ -13,18 +14,7 @@ const meta: Meta<typeof Footer> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Bottom bar with leading/trailing slots and optional center content.
-
-Mirrors the \`HeaderBar\` pattern at the bottom of a view or window.
-
-### Guidelines
-- Use **flat** buttons (\`variant="flat"\`) for actions inside the footer.
-- Keep content minimal — copyright, secondary links, status info.
-- Place primary info (copyright, version) on the **leading** side.
-- Place secondary actions (links, settings) on the **trailing** side.
-- Use \`flat\` when the footer is visually separated from content by another boundary.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Footer/Footer.tsx
+++ b/packages/react/src/components/Footer/Footer.tsx
@@ -24,7 +24,14 @@ export interface FooterProps extends HTMLAttributes<HTMLElement> {
  *
  * @see https://developer.gnome.org/hig/patterns/containers/header-bars.html
  */
-export function Footer({ start, end, children, flat = false, className, ...props }: FooterProps) {
+export const Footer = ({
+  start,
+  end,
+  children,
+  flat = false,
+  className,
+  ...props
+}: FooterProps) => {
   return (
     <footer
       className={[styles.footer, flat ? styles.flat : null, className].filter(Boolean).join(' ')}
@@ -39,4 +46,4 @@ export function Footer({ start, end, children, flat = false, className, ...props
       <div className={[styles.slot, styles.slotEnd].filter(Boolean).join(' ')}>{end}</div>
     </footer>
   );
-}
+};

--- a/packages/react/src/components/Footer/README.md
+++ b/packages/react/src/components/Footer/README.md
@@ -1,0 +1,10 @@
+Bottom bar with leading/trailing slots and optional center content.
+
+Mirrors the `HeaderBar` pattern at the bottom of a view or window.
+
+### Guidelines
+- Use **flat** buttons (`variant="flat"`) for actions inside the footer.
+- Keep content minimal — copyright, secondary links, status info.
+- Place primary info (copyright, version) on the **leading** side.
+- Place secondary actions (links, settings) on the **trailing** side.
+- Use `flat` when the footer is visually separated from content by another boundary.

--- a/packages/react/src/components/Frame/Frame.stories.tsx
+++ b/packages/react/src/components/Frame/Frame.stories.tsx
@@ -5,6 +5,7 @@ import { BoxedList } from '../BoxedList';
 import { Switch } from '../Switch';
 
 import { Frame } from './Frame';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Frame> = {
   title: 'Components/Frame',
@@ -13,17 +14,7 @@ const meta: Meta<typeof Frame> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Simple bordered surface with \`border-radius\` but no background fill.
-
-Use to visually delimit a region without adding the elevated appearance of a \`Card\`.
-Mirrors \`GtkFrame\` default styling and the libadwaita \`.frame\` style class.
-
-### Guidelines
-- Use \`Frame\` when you need a visible boundary without a background (e.g. wrapping a media preview, a canvas area, or a list).
-- Use \`Card\` when you need an elevated surface with its own background.
-- \`Frame\` clips its children via \`overflow: hidden\`, so inner content respects the border radius.
-      `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Frame/Frame.tsx
+++ b/packages/react/src/components/Frame/Frame.tsx
@@ -15,10 +15,10 @@ export interface FrameProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1-latest/style-classes.html#frame-style-class
  */
-export function Frame({ children, className, ...props }: FrameProps) {
+export const Frame = ({ children, className, ...props }: FrameProps) => {
   return (
     <div className={[styles.frame, className].filter(Boolean).join(' ')} {...props}>
       {children}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Frame/README.md
+++ b/packages/react/src/components/Frame/README.md
@@ -1,0 +1,9 @@
+Simple bordered surface with `border-radius` but no background fill.
+
+Use to visually delimit a region without adding the elevated appearance of a `Card`.
+Mirrors `GtkFrame` default styling and the libadwaita `.frame` style class.
+
+### Guidelines
+- Use `Frame` when you need a visible boundary without a background (e.g. wrapping a media preview, a canvas area, or a list).
+- Use `Card` when you need an elevated surface with its own background.
+- `Frame` clips its children via `overflow: hidden`, so inner content respects the border radius.

--- a/packages/react/src/components/GnomeProvider/GnomeProvider.test.tsx
+++ b/packages/react/src/components/GnomeProvider/GnomeProvider.test.tsx
@@ -23,17 +23,17 @@ function mockMatchMedia(matches: boolean) {
   });
 }
 
-function FormattedNumber({ value }: { value: number }) {
+const FormattedNumber = ({ value }: { value: number }) => {
   const formatter = useNumberFormatter();
 
   return <span>{formatter.format(value)}</span>;
-}
+};
 
-function FormattedMonth({ value }: { value: Date }) {
+const FormattedMonth = ({ value }: { value: Date }) => {
   const formatter = useDateTimeFormatter({ month: 'short' });
 
   return <span>{formatter.format(value)}</span>;
-}
+};
 
 describe('GnomeProvider colorScheme', () => {
   afterEach(() => {
@@ -72,9 +72,10 @@ describe('GnomeProvider colorScheme', () => {
 
   it('exposes colorScheme via useColorScheme', () => {
     mockMatchMedia(false);
-    function Reader() {
+    const Reader = () => {
       return <span>{useColorScheme()}</span>;
-    }
+    };
+
     render(
       <GnomeProvider colorScheme="dark">
         <Reader />
@@ -85,9 +86,10 @@ describe('GnomeProvider colorScheme', () => {
 
   it('resolves system to light when OS is light', () => {
     mockMatchMedia(false);
-    function Reader() {
+    const Reader = () => {
       return <span>{useResolvedColorScheme()}</span>;
-    }
+    };
+
     render(
       <GnomeProvider colorScheme="system">
         <Reader />
@@ -98,9 +100,10 @@ describe('GnomeProvider colorScheme', () => {
 
   it('resolves system to dark when OS is dark', () => {
     mockMatchMedia(true);
-    function Reader() {
+    const Reader = () => {
       return <span>{useResolvedColorScheme()}</span>;
-    }
+    };
+
     render(
       <GnomeProvider colorScheme="system">
         <Reader />
@@ -172,9 +175,10 @@ describe('GnomeProvider accentColor', () => {
 
   it('exposes accentColor via useAccentColor', () => {
     mockMatchMedia(false);
-    function Reader() {
+    const Reader = () => {
       return <span>{useAccentColor()}</span>;
-    }
+    };
+
     render(
       <GnomeProvider accentColor="red">
         <Reader />

--- a/packages/react/src/components/GnomeProvider/GnomeProvider.tsx
+++ b/packages/react/src/components/GnomeProvider/GnomeProvider.tsx
@@ -57,7 +57,7 @@ function getSystemIsDark(): boolean {
 }
 
 /** Provides locale, text direction, color scheme, and accent color to all descendant gnome-ui components. */
-export function GnomeProvider({
+export const GnomeProvider = ({
   locale,
   dir = 'ltr',
   numberFormat,
@@ -65,7 +65,7 @@ export function GnomeProvider({
   colorScheme = 'system',
   accentColor = 'blue',
   children,
-}: GnomeProviderProps) {
+}: GnomeProviderProps) => {
   const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
 
   useEffect(() => {
@@ -128,4 +128,4 @@ export function GnomeProvider({
   );
 
   return <GnomeContext.Provider value={value}>{children}</GnomeContext.Provider>;
-}
+};

--- a/packages/react/src/components/HeaderBar/HeaderBar.stories.tsx
+++ b/packages/react/src/components/HeaderBar/HeaderBar.stories.tsx
@@ -4,6 +4,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 
 import { HeaderBar } from './HeaderBar';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof HeaderBar> = {
   title: 'Components/HeaderBar',
@@ -13,19 +14,7 @@ const meta: Meta<typeof HeaderBar> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Title bar with centered title and leading/trailing action slots.
-
-Mirrors the Adwaita \`AdwHeaderBar\` pattern.
-
-### Guidelines
-- Use **flat** buttons (\`variant="flat"\`) for all controls inside the header bar.
-- Keep the title short and centered — it should name the current view, not the app.
-- Place primary navigation controls (back, menu) on the **leading** side.
-- Place secondary actions (add, share, overflow menu) on the **trailing** side.
-- Use at most 2–3 actions per side; move the rest into an overflow menu.
-- Use \`flat\` on the topmost bar of a full-window layout to blend with the window chrome.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/HeaderBar/HeaderBar.tsx
+++ b/packages/react/src/components/HeaderBar/HeaderBar.tsx
@@ -26,14 +26,14 @@ export interface HeaderBarProps extends Omit<HTMLAttributes<HTMLElement>, 'title
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.HeaderBar.html
  * @see https://developer.gnome.org/hig/patterns/containers/header-bars.html
  */
-export function HeaderBar({
+export const HeaderBar = ({
   title,
   start,
   end,
   flat = false,
   className,
   ...props
-}: HeaderBarProps) {
+}: HeaderBarProps) => {
   return (
     <header
       className={[styles.headerBar, flat ? styles.flat : null, className].filter(Boolean).join(' ')}
@@ -51,4 +51,4 @@ export function HeaderBar({
       <div className={[styles.slot, styles.slotEnd].filter(Boolean).join(' ')}>{end}</div>
     </header>
   );
-}
+};

--- a/packages/react/src/components/HeaderBar/README.md
+++ b/packages/react/src/components/HeaderBar/README.md
@@ -1,0 +1,11 @@
+Title bar with centered title and leading/trailing action slots.
+
+Mirrors the Adwaita `AdwHeaderBar` pattern.
+
+### Guidelines
+- Use **flat** buttons (`variant="flat"`) for all controls inside the header bar.
+- Keep the title short and centered — it should name the current view, not the app.
+- Place primary navigation controls (back, menu) on the **leading** side.
+- Place secondary actions (add, share, overflow menu) on the **trailing** side.
+- Use at most 2–3 actions per side; move the rest into an overflow menu.
+- Use `flat` on the topmost bar of a full-window layout to blend with the window chrome.

--- a/packages/react/src/components/Icon/Icon.stories.tsx
+++ b/packages/react/src/components/Icon/Icon.stories.tsx
@@ -169,7 +169,7 @@ const CATEGORIES: IconGalleryCategory[] = [
 
 const TOTAL = CATEGORIES.reduce((n, c) => n + c.items.length, 0);
 
-function IconTile({ name, icon }: { name: string; icon: Icons.IconDefinition }) {
+const IconTile = ({ name, icon }: { name: string; icon: Icons.IconDefinition }) => {
   const [copied, setCopied] = useState(false);
 
   function handleClick() {
@@ -226,7 +226,7 @@ function IconTile({ name, icon }: { name: string; icon: Icons.IconDefinition }) 
       </span>
     </button>
   );
-}
+};
 
 export const Gallery: Story = {
   render: () => (

--- a/packages/react/src/components/Icon/Icon.stories.tsx
+++ b/packages/react/src/components/Icon/Icon.stories.tsx
@@ -13,25 +13,7 @@ const meta: Meta<typeof Icon> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Renders an [\`@gnome-ui/icons\`](https://www.npmjs.com/package/@gnome-ui/icons) definition as an inline SVG.
-
-Icons are **framework-agnostic** path data objects — the \`Icon\` component is the React adapter.
-Uses \`currentColor\` so the icon automatically inherits the parent's text color.
-
-### Guidelines
-- Pass \`label\` only when the icon stands alone (no sibling text). Otherwise omit it — the icon is marked \`aria-hidden\`.
-- Use \`size="sm"\` (12 px) for dense UIs, \`"md"\` (16 px, default) for inline icons, \`"lg"\` (20 px) for standalone icons.
-- Pair with \`<Button variant="flat">\` for icon buttons in header bars.
-
-### Usage
-\`\`\`tsx
-import { Icon } from "@gnome-ui/react";
-import { Search } from "@gnome-ui/icons";
-
-<Icon icon={Search} size="md" label="Search" />
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },
@@ -293,6 +275,7 @@ The viewBox defaults to \`"0 0 24 24"\` — the simple-icons standard.
 
 \`\`\`tsx
 import { siGithub } from "simple-icons";
+import readme from './README.md?raw';
 <Icon icon={siGithub} label="GitHub" />
 \`\`\``,
       },

--- a/packages/react/src/components/Icon/Icon.tsx
+++ b/packages/react/src/components/Icon/Icon.tsx
@@ -41,7 +41,7 @@ function isIconDefinition(icon: AnyIconDefinition): icon is IconDefinition {
  * import { siGithub } from "simple-icons";
  * <Icon icon={siGithub} label="GitHub" />
  */
-export function Icon({ icon, size = 'md', label, width, height, ...props }: IconProps) {
+export const Icon = ({ icon, size = 'md', label, width, height, ...props }: IconProps) => {
   const px = SIZE_MAP[size];
 
   const resolvedViewBox = isIconDefinition(icon) ? icon.viewBox : (icon.viewBox ?? '0 0 24 24');
@@ -68,4 +68,4 @@ export function Icon({ icon, size = 'md', label, width, height, ...props }: Icon
       {paths}
     </svg>
   );
-}
+};

--- a/packages/react/src/components/Icon/README.md
+++ b/packages/react/src/components/Icon/README.md
@@ -1,0 +1,17 @@
+Renders an [`@gnome-ui/icons`](https://www.npmjs.com/package/@gnome-ui/icons) definition as an inline SVG.
+
+Icons are **framework-agnostic** path data objects — the `Icon` component is the React adapter.
+Uses `currentColor` so the icon automatically inherits the parent's text color.
+
+### Guidelines
+- Pass `label` only when the icon stands alone (no sibling text). Otherwise omit it — the icon is marked `aria-hidden`.
+- Use `size="sm"` (12 px) for dense UIs, `"md"` (16 px, default) for inline icons, `"lg"` (20 px) for standalone icons.
+- Pair with `<Button variant="flat">` for icon buttons in header bars.
+
+### Usage
+```tsx
+import { Icon } from "@gnome-ui/react";
+import { Search } from "@gnome-ui/icons";
+
+<Icon icon={Search} size="md" label="Search" />
+```

--- a/packages/react/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/react/src/components/IconButton/IconButton.stories.tsx
@@ -2,11 +2,15 @@ import { Delete, Refresh, Save, Search, Settings } from '@gnome-ui/icons';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { IconButton } from './IconButton';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof IconButton> = {
   title: 'Components/IconButton',
   component: IconButton,
   tags: ['autodocs'],
+  parameters: {
+    docs: { description: { component: readme } },
+  },
   argTypes: {
     variant: {
       control: 'select',

--- a/packages/react/src/components/IconButton/README.md
+++ b/packages/react/src/components/IconButton/README.md
@@ -1,0 +1,41 @@
+Icon-only action button composed from `Button`, `Icon`, and optionally `Tooltip`.
+
+`label` is required as the accessible name since the button has no visible text. Optionally pass `tooltip` to show it on hover/focus.
+
+```tsx
+import { Search, Settings } from '@gnome-ui/icons';
+import { IconButton } from '@gnome-ui/react';
+
+<IconButton icon={Search} label="Search" />
+<IconButton icon={Settings} label="Settings" variant="flat" tooltip="Open settings" />
+```
+
+### Variants
+
+| Variant | Use case |
+|---------|----------|
+| `default` | Standard toolbar action |
+| `suggested` | Primary recommended action |
+| `destructive` | Irreversible action (delete, remove) |
+| `flat` | Low-emphasis, no background |
+| `raised` | Elevated surface (floating button) |
+| `osd` | On-screen display overlay (media controls) |
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `icon` | `IconDefinition` | — | Icon from `@gnome-ui/icons` |
+| `label` | `string` | — | Accessible name (required) |
+| `variant` | `IconButtonVariant` | `"default"` | Visual style |
+| `size` | `"sm" \| "md" \| "lg"` | `"md"` | Button size |
+| `iconSize` | `IconSize` | matches `size` | Override icon size independently |
+| `tooltip` | `string` | — | Tooltip text shown on hover/focus |
+| `tooltipPlacement` | `TooltipPlacement` | `"top"` | Preferred tooltip position |
+| `tooltipDelay` | `number` | — | Tooltip delay in ms |
+
+### Guidelines
+
+- Always provide a descriptive `label` — it is the only accessible name.
+- Use `tooltip` to expose the label visually when context is ambiguous.
+- Use `osd` variant for media overlays on dark or blurred backgrounds.

--- a/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcher.stories.tsx
+++ b/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcher.stories.tsx
@@ -6,6 +6,7 @@ import { HeaderBar } from '../HeaderBar';
 
 import { InlineViewSwitcher } from './InlineViewSwitcher';
 import { InlineViewSwitcherItem } from './InlineViewSwitcherItem';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof InlineViewSwitcher> = {
   title: 'Components/InlineViewSwitcher',
@@ -14,28 +15,7 @@ const meta: Meta<typeof InlineViewSwitcher> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Compact inline view switcher for placing inside content areas, cards, or toolbars.
-
-Use when \`ViewSwitcher\` (header-bar sized) is too heavy — \`InlineViewSwitcher\` sits
-comfortably inline with other content. Mirrors \`AdwInlineViewSwitcher\`
-(libadwaita 1.7 / GNOME 48).
-
-Compose with \`InlineViewSwitcherItem\`. Keyboard: **← →** cycle, **Home / End** jump.
-
-### Variants
-| Variant | When to use |
-|---------|-------------|
-| \`default\` | Standalone control with clear elevation — inside cards or content areas |
-| \`flat\` | Inside a toolbar or header bar background — blends with the surface |
-| \`round\` | Prominent pill shape with accent active indicator |
-| \`pill\` | Segmented-control style — active item lifted, no accent color (Following tabs) |
-
-### Guidelines
-- Prefer \`ViewSwitcher\` in a \`HeaderBar\` for top-level navigation.
-- Use \`InlineViewSwitcher\` for secondary, in-context view switching (e.g. chart type, layout mode).
-- Always provide an \`aria-label\` on the container and \`aria-label\` on icon-only items.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcher.tsx
+++ b/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcher.tsx
@@ -62,7 +62,7 @@ export interface InlineViewSwitcherProps extends HTMLAttributes<HTMLDivElement> 
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.InlineViewSwitcher.html
  */
-export function InlineViewSwitcher({
+export const InlineViewSwitcher = ({
   value,
   onValueChange,
   variant = 'default',
@@ -70,7 +70,7 @@ export function InlineViewSwitcher({
   children,
   className,
   ...props
-}: InlineViewSwitcherProps) {
+}: InlineViewSwitcherProps) => {
   const groupRef = useRef<HTMLDivElement>(null);
 
   function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
@@ -116,4 +116,4 @@ export function InlineViewSwitcher({
       </div>
     </InlineViewSwitcherContext.Provider>
   );
-}
+};

--- a/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcherItem.tsx
+++ b/packages/react/src/components/InlineViewSwitcher/InlineViewSwitcherItem.tsx
@@ -21,14 +21,14 @@ export interface InlineViewSwitcherItemProps extends ButtonHTMLAttributes<HTMLBu
  * Can be icon-only, label-only, or icon + label. For icon-only items always
  * provide an `aria-label` so screen readers can identify the view.
  */
-export function InlineViewSwitcherItem({
+export const InlineViewSwitcherItem = ({
   name,
   label,
   icon,
   disabled,
   className,
   ...props
-}: InlineViewSwitcherItemProps) {
+}: InlineViewSwitcherItemProps) => {
   const { value, onValueChange } = useInlineViewSwitcher();
   const active = value === name;
   const iconOnly = icon && !label;
@@ -59,4 +59,4 @@ export function InlineViewSwitcherItem({
       {label && <span className={styles.itemLabel}>{label}</span>}
     </button>
   );
-}
+};

--- a/packages/react/src/components/InlineViewSwitcher/README.md
+++ b/packages/react/src/components/InlineViewSwitcher/README.md
@@ -1,0 +1,20 @@
+Compact inline view switcher for placing inside content areas, cards, or toolbars.
+
+Use when `ViewSwitcher` (header-bar sized) is too heavy — `InlineViewSwitcher` sits
+comfortably inline with other content. Mirrors `AdwInlineViewSwitcher`
+(libadwaita 1.7 / GNOME 48).
+
+Compose with `InlineViewSwitcherItem`. Keyboard: **← →** cycle, **Home / End** jump.
+
+### Variants
+| Variant | When to use |
+|---------|-------------|
+| `default` | Standalone control with clear elevation — inside cards or content areas |
+| `flat` | Inside a toolbar or header bar background — blends with the surface |
+| `round` | Prominent pill shape with accent active indicator |
+| `pill` | Segmented-control style — active item lifted, no accent color (Following tabs) |
+
+### Guidelines
+- Prefer `ViewSwitcher` in a `HeaderBar` for top-level navigation.
+- Use `InlineViewSwitcher` for secondary, in-context view switching (e.g. chart type, layout mode).
+- Always provide an `aria-label` on the container and `aria-label` on icon-only items.

--- a/packages/react/src/components/Link/Link.stories.tsx
+++ b/packages/react/src/components/Link/Link.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Text } from '../Text';
 
 import { Link } from './Link';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Link> = {
   title: 'Components/Link',
@@ -11,13 +12,7 @@ const meta: Meta<typeof Link> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Inline hyperlink following GNOME HIG.
-
-- Accent-coloured text with an animated underline on hover.
-- \`external\` prop (or \`target="_blank"\`) opens in a new tab safely and appends a visual ↗ indicator.
-- Fully keyboard accessible with a focus ring.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Link/Link.tsx
+++ b/packages/react/src/components/Link/Link.tsx
@@ -19,7 +19,14 @@ export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
  *
  * @see https://developer.gnome.org/hig/patterns/controls/links.html
  */
-export function Link({ external = false, children, className, target, rel, ...props }: LinkProps) {
+export const Link = ({
+  external = false,
+  children,
+  className,
+  target,
+  rel,
+  ...props
+}: LinkProps) => {
   const isExternal = external || target === '_blank';
 
   return (
@@ -37,4 +44,4 @@ export function Link({ external = false, children, className, target, rel, ...pr
       )}
     </a>
   );
-}
+};

--- a/packages/react/src/components/Link/README.md
+++ b/packages/react/src/components/Link/README.md
@@ -1,0 +1,5 @@
+Inline hyperlink following GNOME HIG.
+
+- Accent-coloured text with an animated underline on hover.
+- `external` prop (or `target="_blank"`) opens in a new tab safely and appends a visual ↗ indicator.
+- Fully keyboard accessible with a focus ring.

--- a/packages/react/src/components/LinkedGroup/LinkedGroup.stories.tsx
+++ b/packages/react/src/components/LinkedGroup/LinkedGroup.stories.tsx
@@ -4,6 +4,7 @@ import { Button } from '../Button';
 import { TextField } from '../TextField';
 
 import { LinkedGroup } from './LinkedGroup';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof LinkedGroup> = {
   title: 'Components/LinkedGroup',
@@ -12,25 +13,7 @@ const meta: Meta<typeof LinkedGroup> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Renders children as a single visually-connected unit with no gap and merged borders.
-
-The canonical GNOME pattern for button groups and segmented inputs — mirrors the
-libadwaita \`.linked\` style class.
-
-### How it works
-- First child retains its outer border radius (left side or top side).
-- Last child retains its outer border radius (right side or bottom side).
-- All middle children have their border radius removed.
-- Adjacent borders are collapsed to a single pixel via \`margin: -1px\`.
-- Hovered and focused children are raised with \`z-index\` so their border stays visible.
-
-### Guidelines
-- Use for tightly related actions that form a logical group (Cut/Copy/Paste, Zoom −/+).
-- Use \`vertical\` for stacked inputs or option lists.
-- Prefer \`ToggleGroup\` for mutually-exclusive toggle buttons — \`LinkedGroup\` is for generic grouping.
-- Avoid mixing very different widget types (e.g. a button and a text field) unless the UX warrants it.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/LinkedGroup/LinkedGroup.tsx
+++ b/packages/react/src/components/LinkedGroup/LinkedGroup.tsx
@@ -32,7 +32,12 @@ export interface LinkedGroupProps extends HTMLAttributes<HTMLDivElement> {
  *   <Button>Paste</Button>
  * </LinkedGroup>
  */
-export function LinkedGroup({ children, vertical = false, className, ...props }: LinkedGroupProps) {
+export const LinkedGroup = ({
+  children,
+  vertical = false,
+  className,
+  ...props
+}: LinkedGroupProps) => {
   const classes = [styles.linked, vertical ? styles.vertical : null, className]
     .filter(Boolean)
     .join(' ');
@@ -42,4 +47,4 @@ export function LinkedGroup({ children, vertical = false, className, ...props }:
       {children}
     </div>
   );
-}
+};

--- a/packages/react/src/components/LinkedGroup/README.md
+++ b/packages/react/src/components/LinkedGroup/README.md
@@ -1,0 +1,17 @@
+Renders children as a single visually-connected unit with no gap and merged borders.
+
+The canonical GNOME pattern for button groups and segmented inputs — mirrors the
+libadwaita `.linked` style class.
+
+### How it works
+- First child retains its outer border radius (left side or top side).
+- Last child retains its outer border radius (right side or bottom side).
+- All middle children have their border radius removed.
+- Adjacent borders are collapsed to a single pixel via `margin: -1px`.
+- Hovered and focused children are raised with `z-index` so their border stays visible.
+
+### Guidelines
+- Use for tightly related actions that form a logical group (Cut/Copy/Paste, Zoom −/+).
+- Use `vertical` for stacked inputs or option lists.
+- Prefer `ToggleGroup` for mutually-exclusive toggle buttons — `LinkedGroup` is for generic grouping.
+- Avoid mixing very different widget types (e.g. a button and a text field) unless the UX warrants it.

--- a/packages/react/src/components/NavigationSplitView/NavigationSplitView.stories.tsx
+++ b/packages/react/src/components/NavigationSplitView/NavigationSplitView.stories.tsx
@@ -11,6 +11,7 @@ import { SidebarItem } from '../Sidebar/SidebarItem';
 import { Text } from '../Text';
 
 import { NavigationSplitView } from './NavigationSplitView';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof NavigationSplitView> = {
   title: 'Adaptive/NavigationSplitView',
@@ -20,18 +21,7 @@ const meta: Meta<typeof NavigationSplitView> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Two-pane sidebar + content layout that collapses to a single navigable pane on narrow screens (≤ 400 px), mirroring \`AdwNavigationSplitView\`.
-
-- **Wide (> 400 px):** sidebar and content are side-by-side. \`showContent\` is ignored.
-- **Narrow (≤ 400 px):** only one pane is visible at a time. Use \`showContent\` to switch.
-
-### Guidelines
-- Use for apps with a list → detail navigation pattern (mail, files, contacts).
-- The sidebar should contain a navigable list; the content pane shows the selected item.
-- On narrow screens, add a **Back** button to the content header bar so users can return to the sidebar.
-- The \`showContent\` prop is typically driven by whether a selection has been made.
-      `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/NavigationSplitView/NavigationSplitView.tsx
+++ b/packages/react/src/components/NavigationSplitView/NavigationSplitView.tsx
@@ -58,7 +58,7 @@ export interface NavigationSplitViewProps extends Omit<HTMLAttributes<HTMLDivEle
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.NavigationSplitView.html
  */
-export function NavigationSplitView({
+export const NavigationSplitView = ({
   sidebar,
   content,
   showContent = false,
@@ -68,7 +68,7 @@ export function NavigationSplitView({
   className,
   style,
   ...props
-}: NavigationSplitViewProps) {
+}: NavigationSplitViewProps) => {
   const { isNarrow } = useBreakpoint();
 
   // CSS custom property drives the sidebar width clamp
@@ -112,4 +112,4 @@ export function NavigationSplitView({
       </div>
     </div>
   );
-}
+};

--- a/packages/react/src/components/NavigationSplitView/README.md
+++ b/packages/react/src/components/NavigationSplitView/README.md
@@ -1,0 +1,10 @@
+Two-pane sidebar + content layout that collapses to a single navigable pane on narrow screens (≤ 400 px), mirroring `AdwNavigationSplitView`.
+
+- **Wide (> 400 px):** sidebar and content are side-by-side. `showContent` is ignored.
+- **Narrow (≤ 400 px):** only one pane is visible at a time. Use `showContent` to switch.
+
+### Guidelines
+- Use for apps with a list → detail navigation pattern (mail, files, contacts).
+- The sidebar should contain a navigable list; the content pane shows the selected item.
+- On narrow screens, add a **Back** button to the content header bar so users can return to the sidebar.
+- The `showContent` prop is typically driven by whether a selection has been made.

--- a/packages/react/src/components/NavigationView/NavigationView.stories.tsx
+++ b/packages/react/src/components/NavigationView/NavigationView.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 
 import { NavigationPage, NavigationView, useNavigation } from './NavigationView';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof NavigationView> = {
   title: 'Components/NavigationView',
@@ -15,18 +16,7 @@ const meta: Meta<typeof NavigationView> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Single-pane push/pop navigation stack.
-
-Mirrors \`AdwNavigationView\` — the mobile-first counterpart to \`NavigationSplitView\`.
-Compose \`NavigationPage\` children and use \`useNavigation()\` inside them to push/pop pages.
-
-### Usage
-- Each \`NavigationPage\` has a unique \`tag\` and a \`title\`.
-- Call \`navigate(tag)\` to push a new page onto the stack.
-- Call \`pop()\` to go back one page.
-- \`canGoBack\` is \`true\` when there is a page to return to.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/NavigationView/NavigationView.stories.tsx
+++ b/packages/react/src/components/NavigationView/NavigationView.stories.tsx
@@ -43,7 +43,7 @@ type Story = StoryObj<typeof NavigationView>;
 
 // ─── Inner pages (use hook) ────────────────────────────────────────────────────
 
-function HomePage() {
+const HomePage = () => {
   const { navigate } = useNavigation();
 
   return (
@@ -58,9 +58,9 @@ function HomePage() {
       </BoxedList>
     </div>
   );
-}
+};
 
-function DetailPage({ name }: { name: string }) {
+const DetailPage = ({ name }: { name: string }) => {
   const { pop, canGoBack } = useNavigation();
 
   return (
@@ -75,7 +75,7 @@ function DetailPage({ name }: { name: string }) {
       )}
     </div>
   );
-}
+};
 
 // ─── Default ───────────────────────────────────────────────────────────────────
 
@@ -117,7 +117,7 @@ export const Default: Story = {
 
 // ─── Deep stack ────────────────────────────────────────────────────────────────
 
-function LevelPage({ level }: { level: number }) {
+const LevelPage = ({ level }: { level: number }) => {
   const { navigate, pop, canGoBack } = useNavigation();
 
   return (
@@ -135,7 +135,7 @@ function LevelPage({ level }: { level: number }) {
       </div>
     </div>
   );
-}
+};
 
 export const DeepStack: Story = {
   render: () => (

--- a/packages/react/src/components/NavigationView/NavigationView.tsx
+++ b/packages/react/src/components/NavigationView/NavigationView.tsx
@@ -45,7 +45,13 @@ export interface NavigationPageProps extends HTMLAttributes<HTMLDivElement> {
  * A single page inside a `NavigationView`.
  * Only visible when its `tag` matches the current page in the stack.
  */
-export function NavigationPage({ tag, title, children, className, ...props }: NavigationPageProps) {
+export const NavigationPage = ({
+  tag,
+  title,
+  children,
+  className,
+  ...props
+}: NavigationPageProps) => {
   const { currentTag, direction } = useContext(NavigationContext);
 
   if (currentTag !== tag) {
@@ -69,7 +75,7 @@ export function NavigationPage({ tag, title, children, className, ...props }: Na
       <div className={styles.pageContent}>{children}</div>
     </div>
   );
-}
+};
 
 // ─── NavigationView ───────────────────────────────────────────────────────────
 
@@ -100,12 +106,12 @@ export interface NavigationViewProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.NavigationView.html
  */
-export function NavigationView({
+export const NavigationView = ({
   initialPage,
   children,
   className,
   ...props
-}: NavigationViewProps) {
+}: NavigationViewProps) => {
   const [stack, setStack] = useState<string[]>([initialPage]);
 
   const currentTag = stack[stack.length - 1];
@@ -133,4 +139,4 @@ export function NavigationView({
       </div>
     </NavigationContext.Provider>
   );
-}
+};

--- a/packages/react/src/components/NavigationView/README.md
+++ b/packages/react/src/components/NavigationView/README.md
@@ -1,0 +1,10 @@
+Single-pane push/pop navigation stack.
+
+Mirrors `AdwNavigationView` — the mobile-first counterpart to `NavigationSplitView`.
+Compose `NavigationPage` children and use `useNavigation()` inside them to push/pop pages.
+
+### Usage
+- Each `NavigationPage` has a unique `tag` and a `title`.
+- Call `navigate(tag)` to push a new page onto the stack.
+- Call `pop()` to go back one page.
+- `canGoBack` is `true` when there is a page to return to.

--- a/packages/react/src/components/OverlaySplitView/OverlaySplitView.stories.tsx
+++ b/packages/react/src/components/OverlaySplitView/OverlaySplitView.stories.tsx
@@ -11,6 +11,7 @@ import { SidebarItem } from '../Sidebar/SidebarItem';
 import { Text } from '../Text';
 
 import { OverlaySplitView } from './OverlaySplitView';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof OverlaySplitView> = {
   title: 'Adaptive/OverlaySplitView',
@@ -20,18 +21,7 @@ const meta: Meta<typeof OverlaySplitView> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Sidebar + content layout where the sidebar becomes a slide-over **overlay** on narrow screens (≤ 400 px), mirroring \`AdwOverlaySplitView\`.
-
-- **Wide (> 400 px):** sidebar and content are side-by-side. \`showSidebar\` is ignored.
-- **Narrow (≤ 400 px):** content fills full width; sidebar slides in as an overlay when \`showSidebar\` is true.
-
-### Guidelines
-- Use when the sidebar is contextual and not always needed (e.g. document outline, filters).
-- A hamburger / menu button in the HeaderBar typically toggles it on narrow screens.
-- Backdrop click and Escape close the overlay. Provide an \`onClose\` handler.
-- Prefer \`NavigationSplitView\` for primary list → detail navigation.
-      `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/OverlaySplitView/OverlaySplitView.tsx
+++ b/packages/react/src/components/OverlaySplitView/OverlaySplitView.tsx
@@ -68,7 +68,7 @@ export interface OverlaySplitViewProps extends Omit<HTMLAttributes<HTMLDivElemen
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.OverlaySplitView.html
  */
-export function OverlaySplitView({
+export const OverlaySplitView = ({
   sidebar,
   content,
   showSidebar = false,
@@ -81,7 +81,7 @@ export function OverlaySplitView({
   className,
   style,
   ...props
-}: OverlaySplitViewProps) {
+}: OverlaySplitViewProps) => {
   const { isNarrow } = useBreakpoint();
   const sidebarRef = useRef<HTMLDivElement>(null);
 
@@ -198,4 +198,4 @@ export function OverlaySplitView({
       <div className={styles.content}>{content}</div>
     </div>
   );
-}
+};

--- a/packages/react/src/components/OverlaySplitView/README.md
+++ b/packages/react/src/components/OverlaySplitView/README.md
@@ -1,0 +1,10 @@
+Sidebar + content layout where the sidebar becomes a slide-over **overlay** on narrow screens (≤ 400 px), mirroring `AdwOverlaySplitView`.
+
+- **Wide (> 400 px):** sidebar and content are side-by-side. `showSidebar` is ignored.
+- **Narrow (≤ 400 px):** content fills full width; sidebar slides in as an overlay when `showSidebar` is true.
+
+### Guidelines
+- Use when the sidebar is contextual and not always needed (e.g. document outline, filters).
+- A hamburger / menu button in the HeaderBar typically toggles it on narrow screens.
+- Backdrop click and Escape close the overlay. Provide an `onClose` handler.
+- Prefer `NavigationSplitView` for primary list → detail navigation.

--- a/packages/react/src/components/PasswordEntryRow/PasswordEntryRow.stories.tsx
+++ b/packages/react/src/components/PasswordEntryRow/PasswordEntryRow.stories.tsx
@@ -4,6 +4,7 @@ import { BoxedList } from '../BoxedList';
 import { EntryRow } from '../EntryRow';
 
 import { PasswordEntryRow } from './PasswordEntryRow';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof PasswordEntryRow> = {
   title: 'Components/PasswordEntryRow',
@@ -12,18 +13,7 @@ const meta: Meta<typeof PasswordEntryRow> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Password entry row with a built-in reveal/conceal toggle.
-
-Mirrors \`AdwPasswordEntryRow\` — an \`EntryRow\` variant that defaults to
-\`type="password"\` and provides a trailing icon button to show or hide the
-entered text. Use inside a \`BoxedList\` for password settings fields.
-
-### Guidelines
-- Use \`title\` as the floating label (e.g. "Password", "Confirm Password").
-- The reveal button is always present; do not replicate it via \`trailing\`.
-- Supports controlled (\`value\`) and uncontrolled (\`defaultValue\`) modes.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/PasswordEntryRow/PasswordEntryRow.tsx
+++ b/packages/react/src/components/PasswordEntryRow/PasswordEntryRow.tsx
@@ -20,7 +20,7 @@ export interface PasswordEntryRowProps extends Omit<EntryRowProps, 'type' | 'tra
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.PasswordEntryRow.html
  */
-export function PasswordEntryRow({ trailing, disabled, ...props }: PasswordEntryRowProps) {
+export const PasswordEntryRow = ({ trailing, disabled, ...props }: PasswordEntryRowProps) => {
   const [revealed, setRevealed] = useState(false);
 
   const revealButton = (
@@ -52,4 +52,4 @@ export function PasswordEntryRow({ trailing, disabled, ...props }: PasswordEntry
       }
     />
   );
-}
+};

--- a/packages/react/src/components/PasswordEntryRow/README.md
+++ b/packages/react/src/components/PasswordEntryRow/README.md
@@ -1,0 +1,10 @@
+Password entry row with a built-in reveal/conceal toggle.
+
+Mirrors `AdwPasswordEntryRow` — an `EntryRow` variant that defaults to
+`type="password"` and provides a trailing icon button to show or hide the
+entered text. Use inside a `BoxedList` for password settings fields.
+
+### Guidelines
+- Use `title` as the floating label (e.g. "Password", "Confirm Password").
+- The reveal button is always present; do not replicate it via `trailing`.
+- Supports controlled (`value`) and uncontrolled (`defaultValue`) modes.

--- a/packages/react/src/components/PathBar/PathBar.stories.tsx
+++ b/packages/react/src/components/PathBar/PathBar.stories.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import type { PathBarSegment } from './PathBar';
 import { PathBar } from './PathBar';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof PathBar> = {
   title: 'Components/PathBar',
@@ -11,27 +12,7 @@ const meta: Meta<typeof PathBar> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Breadcrumb path bar for navigating a hierarchical location.
-
-Mirrors the location bar in **GNOME Files (Nautilus)**. Segments are separated
-by chevron dividers. All segments except the last are interactive — clicking
-them calls \`onNavigate\`. The last segment represents the current location and
-is rendered as a bold, non-interactive label.
-
-\`\`\`tsx
-import { PathBar } from "@gnome-ui/react";
-
-<PathBar
-  segments={[
-    { label: "Home",      path: "/home"                     },
-    { label: "Documents", path: "/home/documents"           },
-    { label: "Projects",  path: "/home/documents/projects"  },
-  ]}
-  onNavigate={(path) => navigate(path)}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/PathBar/PathBar.tsx
+++ b/packages/react/src/components/PathBar/PathBar.tsx
@@ -34,7 +34,7 @@ export interface PathBarProps extends HTMLAttributes<HTMLElement> {
  *
  * @see https://developer.gnome.org/hig/patterns/nav/search.html
  */
-export function PathBar({ segments, onNavigate, className, ...props }: PathBarProps) {
+export const PathBar = ({ segments, onNavigate, className, ...props }: PathBarProps) => {
   return (
     <nav
       aria-label="Breadcrumb"
@@ -94,4 +94,4 @@ export function PathBar({ segments, onNavigate, className, ...props }: PathBarPr
       </ol>
     </nav>
   );
-}
+};

--- a/packages/react/src/components/PathBar/README.md
+++ b/packages/react/src/components/PathBar/README.md
@@ -1,0 +1,19 @@
+Breadcrumb path bar for navigating a hierarchical location.
+
+Mirrors the location bar in **GNOME Files (Nautilus)**. Segments are separated
+by chevron dividers. All segments except the last are interactive — clicking
+them calls `onNavigate`. The last segment represents the current location and
+is rendered as a bold, non-interactive label.
+
+```tsx
+import { PathBar } from "@gnome-ui/react";
+
+<PathBar
+  segments={[
+    { label: "Home",      path: "/home"                     },
+    { label: "Documents", path: "/home/documents"           },
+    { label: "Projects",  path: "/home/documents/projects"  },
+  ]}
+  onNavigate={(path) => navigate(path)}
+/>
+```

--- a/packages/react/src/components/Popover/Popover.stories.tsx
+++ b/packages/react/src/components/Popover/Popover.stories.tsx
@@ -10,6 +10,7 @@ import { Switch } from '../Switch';
 import { Text } from '../Text';
 
 import { Popover } from './Popover';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof Popover> = {
   title: 'Components/Popover',
@@ -19,18 +20,7 @@ const meta: Meta<typeof Popover> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Floating panel anchored to a trigger element, following the Adwaita \`GtkPopover\` pattern.
-
-Unlike **Tooltip**, a Popover can contain rich interactive content — menus, forms, sliders, toggles.
-
-### Guidelines
-- Use for secondary controls that are not important enough for permanent screen space.
-- Keep content focused — one task or group of related settings.
-- Prefer **Dialog** for actions that require confirmation or have significant consequences.
-- Provide a clear way to close: Escape key, outside click, and a close/done button for longer panels.
-- Supports both **uncontrolled** (toggle on trigger click) and **controlled** (\`open\` + \`onClose\`) modes.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Popover/Popover.stories.tsx
+++ b/packages/react/src/components/Popover/Popover.stories.tsx
@@ -252,7 +252,7 @@ export const Controlled: Story = {
 
 // ─── Edge detection ───────────────────────────────────────────────────────────
 
-function QuickSettingsContent() {
+const QuickSettingsContent = () => {
   const [wifi, setWifi] = useState(true);
   const [bluetooth, setBluetooth] = useState(false);
   const [brightness, setBrightness] = useState(70);
@@ -292,7 +292,7 @@ function QuickSettingsContent() {
       </div>
     </div>
   );
-}
+};
 
 export const EdgeDetection: Story = {
   render: () => (

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -2,8 +2,8 @@ import {
   cloneElement,
   type HTMLAttributes,
   type KeyboardEvent,
-  type MouseEvent as ReactMouseEvent,
   type ReactElement,
+  type MouseEvent as ReactMouseEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -199,14 +199,14 @@ function computePosition(
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Popover.html
  */
-export function Popover({
+export const Popover = ({
   content,
   placement: preferredPlacement = 'bottom',
   open: controlledOpen,
   onClose,
   onOpenChange,
   children,
-}: PopoverProps) {
+}: PopoverProps) => {
   const isControlled = controlledOpen !== undefined;
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const open = isControlled ? controlledOpen : uncontrolledOpen;
@@ -381,4 +381,4 @@ export function Popover({
       {open && (typeof document !== 'undefined' ? createPortal(panel, document.body) : panel)}
     </>
   );
-}
+};

--- a/packages/react/src/components/Popover/README.md
+++ b/packages/react/src/components/Popover/README.md
@@ -1,0 +1,10 @@
+Floating panel anchored to a trigger element, following the Adwaita `GtkPopover` pattern.
+
+Unlike **Tooltip**, a Popover can contain rich interactive content — menus, forms, sliders, toggles.
+
+### Guidelines
+- Use for secondary controls that are not important enough for permanent screen space.
+- Keep content focused — one task or group of related settings.
+- Prefer **Dialog** for actions that require confirmation or have significant consequences.
+- Provide a clear way to close: Escape key, outside click, and a close/done button for longer panels.
+- Supports both **uncontrolled** (toggle on trigger click) and **controlled** (`open` + `onClose`) modes.

--- a/packages/react/src/components/PreferencesDialog/PreferencesDialog.stories.tsx
+++ b/packages/react/src/components/PreferencesDialog/PreferencesDialog.stories.tsx
@@ -11,6 +11,7 @@ import { SpinRow } from '../SpinRow';
 import { SwitchRow } from '../SwitchRow';
 
 import { PreferencesDialog } from './PreferencesDialog';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof PreferencesDialog> = {
   title: 'Components/PreferencesDialog',
@@ -20,29 +21,7 @@ const meta: Meta<typeof PreferencesDialog> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Multi-page settings dialog using \`PreferencesPage\` tabs.
-
-Renders a wide modal with a sidebar listing pages on the left. Each
-\`PreferencesPage\` child becomes a navigation entry. When only one page
-is provided the sidebar is hidden. Supports built-in search via the
-\`searchable\` prop (default: \`true\`).
-
-Mirrors \`AdwPreferencesDialog\`.
-
-### Usage
-\`\`\`tsx
-<PreferencesDialog open={open} onClose={() => setOpen(false)}>
-  <PreferencesPage title="General" iconName="preferences-system-symbolic">
-    <PreferencesGroup title="Appearance">
-      <BoxedList>
-        <SwitchRow title="Dark mode" />
-      </BoxedList>
-    </PreferencesGroup>
-  </PreferencesPage>
-</PreferencesDialog>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/PreferencesDialog/PreferencesDialog.tsx
+++ b/packages/react/src/components/PreferencesDialog/PreferencesDialog.tsx
@@ -98,14 +98,14 @@ export interface PreferencesDialogProps extends Omit<HTMLAttributes<HTMLDivEleme
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.PreferencesDialog.html
  */
-export function PreferencesDialog({
+export const PreferencesDialog = ({
   open,
   onClose,
   children,
   searchable = true,
   className,
   ...props
-}: PreferencesDialogProps) {
+}: PreferencesDialogProps) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const titleId = useId();
@@ -254,4 +254,4 @@ export function PreferencesDialog({
     </div>,
     document.body,
   );
-}
+};

--- a/packages/react/src/components/PreferencesDialog/README.md
+++ b/packages/react/src/components/PreferencesDialog/README.md
@@ -1,0 +1,21 @@
+Multi-page settings dialog using `PreferencesPage` tabs.
+
+Renders a wide modal with a sidebar listing pages on the left. Each
+`PreferencesPage` child becomes a navigation entry. When only one page
+is provided the sidebar is hidden. Supports built-in search via the
+`searchable` prop (default: `true`).
+
+Mirrors `AdwPreferencesDialog`.
+
+### Usage
+```tsx
+<PreferencesDialog open={open} onClose={() => setOpen(false)}>
+  <PreferencesPage title="General" iconName="preferences-system-symbolic">
+    <PreferencesGroup title="Appearance">
+      <BoxedList>
+        <SwitchRow title="Dark mode" />
+      </BoxedList>
+    </PreferencesGroup>
+  </PreferencesPage>
+</PreferencesDialog>
+```

--- a/packages/react/src/components/PreferencesGroup/PreferencesGroup.stories.tsx
+++ b/packages/react/src/components/PreferencesGroup/PreferencesGroup.stories.tsx
@@ -7,6 +7,7 @@ import { ComboRow } from '../ComboRow';
 import { SwitchRow } from '../SwitchRow';
 
 import { PreferencesGroup } from './PreferencesGroup';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof PreferencesGroup> = {
   title: 'Components/PreferencesGroup',
@@ -15,20 +16,7 @@ const meta: Meta<typeof PreferencesGroup> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Titled section that wraps a \`BoxedList\` with an optional description.
-
-Use inside a \`PreferencesPage\` to group related settings under a named
-heading. The group is purely a layout and labelling wrapper — pass a
-\`BoxedList\` as \`children\`.
-
-Mirrors \`AdwPreferencesGroup\`.
-
-### Usage
-- \`title\` labels the group (e.g. "Appearance", "Privacy").
-- \`description\` adds a dimmed subtitle below the title.
-- \`headerSuffix\` places a widget (e.g. a reset Button) at the trailing edge of the header.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/PreferencesGroup/PreferencesGroup.tsx
+++ b/packages/react/src/components/PreferencesGroup/PreferencesGroup.tsx
@@ -24,14 +24,14 @@ export interface PreferencesGroupProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.PreferencesGroup.html
  */
-export function PreferencesGroup({
+export const PreferencesGroup = ({
   title,
   description,
   headerSuffix,
   children,
   className,
   ...props
-}: PreferencesGroupProps) {
+}: PreferencesGroupProps) => {
   const hasHeader = title || description || headerSuffix;
 
   return (
@@ -48,4 +48,4 @@ export function PreferencesGroup({
       <div className={styles.content}>{children}</div>
     </div>
   );
-}
+};

--- a/packages/react/src/components/PreferencesGroup/README.md
+++ b/packages/react/src/components/PreferencesGroup/README.md
@@ -1,0 +1,12 @@
+Titled section that wraps a `BoxedList` with an optional description.
+
+Use inside a `PreferencesPage` to group related settings under a named
+heading. The group is purely a layout and labelling wrapper — pass a
+`BoxedList` as `children`.
+
+Mirrors `AdwPreferencesGroup`.
+
+### Usage
+- `title` labels the group (e.g. "Appearance", "Privacy").
+- `description` adds a dimmed subtitle below the title.
+- `headerSuffix` places a widget (e.g. a reset Button) at the trailing edge of the header.

--- a/packages/react/src/components/PreferencesPage/PreferencesPage.stories.tsx
+++ b/packages/react/src/components/PreferencesPage/PreferencesPage.stories.tsx
@@ -8,6 +8,7 @@ import { SpinRow } from '../SpinRow';
 import { SwitchRow } from '../SwitchRow';
 
 import { PreferencesPage } from './PreferencesPage';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof PreferencesPage> = {
   title: 'Components/PreferencesPage',
@@ -16,19 +17,7 @@ const meta: Meta<typeof PreferencesPage> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Scrollable page composed of \`PreferencesGroup\` sections.
-
-Use as a child of \`PreferencesDialog\`. Each page appears as a labelled
-navigation entry in the dialog sidebar.
-
-Mirrors \`AdwPreferencesPage\`.
-
-### Usage
-- \`title\` is used as the sidebar navigation label.
-- \`iconName\` optionally places an icon next to the title in the sidebar.
-- Put \`PreferencesGroup\` children inside to build the page layout.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/PreferencesPage/PreferencesPage.tsx
+++ b/packages/react/src/components/PreferencesPage/PreferencesPage.tsx
@@ -27,16 +27,16 @@ export interface PreferencesPageProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.PreferencesPage.html
  */
-export function PreferencesPage({
+export const PreferencesPage = ({
   title: _title,
   iconName: _iconName,
   children,
   className,
   ...props
-}: PreferencesPageProps) {
+}: PreferencesPageProps) => {
   return (
     <div className={[styles.page, className].filter(Boolean).join(' ')} role="tabpanel" {...props}>
       <div className={styles.inner}>{children}</div>
     </div>
   );
-}
+};

--- a/packages/react/src/components/PreferencesPage/README.md
+++ b/packages/react/src/components/PreferencesPage/README.md
@@ -1,0 +1,11 @@
+Scrollable page composed of `PreferencesGroup` sections.
+
+Use as a child of `PreferencesDialog`. Each page appears as a labelled
+navigation entry in the dialog sidebar.
+
+Mirrors `AdwPreferencesPage`.
+
+### Usage
+- `title` is used as the sidebar navigation label.
+- `iconName` optionally places an icon next to the title in the sidebar.
+- Put `PreferencesGroup` children inside to build the page layout.

--- a/packages/react/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Text } from '../Text';
 
 import { ProgressBar } from './ProgressBar';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof ProgressBar> = {
   title: 'Components/ProgressBar',
@@ -12,16 +13,7 @@ const meta: Meta<typeof ProgressBar> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Determinate and indeterminate progress bar following the Adwaita style.
-
-### Guidelines
-- Use **determinate** (\`value\` 0–1) when you know the exact completion percentage.
-- Use **indeterminate** (no \`value\`) when duration is unknown — prefer \`Spinner\` for short waits.
-- Always provide an \`aria-label\` or \`aria-labelledby\` so screen readers can announce what is loading.
-- Pair with a text label to show the percentage or description alongside the bar.
-- Respects \`prefers-reduced-motion\` — the indeterminate animation is stopped and the bar shown at full width with reduced opacity.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.tsx
@@ -35,14 +35,14 @@ export interface ProgressBarProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://developer.gnome.org/hig/patterns/feedback/progress.html
  */
-export function ProgressBar({
+export const ProgressBar = ({
   value,
   variant = 'accent',
   className,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
   ...props
-}: ProgressBarProps) {
+}: ProgressBarProps) => {
   const isIndeterminate = value === undefined || value === null;
   const clamped = isIndeterminate ? undefined : Math.min(1, Math.max(0, value));
   const percent = clamped !== undefined ? clamped * 100 : undefined;
@@ -66,4 +66,4 @@ export function ProgressBar({
       />
     </div>
   );
-}
+};

--- a/packages/react/src/components/ProgressBar/README.md
+++ b/packages/react/src/components/ProgressBar/README.md
@@ -1,0 +1,8 @@
+Determinate and indeterminate progress bar following the Adwaita style.
+
+### Guidelines
+- Use **determinate** (`value` 0–1) when you know the exact completion percentage.
+- Use **indeterminate** (no `value`) when duration is unknown — prefer `Spinner` for short waits.
+- Always provide an `aria-label` or `aria-labelledby` so screen readers can announce what is loading.
+- Pair with a text label to show the percentage or description alongside the bar.
+- Respects `prefers-reduced-motion` — the indeterminate animation is stopped and the bar shown at full width with reduced opacity.

--- a/packages/react/src/components/RadioButton/README.md
+++ b/packages/react/src/components/RadioButton/README.md
@@ -1,0 +1,9 @@
+Single-selection radio button following the GNOME HIG and Adwaita style.
+
+### Guidelines
+- Use radio buttons when only one option in a group can be active at a time.
+- Always group with a shared `name` attribute so the browser enforces mutual exclusion and enables arrow-key navigation.
+- Always pre-select a default option — never leave all options unselected.
+- Use 2–5 options; for longer lists prefer a **Dropdown/Select**.
+- Always pair each radio with a visible `<label>`.
+- Label the group itself with a heading or `<fieldset>` + `<legend>`.

--- a/packages/react/src/components/RadioButton/RadioButton.stories.tsx
+++ b/packages/react/src/components/RadioButton/RadioButton.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Text } from '../Text';
 
 import { RadioButton } from './RadioButton';
+import readme from './README.md?raw';
 
 const meta: Meta<typeof RadioButton> = {
   title: 'Components/RadioButton',
@@ -12,17 +13,7 @@ const meta: Meta<typeof RadioButton> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Single-selection radio button following the GNOME HIG and Adwaita style.
-
-### Guidelines
-- Use radio buttons when only one option in a group can be active at a time.
-- Always group with a shared \`name\` attribute so the browser enforces mutual exclusion and enables arrow-key navigation.
-- Always pre-select a default option — never leave all options unselected.
-- Use 2–5 options; for longer lists prefer a **Dropdown/Select**.
-- Always pair each radio with a visible \`<label>\`.
-- Label the group itself with a heading or \`<fieldset>\` + \`<legend>\`.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/RadioButton/RadioButton.tsx
+++ b/packages/react/src/components/RadioButton/RadioButton.tsx
@@ -16,7 +16,7 @@ export interface RadioButtonProps extends Omit<InputHTMLAttributes<HTMLInputElem
  *
  * @see https://developer.gnome.org/hig/patterns/controls/radio-buttons.html
  */
-export function RadioButton({ className, ...props }: RadioButtonProps) {
+export const RadioButton = ({ className, ...props }: RadioButtonProps) => {
   return (
     <input
       type="radio"
@@ -24,4 +24,4 @@ export function RadioButton({ className, ...props }: RadioButtonProps) {
       {...props}
     />
   );
-}
+};

--- a/packages/react/src/components/SearchBar/README.md
+++ b/packages/react/src/components/SearchBar/README.md
@@ -1,0 +1,9 @@
+Collapsible search bar following the Adwaita `AdwSearchBar` pattern.
+
+### Guidelines
+- Toggle visibility with the `open` prop — the bar slides in/out with a CSS transition.
+- Place it directly below a `HeaderBar` (the canonical GNOME pattern).
+- Pass `onClose` to handle Escape key and any "close search" trigger in your UI.
+- Use `onClear` to reset the search query when the × button is clicked.
+- The input auto-focuses when `open` becomes `true`.
+- Optional `children` render a filter-chip row below the input.

--- a/packages/react/src/components/SearchBar/SearchBar.stories.tsx
+++ b/packages/react/src/components/SearchBar/SearchBar.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from '../Button';
 import { HeaderBar } from '../HeaderBar';
 import { Icon } from '../Icon';
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { SearchBar, type Suggestion } from './SearchBar';
 
 const meta: Meta<typeof SearchBar> = {
@@ -16,17 +16,7 @@ const meta: Meta<typeof SearchBar> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Collapsible search bar following the Adwaita \`AdwSearchBar\` pattern.
-
-### Guidelines
-- Toggle visibility with the \`open\` prop — the bar slides in/out with a CSS transition.
-- Place it directly below a \`HeaderBar\` (the canonical GNOME pattern).
-- Pass \`onClose\` to handle Escape key and any "close search" trigger in your UI.
-- Use \`onClear\` to reset the search query when the × button is clicked.
-- The input auto-focuses when \`open\` becomes \`true\`.
-- Optional \`children\` render a filter-chip row below the input.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/SearchBar/SearchBar.tsx
+++ b/packages/react/src/components/SearchBar/SearchBar.tsx
@@ -72,7 +72,7 @@ interface DropdownPos {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.SearchBar.html
  */
-export function SearchBar({
+export const SearchBar = ({
   open,
   onClose,
   onClear,
@@ -89,7 +89,7 @@ export function SearchBar({
   renderSuggestion,
   suggestionsLabel = 'Suggestions',
   ...props
-}: SearchBarProps) {
+}: SearchBarProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const listboxRef = useRef<HTMLUListElement>(null);
@@ -293,4 +293,4 @@ export function SearchBar({
       {typeof document !== 'undefined' && dropdown}
     </>
   );
-}
+};

--- a/packages/react/src/components/SegmentedBar/README.md
+++ b/packages/react/src/components/SegmentedBar/README.md
@@ -1,0 +1,16 @@
+Horizontal bar split into proportional segments, one per category.
+
+Hover any segment to highlight it and reveal a tooltip with its label and percentage.
+Values are automatically normalized if they don't sum to exactly 100.
+
+Typical use case: repository language distribution (similar to GitHub's language bar).
+
+```tsx
+<SegmentedBar
+  values={[
+    { label: "TypeScript", value: 60, color: "#3178c6" },
+    { label: "JavaScript", value: 30, color: "#f7df1e" },
+    { label: "CSS",        value: 10, color: "#563d7c" },
+  ]}
+/>
+```

--- a/packages/react/src/components/SegmentedBar/SegmentedBar.stories.tsx
+++ b/packages/react/src/components/SegmentedBar/SegmentedBar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { SegmentedBar } from './SegmentedBar';
 
 const meta: Meta<typeof SegmentedBar> = {
@@ -12,24 +12,7 @@ const meta: Meta<typeof SegmentedBar> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Horizontal bar split into proportional segments, one per category.
-
-Hover any segment to highlight it and reveal a tooltip with its label and percentage.
-Values are automatically normalized if they don't sum to exactly 100.
-
-Typical use case: repository language distribution (similar to GitHub's language bar).
-
-\`\`\`tsx
-<SegmentedBar
-  values={[
-    { label: "TypeScript", value: 60, color: "#3178c6" },
-    { label: "JavaScript", value: 30, color: "#f7df1e" },
-    { label: "CSS",        value: 10, color: "#563d7c" },
-  ]}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Separator/README.md
+++ b/packages/react/src/components/Separator/README.md
@@ -1,0 +1,7 @@
+Thin dividing line that separates groups of content.
+
+### Guidelines
+- Use to visually group related items without adding heavy structure.
+- Prefer `horizontal` (default) between stacked sections.
+- Use `vertical` inside flex rows — e.g. between toolbar actions or header bar buttons.
+- Don't overuse separators; whitespace and headings are often enough.

--- a/packages/react/src/components/Separator/Separator.stories.tsx
+++ b/packages/react/src/components/Separator/Separator.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { Separator } from './Separator';
 
 const meta: Meta<typeof Separator> = {
@@ -11,15 +11,7 @@ const meta: Meta<typeof Separator> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Thin dividing line that separates groups of content.
-
-### Guidelines
-- Use to visually group related items without adding heavy structure.
-- Prefer \`horizontal\` (default) between stacked sections.
-- Use \`vertical\` inside flex rows — e.g. between toolbar actions or header bar buttons.
-- Don't overuse separators; whitespace and headings are often enough.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Separator/Separator.tsx
+++ b/packages/react/src/components/Separator/Separator.tsx
@@ -17,7 +17,7 @@ export interface SeparatorProps extends HTMLAttributes<HTMLHRElement> {
  *
  * @see https://developer.gnome.org/hig/patterns/containers.html
  */
-export function Separator({ orientation = 'horizontal', className, ...props }: SeparatorProps) {
+export const Separator = ({ orientation = 'horizontal', className, ...props }: SeparatorProps) => {
   const classes = [
     styles.separator,
     orientation === 'vertical' ? styles.vertical : styles.horizontal,
@@ -38,4 +38,4 @@ export function Separator({ orientation = 'horizontal', className, ...props }: S
   }
 
   return <hr className={classes} {...props} />;
-}
+};

--- a/packages/react/src/components/ShortcutLabel/README.md
+++ b/packages/react/src/components/ShortcutLabel/README.md
@@ -1,0 +1,12 @@
+Read-only display of a keyboard shortcut with per-key key-cap styling.
+
+Each token in the `shortcut` string (split by `+`) is rendered as a
+separate `<kbd>` element. Modifier keys are normalised to their Unicode
+symbols by default (`Ctrl` → `⌃`, `Shift` → `⇧`, etc.).
+
+Mirrors `GtkShortcutLabel`.
+
+### Usage
+- Pass the shortcut as a `+`-separated string, e.g. `"Ctrl+S"`.
+- Set `symbols={false}` to keep raw token names instead of symbols.
+- Use as the `suffix` of an `ActionRow` in a `BoxedList`.

--- a/packages/react/src/components/ShortcutLabel/ShortcutLabel.stories.tsx
+++ b/packages/react/src/components/ShortcutLabel/ShortcutLabel.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { ActionRow } from '../ActionRow';
 import { BoxedList } from '../BoxedList';
-
+import readme from './README.md?raw';
 import { ShortcutLabel } from './ShortcutLabel';
 
 const meta: Meta<typeof ShortcutLabel> = {
@@ -12,20 +12,7 @@ const meta: Meta<typeof ShortcutLabel> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Read-only display of a keyboard shortcut with per-key key-cap styling.
-
-Each token in the \`shortcut\` string (split by \`+\`) is rendered as a
-separate \`<kbd>\` element. Modifier keys are normalised to their Unicode
-symbols by default (\`Ctrl\` → \`⌃\`, \`Shift\` → \`⇧\`, etc.).
-
-Mirrors \`GtkShortcutLabel\`.
-
-### Usage
-- Pass the shortcut as a \`+\`-separated string, e.g. \`"Ctrl+S"\`.
-- Set \`symbols={false}\` to keep raw token names instead of symbols.
-- Use as the \`suffix\` of an \`ActionRow\` in a \`BoxedList\`.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ShortcutLabel/ShortcutLabel.tsx
+++ b/packages/react/src/components/ShortcutLabel/ShortcutLabel.tsx
@@ -68,12 +68,12 @@ const SYMBOL_MAP: Record<string, string> = {
  *
  * @see https://docs.gtk.org/gtk4/class.ShortcutLabel.html
  */
-export function ShortcutLabel({
+export const ShortcutLabel = ({
   shortcut,
   symbols = true,
   className,
   ...props
-}: ShortcutLabelProps) {
+}: ShortcutLabelProps) => {
   const tokens = shortcut
     .split('+')
     .map((t) => t.trim())
@@ -96,4 +96,4 @@ export function ShortcutLabel({
       })}
     </span>
   );
-}
+};

--- a/packages/react/src/components/ShortcutsDialog/README.md
+++ b/packages/react/src/components/ShortcutsDialog/README.md
@@ -1,0 +1,7 @@
+Modal dialog listing keyboard shortcuts grouped in sections, with integrated search.
+
+Mirrors `AdwShortcutsDialog` (libadwaita 1.8 / GNOME 49) — the modern replacement for `GtkShortcutsWindow`.
+
+- Search filters across all sections in real time (by description or key name).
+- Renders into a portal; traps focus; Escape closes.
+- Pass `sections` as a plain data array — no JSX needed for the shortcut entries.

--- a/packages/react/src/components/ShortcutsDialog/ShortcutsDialog.stories.tsx
+++ b/packages/react/src/components/ShortcutsDialog/ShortcutsDialog.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { Button } from '../Button';
-
+import readme from './README.md?raw';
 import type { ShortcutsSection } from './ShortcutsDialog';
 import { ShortcutsDialog } from './ShortcutsDialog';
 
@@ -13,15 +13,7 @@ const meta: Meta<typeof ShortcutsDialog> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Modal dialog listing keyboard shortcuts grouped in sections, with integrated search.
-
-Mirrors \`AdwShortcutsDialog\` (libadwaita 1.8 / GNOME 49) — the modern replacement for \`GtkShortcutsWindow\`.
-
-- Search filters across all sections in real time (by description or key name).
-- Renders into a portal; traps focus; Escape closes.
-- Pass \`sections\` as a plain data array — no JSX needed for the shortcut entries.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ShortcutsDialog/ShortcutsDialog.tsx
+++ b/packages/react/src/components/ShortcutsDialog/ShortcutsDialog.tsx
@@ -52,12 +52,12 @@ const FOCUSABLE =
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ShortcutsDialog.html
  */
-export function ShortcutsDialog({
+export const ShortcutsDialog = ({
   open,
   onClose,
   title = 'Keyboard Shortcuts',
   sections,
-}: ShortcutsDialogProps) {
+}: ShortcutsDialogProps) => {
   const [query, setQuery] = useState('');
   const dialogRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -224,4 +224,4 @@ export function ShortcutsDialog({
   }
 
   return createPortal(node, document.body);
-}
+};

--- a/packages/react/src/components/Sidebar/README.md
+++ b/packages/react/src/components/Sidebar/README.md
@@ -1,0 +1,12 @@
+Lateral navigation panel following the Adwaita `.navigation-sidebar` pattern.
+
+Updated for **libadwaita 1.9 / GNOME 50**:
+
+- **`SidebarSection`** — groups items under a named heading with a divider between sections.
+- **`suffix`** — general trailing widget per item (button, badge, icon…); supersedes `badge`.
+- **`tooltip`** — short label shown on hover, useful for truncated or icon-only rows.
+- **`menuItems`** — per-item context menu on right-click or the `Menu` key.
+- **`searchable`** — built-in search bar with automatic item filtering.
+- **`mode`** — `"sidebar"` (default) or `"page"` (full-width boxed-list layout for narrow viewports).
+
+All previous `Sidebar` / `SidebarItem` usage is fully backward compatible.

--- a/packages/react/src/components/Sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/Sidebar/Sidebar.stories.tsx
@@ -19,7 +19,7 @@ import { Button } from '../Button';
 import { HeaderBar } from '../HeaderBar';
 import { Icon } from '../Icon';
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { Sidebar } from './Sidebar';
 import { SidebarItem } from './SidebarItem';
 import type { SidebarSectionHandle } from './SidebarSection';
@@ -33,20 +33,7 @@ const meta: Meta<typeof Sidebar> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Lateral navigation panel following the Adwaita \`.navigation-sidebar\` pattern.
-
-Updated for **libadwaita 1.9 / GNOME 50**:
-
-- **\`SidebarSection\`** — groups items under a named heading with a divider between sections.
-- **\`suffix\`** — general trailing widget per item (button, badge, icon…); supersedes \`badge\`.
-- **\`tooltip\`** — short label shown on hover, useful for truncated or icon-only rows.
-- **\`menuItems\`** — per-item context menu on right-click or the \`Menu\` key.
-- **\`searchable\`** — built-in search bar with automatic item filtering.
-- **\`mode\`** — \`"sidebar"\` (default) or \`"page"\` (full-width boxed-list layout for narrow viewports).
-
-All previous \`Sidebar\` / \`SidebarItem\` usage is fully backward compatible.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Sidebar/Sidebar.tsx
+++ b/packages/react/src/components/Sidebar/Sidebar.tsx
@@ -120,7 +120,7 @@ export interface SidebarProps extends HTMLAttributes<HTMLElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Sidebar.html
  */
-export function Sidebar({
+export const Sidebar = ({
   children,
   collapsed = false,
   searchable,
@@ -130,7 +130,7 @@ export function Sidebar({
   variant = 'classic',
   className,
   ...props
-}: SidebarProps) {
+}: SidebarProps) => {
   const [internalFilter, setInternalFilter] = useState('');
   const { isNarrow } = useBreakpoint();
 
@@ -186,4 +186,4 @@ export function Sidebar({
       </SidebarFilterContext.Provider>
     </SidebarCollapsedContext.Provider>
   );
-}
+};

--- a/packages/react/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/react/src/components/Sidebar/SidebarItem.tsx
@@ -227,7 +227,7 @@ export function SidebarItem({
       )}
 
       {menu &&
-        menuItems?.length &&
+        !!menuItems?.length &&
         typeof document !== 'undefined' &&
         createPortal(
           <div

--- a/packages/react/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/react/src/components/Sidebar/SidebarItem.tsx
@@ -76,7 +76,7 @@ export interface SidebarItemProps extends ButtonHTMLAttributes<HTMLButtonElement
  *   and the `label` does not match (case-insensitive substring).
  * - `onDrop` / `acceptTypes` — HTML5 drag-and-drop target support.
  */
-export function SidebarItem({
+export const SidebarItem = ({
   label,
   icon,
   active = false,
@@ -88,7 +88,7 @@ export function SidebarItem({
   acceptTypes,
   className,
   ...props
-}: SidebarItemProps) {
+}: SidebarItemProps) => {
   const collapsed = useSidebarCollapsed();
   const filterValue = useContext(SidebarFilterContext);
   const trailing = suffix ?? badge;
@@ -261,4 +261,4 @@ export function SidebarItem({
         )}
     </li>
   );
-}
+};

--- a/packages/react/src/components/Skeleton/README.md
+++ b/packages/react/src/components/Skeleton/README.md
@@ -1,0 +1,5 @@
+Content-shaped loading placeholder for skeleton screens.
+
+GNOME HIG recommends `Spinner` and `ProgressBar` for loading states. `Skeleton`
+is provided as a pragmatic web-style extension for dashboards and data-heavy
+views where placeholders reduce layout shift.

--- a/packages/react/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Card } from '../Card';
-
+import readme from './README.md?raw';
 import { Skeleton } from './Skeleton';
 
 const meta: Meta<typeof Skeleton> = {
@@ -11,13 +11,7 @@ const meta: Meta<typeof Skeleton> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Content-shaped loading placeholder for skeleton screens.
-
-GNOME HIG recommends \`Spinner\` and \`ProgressBar\` for loading states. \`Skeleton\`
-is provided as a pragmatic web-style extension for dashboards and data-heavy
-views where placeholders reduce layout shift.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Skeleton/Skeleton.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.tsx
@@ -32,7 +32,7 @@ function toCssSize(value: number | string) {
  * GNOME HIG recommends `Spinner` or `ProgressBar` for loading states; this is a
  * pragmatic web-style extension for layouts that benefit from placeholder shape.
  */
-export function Skeleton({
+export const Skeleton = ({
   variant = 'rect',
   width = '100%',
   height = 16,
@@ -42,7 +42,7 @@ export function Skeleton({
   className,
   style,
   ...props
-}: SkeletonProps) {
+}: SkeletonProps) => {
   const classes = [styles.skeleton, styles[variant], animated ? styles.animated : null, className]
     .filter(Boolean)
     .join(' ');
@@ -75,4 +75,4 @@ export function Skeleton({
   return (
     <div aria-hidden="true" className={classes} style={{ ...shapeStyle, ...style }} {...props} />
   );
-}
+};

--- a/packages/react/src/components/Slider/README.md
+++ b/packages/react/src/components/Slider/README.md
@@ -1,0 +1,8 @@
+Draggable range control following the Adwaita `GtkScale` pattern.
+
+### Guidelines
+- Use when the range is large or the exact value matters less than relative position (volume, zoom, brightness).
+- Prefer **SpinButton** when the user needs to enter a precise value.
+- Always set meaningful `min`, `max`, and `step`.
+- Provide an `aria-label` or associate with a visible label via `aria-labelledby`.
+- Keyboard: ← / → move by one step; Page Up/Down by 10 steps; Home/End jump to bounds.

--- a/packages/react/src/components/Slider/Slider.stories.tsx
+++ b/packages/react/src/components/Slider/Slider.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 import { SpinButton } from '../SpinButton';
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { Slider } from './Slider';
 
 const meta: Meta<typeof Slider> = {
@@ -13,16 +13,7 @@ const meta: Meta<typeof Slider> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Draggable range control following the Adwaita \`GtkScale\` pattern.
-
-### Guidelines
-- Use when the range is large or the exact value matters less than relative position (volume, zoom, brightness).
-- Prefer **SpinButton** when the user needs to enter a precise value.
-- Always set meaningful \`min\`, \`max\`, and \`step\`.
-- Provide an \`aria-label\` or associate with a visible label via \`aria-labelledby\`.
-- Keyboard: ← / → move by one step; Page Up/Down by 10 steps; Home/End jump to bounds.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -64,7 +64,7 @@ function countDecimals(n: number) {
  *
  * @see https://developer.gnome.org/hig/patterns/controls/sliders.html
  */
-export function Slider({
+export const Slider = ({
   value,
   onChange,
   min = 0,
@@ -77,7 +77,7 @@ export function Slider({
   'aria-labelledby': ariaLabelledBy,
   'aria-describedby': ariaDescribedBy,
   ...props
-}: SliderProps) {
+}: SliderProps) => {
   const trackRef = useRef<HTMLDivElement>(null);
   const dp = countDecimals(step);
 
@@ -220,4 +220,4 @@ export function Slider({
       )}
     </div>
   );
-}
+};

--- a/packages/react/src/components/SpinButton/README.md
+++ b/packages/react/src/components/SpinButton/README.md
@@ -1,0 +1,8 @@
+Numeric input with − and + buttons following the Adwaita `GtkSpinButton` style.
+
+### Guidelines
+- Use for small bounded integer or decimal values (font size, quantity, opacity…).
+- Always set meaningful `min`, `max`, and `step`.
+- Prefer a **Slider** when the range is large or the exact value matters less than relative position.
+- Keyboard: ↑/↓ step once, Page Up/Down step ×10, Home/End jump to min/max.
+- The `−` button disables automatically at `min`; `+` at `max`.

--- a/packages/react/src/components/SpinButton/SpinButton.stories.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { SpinButton } from './SpinButton';
 
 const meta: Meta<typeof SpinButton> = {
@@ -12,16 +12,7 @@ const meta: Meta<typeof SpinButton> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Numeric input with − and + buttons following the Adwaita \`GtkSpinButton\` style.
-
-### Guidelines
-- Use for small bounded integer or decimal values (font size, quantity, opacity…).
-- Always set meaningful \`min\`, \`max\`, and \`step\`.
-- Prefer a **Slider** when the range is large or the exact value matters less than relative position.
-- Keyboard: ↑/↓ step once, Page Up/Down step ×10, Home/End jump to min/max.
-- The \`−\` button disables automatically at \`min\`; \`+\` at \`max\`.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.tsx
@@ -42,7 +42,7 @@ function clamp(value: number, min: number, max: number): number {
  *
  * @see https://developer.gnome.org/hig/patterns/controls/spin-buttons.html
  */
-export function SpinButton({
+export const SpinButton = ({
   value,
   onChange,
   min = 0,
@@ -54,7 +54,7 @@ export function SpinButton({
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
   ...props
-}: SpinButtonProps) {
+}: SpinButtonProps) => {
   const dp = decimals ?? countDecimals(step);
 
   const set = useCallback(
@@ -137,4 +137,4 @@ export function SpinButton({
       </button>
     </div>
   );
-}
+};

--- a/packages/react/src/components/SpinRow/README.md
+++ b/packages/react/src/components/SpinRow/README.md
@@ -1,0 +1,11 @@
+Settings row with an integrated spin button for numeric values.
+
+Mirrors `AdwSpinRow` — a standard row layout with − and + buttons at the trailing
+edge. Use inside a `BoxedList` for settings with numeric ranges such as volume,
+timeout durations, item counts, or font sizes.
+
+### Guidelines
+- Set `min`, `max`, and `step` to constrain the allowed range.
+- Use `subtitle` to clarify the unit (e.g. "seconds", "pixels").
+- Supports controlled (`value`) and uncontrolled (`defaultValue`) modes.
+- Keyboard: ↑/↓ step by one, Page Up/Down step by 10×, Home/End jump to min/max.

--- a/packages/react/src/components/SpinRow/SpinRow.stories.tsx
+++ b/packages/react/src/components/SpinRow/SpinRow.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { BoxedList } from '../BoxedList';
-
+import readme from './README.md?raw';
 import { SpinRow } from './SpinRow';
 
 const meta: Meta<typeof SpinRow> = {
@@ -12,19 +12,7 @@ const meta: Meta<typeof SpinRow> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Settings row with an integrated spin button for numeric values.
-
-Mirrors \`AdwSpinRow\` — a standard row layout with − and + buttons at the trailing
-edge. Use inside a \`BoxedList\` for settings with numeric ranges such as volume,
-timeout durations, item counts, or font sizes.
-
-### Guidelines
-- Set \`min\`, \`max\`, and \`step\` to constrain the allowed range.
-- Use \`subtitle\` to clarify the unit (e.g. "seconds", "pixels").
-- Supports controlled (\`value\`) and uncontrolled (\`defaultValue\`) modes.
-- Keyboard: ↑/↓ step by one, Page Up/Down step by 10×, Home/End jump to min/max.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/SpinRow/SpinRow.tsx
+++ b/packages/react/src/components/SpinRow/SpinRow.tsx
@@ -56,7 +56,7 @@ function clamp(v: number, min: number, max: number): number {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.SpinRow.html
  */
-export function SpinRow({
+export const SpinRow = ({
   title,
   subtitle,
   leading,
@@ -70,7 +70,7 @@ export function SpinRow({
   disabled = false,
   className,
   ...props
-}: SpinRowProps) {
+}: SpinRowProps) => {
   const isControlled = controlledValue !== undefined;
   const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
   const value = isControlled ? controlledValue : uncontrolledValue;
@@ -183,4 +183,4 @@ export function SpinRow({
       </div>
     </div>
   );
-}
+};

--- a/packages/react/src/components/Spinner/README.md
+++ b/packages/react/src/components/Spinner/README.md
@@ -1,0 +1,8 @@
+Indeterminate loading indicator following the Adwaita spinner style.
+
+### Guidelines
+- Use to communicate that something is loading with an unknown duration.
+- For a known duration, prefer the **Progress Bar** component instead.
+- Keep spinners small and close to the content they represent.
+- Always provide an accessible `label` (default: `"Loading…"`). Set `label=""` only when a visible sibling label describes the action.
+- Respects `prefers-reduced-motion` — slows the animation instead of stopping it.

--- a/packages/react/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/react/src/components/Spinner/Spinner.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { Spinner } from './Spinner';
 
 const meta: Meta<typeof Spinner> = {
@@ -11,16 +11,7 @@ const meta: Meta<typeof Spinner> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Indeterminate loading indicator following the Adwaita spinner style.
-
-### Guidelines
-- Use to communicate that something is loading with an unknown duration.
-- For a known duration, prefer the **Progress Bar** component instead.
-- Keep spinners small and close to the content they represent.
-- Always provide an accessible \`label\` (default: \`"Loading…"\`). Set \`label=""\` only when a visible sibling label describes the action.
-- Respects \`prefers-reduced-motion\` — slows the animation instead of stopping it.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Spinner/Spinner.tsx
+++ b/packages/react/src/components/Spinner/Spinner.tsx
@@ -22,12 +22,12 @@ export interface SpinnerProps extends HTMLAttributes<HTMLSpanElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/style-classes.html
  */
-export function Spinner({
+export const Spinner = ({
   size = 'md',
   label = 'Loading\u2026',
   className,
   ...props
-}: SpinnerProps) {
+}: SpinnerProps) => {
   const classes = [styles.spinner, styles[size], className].filter(Boolean).join(' ');
 
   return (
@@ -39,4 +39,4 @@ export function Spinner({
       {...props}
     />
   );
-}
+};

--- a/packages/react/src/components/SplitButton/README.md
+++ b/packages/react/src/components/SplitButton/README.md
@@ -1,0 +1,12 @@
+Primary action button with an attached dropdown arrow.
+
+Clicking the **label** half fires `onClick`. Clicking the **arrow** half opens a floating panel
+with `dropdownContent` (menus, options, etc.).
+
+Mirrors `AdwSplitButton` — supports `default`, `suggested`, and `destructive` variants.
+
+### Guidelines
+- Put the most common action in the primary half with a clear imperative label.
+- Use `dropdownContent` for secondary variants of the same action (e.g. "Save as Template").
+- Prefer `suggested` when this is the primary CTA in a dialog or toolbar.
+- Never use `destructive` unless the primary action is irreversible.

--- a/packages/react/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/react/src/components/SplitButton/SplitButton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { SplitButton } from './SplitButton';
 
 /** Simple menu item helper for story dropdown content. */
-function MenuItem({ label, onClick }: { label: string; onClick?: () => void }) {
+const MenuItem = ({ label, onClick }: { label: string; onClick?: () => void }) => {
   return (
     <button
       onClick={onClick}
@@ -32,7 +32,7 @@ function MenuItem({ label, onClick }: { label: string; onClick?: () => void }) {
       {label}
     </button>
   );
-}
+};
 
 const sampleMenu = (
   <div>

--- a/packages/react/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/react/src/components/SplitButton/SplitButton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import { SplitButton } from './SplitButton';
 
 /** Simple menu item helper for story dropdown content. */
@@ -49,20 +49,7 @@ const meta: Meta<typeof SplitButton> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Primary action button with an attached dropdown arrow.
-
-Clicking the **label** half fires \`onClick\`. Clicking the **arrow** half opens a floating panel
-with \`dropdownContent\` (menus, options, etc.).
-
-Mirrors \`AdwSplitButton\` — supports \`default\`, \`suggested\`, and \`destructive\` variants.
-
-### Guidelines
-- Put the most common action in the primary half with a clear imperative label.
-- Use \`dropdownContent\` for secondary variants of the same action (e.g. "Save as Template").
-- Prefer \`suggested\` when this is the primary CTA in a dialog or toolbar.
-- Never use \`destructive\` unless the primary action is irreversible.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/SplitButton/SplitButton.tsx
+++ b/packages/react/src/components/SplitButton/SplitButton.tsx
@@ -39,7 +39,7 @@ export interface SplitButtonProps
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.SplitButton.html
  */
-export function SplitButton({
+export const SplitButton = ({
   label,
   variant = 'default',
   dropdownContent,
@@ -48,7 +48,7 @@ export function SplitButton({
   onClick,
   className,
   ...props
-}: SplitButtonProps) {
+}: SplitButtonProps) => {
   const [open, setOpen] = useState(false);
   const [dropdownStyle, setDropdownStyle] = useState<CSSProperties>({});
 
@@ -196,4 +196,4 @@ export function SplitButton({
       {open && (typeof document !== 'undefined' ? createPortal(panel, document.body) : panel)}
     </>
   );
-}
+};

--- a/packages/react/src/components/StatusBadge/README.md
+++ b/packages/react/src/components/StatusBadge/README.md
@@ -1,0 +1,10 @@
+Pill-shaped text label for entity status. Use for human-readable state labels
+like `published`, `beta`, or `new` — not for numeric counts (use `Badge` for those).
+
+```tsx
+import { StatusBadge } from "@gnome-ui/react";
+
+<StatusBadge variant="success">published</StatusBadge>
+<StatusBadge variant="warning">beta</StatusBadge>
+<StatusBadge variant="new">new</StatusBadge>
+```

--- a/packages/react/src/components/StatusBadge/StatusBadge.stories.tsx
+++ b/packages/react/src/components/StatusBadge/StatusBadge.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import type { StatusBadgeVariant } from './StatusBadge';
 import { StatusBadge } from './StatusBadge';
 
@@ -11,18 +11,7 @@ const meta: Meta<typeof StatusBadge> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Pill-shaped text label for entity status. Use for human-readable state labels
-like \`published\`, \`beta\`, or \`new\` — not for numeric counts (use \`Badge\` for those).
-
-\`\`\`tsx
-import { StatusBadge } from "@gnome-ui/react";
-
-<StatusBadge variant="success">published</StatusBadge>
-<StatusBadge variant="warning">beta</StatusBadge>
-<StatusBadge variant="new">new</StatusBadge>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/StatusBadge/StatusBadge.tsx
+++ b/packages/react/src/components/StatusBadge/StatusBadge.tsx
@@ -30,12 +30,12 @@ export interface StatusBadgeProps extends HTMLAttributes<HTMLSpanElement> {
  * <StatusBadge variant="new">new</StatusBadge>
  * ```
  */
-export function StatusBadge({
+export const StatusBadge = ({
   variant = 'neutral',
   className,
   children,
   ...props
-}: StatusBadgeProps) {
+}: StatusBadgeProps) => {
   return (
     <span
       className={[styles.badge, styles[variant], className].filter(Boolean).join(' ')}
@@ -44,4 +44,4 @@ export function StatusBadge({
       {children}
     </span>
   );
-}
+};

--- a/packages/react/src/components/StatusPage/README.md
+++ b/packages/react/src/components/StatusPage/README.md
@@ -1,0 +1,11 @@
+Empty-state and status page following the Adwaita `AdwStatusPage` pattern.
+
+Use to fill an empty view with context and a path forward.
+
+### Guidelines
+- Always explain **why** the view is empty and **what the user can do** about it.
+- Keep the title to one short noun phrase — "No Results", "All Done", "Connection Lost".
+- The description should be one or two sentences at most.
+- Provide one primary action when there is a clear next step.
+- Choose an icon that reinforces the message — do not use generic placeholders.
+- Do not use for loading states — use `Spinner` or `ProgressBar` instead.

--- a/packages/react/src/components/StatusPage/StatusPage.stories.tsx
+++ b/packages/react/src/components/StatusPage/StatusPage.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '../Button';
 import { Popover } from '../Popover';
-
+import readme from './README.md?raw';
 import { StatusPage } from './StatusPage';
 
 const meta: Meta<typeof StatusPage> = {
@@ -13,19 +13,7 @@ const meta: Meta<typeof StatusPage> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Empty-state and status page following the Adwaita \`AdwStatusPage\` pattern.
-
-Use to fill an empty view with context and a path forward.
-
-### Guidelines
-- Always explain **why** the view is empty and **what the user can do** about it.
-- Keep the title to one short noun phrase — "No Results", "All Done", "Connection Lost".
-- The description should be one or two sentences at most.
-- Provide one primary action when there is a clear next step.
-- Choose an icon that reinforces the message — do not use generic placeholders.
-- Do not use for loading states — use \`Spinner\` or \`ProgressBar\` instead.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/StatusPage/StatusPage.tsx
+++ b/packages/react/src/components/StatusPage/StatusPage.tsx
@@ -43,7 +43,7 @@ export interface StatusPageProps extends HTMLAttributes<HTMLDivElement> {
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.StatusPage.html
  * @see https://developer.gnome.org/hig/patterns/feedback/empty-states.html
  */
-export function StatusPage({
+export const StatusPage = ({
   icon,
   iconNode,
   title,
@@ -52,7 +52,7 @@ export function StatusPage({
   compact = false,
   className,
   ...props
-}: StatusPageProps) {
+}: StatusPageProps) => {
   const iconSize = compact ? 64 : 128;
   const iconContent = icon ? (
     <Icon icon={icon} width={iconSize} height={iconSize} aria-hidden />
@@ -80,4 +80,4 @@ export function StatusPage({
       {children && <div className={styles.actions}>{children}</div>}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Switch/README.md
+++ b/packages/react/src/components/Switch/README.md
@@ -1,0 +1,7 @@
+On/off toggle following the Adwaita switch style.
+
+### Guidelines
+- Use switches for settings that take effect immediately — no Save button needed.
+- Prefer switches over checkboxes in settings UIs (GNOME HIG preference).
+- Always pair with a visible label (via `<label>`) or supply `aria-label`.
+- Place the switch at the trailing end of the row, aligned to the right.

--- a/packages/react/src/components/Switch/Switch.stories.tsx
+++ b/packages/react/src/components/Switch/Switch.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { Switch } from './Switch';
 
 const meta: Meta<typeof Switch> = {
@@ -11,15 +11,7 @@ const meta: Meta<typeof Switch> = {
   parameters: {
     docs: {
       description: {
-        component: `
-On/off toggle following the Adwaita switch style.
-
-### Guidelines
-- Use switches for settings that take effect immediately — no Save button needed.
-- Prefer switches over checkboxes in settings UIs (GNOME HIG preference).
-- Always pair with a visible label (via \`<label>\`) or supply \`aria-label\`.
-- Place the switch at the trailing end of the row, aligned to the right.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -15,7 +15,7 @@ export interface SwitchProps extends Omit<InputHTMLAttributes<HTMLInputElement>,
  *
  * @see https://developer.gnome.org/hig/patterns/controls/switches.html
  */
-export function Switch({ className, ...props }: SwitchProps) {
+export const Switch = ({ className, ...props }: SwitchProps) => {
   return (
     <input
       type="checkbox"
@@ -24,4 +24,4 @@ export function Switch({ className, ...props }: SwitchProps) {
       {...props}
     />
   );
-}
+};

--- a/packages/react/src/components/SwitchRow/README.md
+++ b/packages/react/src/components/SwitchRow/README.md
@@ -1,0 +1,11 @@
+Activatable row with an integrated switch.
+
+Mirrors `AdwSwitchRow` — the entire row is a button that toggles the switch when clicked.
+This differs from `ActionRow` with a `trailing` switch: here the row itself carries the
+`role="switch"` and clicking anywhere (title, subtitle, or the visual switch) toggles state.
+
+### Guidelines
+- Use when a single boolean setting should occupy a full list row.
+- Prefer `SwitchRow` over `ActionRow + Switch trailing` when there is no other trailing widget needed.
+- Supports controlled (`checked`) and uncontrolled (`defaultChecked`) modes.
+- Wrap in `BoxedList` for the canonical GNOME settings appearance.

--- a/packages/react/src/components/SwitchRow/SwitchRow.stories.tsx
+++ b/packages/react/src/components/SwitchRow/SwitchRow.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { BoxedList } from '../BoxedList';
-
+import readme from './README.md?raw';
 import { SwitchRow } from './SwitchRow';
 
 const meta: Meta<typeof SwitchRow> = {
@@ -12,19 +12,7 @@ const meta: Meta<typeof SwitchRow> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Activatable row with an integrated switch.
-
-Mirrors \`AdwSwitchRow\` — the entire row is a button that toggles the switch when clicked.
-This differs from \`ActionRow\` with a \`trailing\` switch: here the row itself carries the
-\`role="switch"\` and clicking anywhere (title, subtitle, or the visual switch) toggles state.
-
-### Guidelines
-- Use when a single boolean setting should occupy a full list row.
-- Prefer \`SwitchRow\` over \`ActionRow + Switch trailing\` when there is no other trailing widget needed.
-- Supports controlled (\`checked\`) and uncontrolled (\`defaultChecked\`) modes.
-- Wrap in \`BoxedList\` for the canonical GNOME settings appearance.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/SwitchRow/SwitchRow.tsx
+++ b/packages/react/src/components/SwitchRow/SwitchRow.tsx
@@ -30,7 +30,7 @@ export interface SwitchRowProps extends Omit<HTMLAttributes<HTMLButtonElement>, 
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.SwitchRow.html
  */
-export function SwitchRow({
+export const SwitchRow = ({
   title,
   subtitle,
   leading,
@@ -41,7 +41,7 @@ export function SwitchRow({
   className,
   onClick,
   ...props
-}: SwitchRowProps) {
+}: SwitchRowProps) => {
   const isControlled = controlledChecked !== undefined;
   const [uncontrolledChecked, setUncontrolledChecked] = useState(defaultChecked);
   const checked = isControlled ? controlledChecked : uncontrolledChecked;
@@ -88,4 +88,4 @@ export function SwitchRow({
       </span>
     </button>
   );
-}
+};

--- a/packages/react/src/components/Tabs/README.md
+++ b/packages/react/src/components/Tabs/README.md
@@ -1,0 +1,13 @@
+Tab-based navigation following the Adwaita `AdwTabBar` pattern.
+
+Three components work together:
+- **`TabBar`** — the horizontal bar that holds `TabItem` elements; manages roving-tabindex keyboard navigation.
+- **`TabItem`** — individual tab button with optional icon, close button, and ARIA wiring.
+- **`TabPanel`** — content panel linked to its tab via `id` / `panelId`.
+
+### Guidelines
+- Use tabs for parallel views of the same data, not sequential steps (use a wizard for those).
+- Keep labels short — one or two words.
+- The active tab has an accent underline and higher contrast.
+- Keyboard: ← / → cycle through tabs, Home / End jump to first / last.
+- When tabs are closeable, always keep at least one tab open.

--- a/packages/react/src/components/Tabs/TabBar.tsx
+++ b/packages/react/src/components/Tabs/TabBar.tsx
@@ -21,13 +21,13 @@ export interface TabBarProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://developer.gnome.org/hig/patterns/nav/tabs.html
  */
-export function TabBar({
+export const TabBar = ({
   children,
   className,
   inline = false,
   'aria-label': ariaLabel = 'Tabs',
   ...props
-}: TabBarProps) {
+}: TabBarProps) => {
   const listRef = useRef<HTMLDivElement>(null);
 
   function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
@@ -74,4 +74,4 @@ export function TabBar({
       </div>
     </div>
   );
-}
+};

--- a/packages/react/src/components/Tabs/TabPanel.tsx
+++ b/packages/react/src/components/Tabs/TabPanel.tsx
@@ -14,7 +14,7 @@ export interface TabPanelProps extends HTMLAttributes<HTMLDivElement> {
  * Content panel associated with a `TabItem`.
  * Hidden panels are kept in the DOM but visually hidden.
  */
-export function TabPanel({ id, active = false, className, children, ...props }: TabPanelProps) {
+export const TabPanel = ({ id, active = false, className, children, ...props }: TabPanelProps) => {
   return (
     <div
       id={id}
@@ -26,4 +26,4 @@ export function TabPanel({ id, active = false, className, children, ...props }: 
       {children}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/Tabs/Tabs.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { TabBar } from './TabBar';
 import { TabItem } from './TabItem';
 import { TabPanel } from './TabPanel';
@@ -16,21 +16,7 @@ const meta: Meta<typeof TabBar> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Tab-based navigation following the Adwaita \`AdwTabBar\` pattern.
-
-Three components work together:
-- **\`TabBar\`** — the horizontal bar that holds \`TabItem\` elements; manages roving-tabindex keyboard navigation.
-- **\`TabItem\`** — individual tab button with optional icon, close button, and ARIA wiring.
-- **\`TabPanel\`** — content panel linked to its tab via \`id\` / \`panelId\`.
-
-### Guidelines
-- Use tabs for parallel views of the same data, not sequential steps (use a wizard for those).
-- Keep labels short — one or two words.
-- The active tab has an accent underline and higher contrast.
-- Keyboard: ← / → cycle through tabs, Home / End jump to first / last.
-- When tabs are closeable, always keep at least one tab open.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/TerminalView/README.md
+++ b/packages/react/src/components/TerminalView/README.md
@@ -1,0 +1,8 @@
+Scrollable terminal-style output area styled after GNOME Terminal.
+Intended for displaying logs, command output, or read-only text content.
+
+```tsx
+import { TerminalView } from "@gnome-ui/react";
+
+<TerminalView lines={["$ npm install", "added 42 packages"]} />
+```

--- a/packages/react/src/components/TerminalView/TerminalView.stories.tsx
+++ b/packages/react/src/components/TerminalView/TerminalView.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useEffect, useRef, useState } from 'react';
-
+import readme from './README.md?raw';
 import { TerminalView } from './TerminalView';
 
 const meta: Meta<typeof TerminalView> = {
@@ -11,16 +11,7 @@ const meta: Meta<typeof TerminalView> = {
     layout: 'padded',
     docs: {
       description: {
-        component: `
-Scrollable terminal-style output area styled after GNOME Terminal.
-Intended for displaying logs, command output, or read-only text content.
-
-\`\`\`tsx
-import { TerminalView } from "@gnome-ui/react";
-
-<TerminalView lines={["$ npm install", "added 42 packages"]} />
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/TerminalView/TerminalView.tsx
+++ b/packages/react/src/components/TerminalView/TerminalView.tsx
@@ -15,14 +15,14 @@ export interface TerminalViewProps extends HTMLAttributes<HTMLDivElement> {
   autoScroll?: boolean;
 }
 
-export function TerminalView({
+export const TerminalView = ({
   lines,
   variant = 'default',
   maxLines = 500,
   autoScroll = true,
   className,
   ...props
-}: TerminalViewProps) {
+}: TerminalViewProps) => {
   const bottomRef = useRef<HTMLDivElement>(null);
   const visibleLines = lines.slice(-maxLines);
 
@@ -47,4 +47,4 @@ export function TerminalView({
       </pre>
     </div>
   );
-}
+};

--- a/packages/react/src/components/Text/README.md
+++ b/packages/react/src/components/Text/README.md
@@ -1,0 +1,20 @@
+Typography component mirroring all [Adwaita text style classes](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/style-classes.html).
+
+### Variants
+
+| Variant | Element | Use case |
+|---------|---------|----------|
+| `large-title` | `h1` | Display heading with lots of whitespace |
+| `title-1` | `h1` | Primary page/view title |
+| `title-2` | `h2` | Section title |
+| `title-3` | `h3` | Sub-section title |
+| `title-4` | `h4` | Minor heading |
+| `heading` | `h3` | UI labels, boxed list headers |
+| `body` | `p` | Default UI text, descriptions |
+| `document` | `p` | Reading content (chat, articles) |
+| `caption` | `span` | Sub-text, metadata |
+| `caption-heading` | `span` | Small group labels (uppercase) |
+| `monospace` | `code` | Code, logs, shell commands |
+| `numeric` | `span` | Aligned numbers, counters |
+
+Use the `as` prop to override the rendered HTML element without changing the visual style.

--- a/packages/react/src/components/Text/Text.stories.tsx
+++ b/packages/react/src/components/Text/Text.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import { Text } from './Text';
 
 const meta: Meta<typeof Text> = {
@@ -9,28 +9,7 @@ const meta: Meta<typeof Text> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Typography component mirroring all [Adwaita text style classes](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/style-classes.html).
-
-### Variants
-
-| Variant | Element | Use case |
-|---------|---------|----------|
-| \`large-title\` | \`h1\` | Display heading with lots of whitespace |
-| \`title-1\` | \`h1\` | Primary page/view title |
-| \`title-2\` | \`h2\` | Section title |
-| \`title-3\` | \`h3\` | Sub-section title |
-| \`title-4\` | \`h4\` | Minor heading |
-| \`heading\` | \`h3\` | UI labels, boxed list headers |
-| \`body\` | \`p\` | Default UI text, descriptions |
-| \`document\` | \`p\` | Reading content (chat, articles) |
-| \`caption\` | \`span\` | Sub-text, metadata |
-| \`caption-heading\` | \`span\` | Small group labels (uppercase) |
-| \`monospace\` | \`code\` | Code, logs, shell commands |
-| \`numeric\` | \`span\` | Aligned numbers, counters |
-
-Use the \`as\` prop to override the rendered HTML element without changing the visual style.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Text/Text.tsx
+++ b/packages/react/src/components/Text/Text.tsx
@@ -61,14 +61,14 @@ export interface TextProps extends HTMLAttributes<HTMLElement> {
  * @see https://developer.gnome.org/hig/guidelines/typography.html
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/style-classes.html
  */
-export function Text({
+export const Text = ({
   variant = 'body',
   color = 'default',
   as,
   className,
   children,
   ...props
-}: TextProps) {
+}: TextProps) => {
   const Tag = as ?? defaultElement[variant];
 
   const classes = [styles.text, styles[variant], styles[`color-${color}`], className]
@@ -80,4 +80,4 @@ export function Text({
       {children}
     </Tag>
   );
-}
+};

--- a/packages/react/src/components/TextField/README.md
+++ b/packages/react/src/components/TextField/README.md
@@ -1,0 +1,10 @@
+Single-line text input with label, helper text, and error state.
+
+Follows the Adwaita `GtkEntry` / `.entry` style class.
+
+### Guidelines
+- Always provide a `label` — it is the primary accessible name for the input.
+- Use `helperText` for formatting hints or constraints (e.g. "Must be at least 8 characters").
+- Replace `helperText` with `error` to communicate validation failure — never show both.
+- Show errors only after the user has interacted (on blur or on submit), not while typing.
+- Keep labels short and in sentence case ("Full name", not "Full Name").

--- a/packages/react/src/components/TextField/TextField.stories.tsx
+++ b/packages/react/src/components/TextField/TextField.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-
+import readme from './README.md?raw';
 import { TextField } from './TextField';
 
 const meta: Meta<typeof TextField> = {
@@ -9,18 +9,7 @@ const meta: Meta<typeof TextField> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Single-line text input with label, helper text, and error state.
-
-Follows the Adwaita \`GtkEntry\` / \`.entry\` style class.
-
-### Guidelines
-- Always provide a \`label\` — it is the primary accessible name for the input.
-- Use \`helperText\` for formatting hints or constraints (e.g. "Must be at least 8 characters").
-- Replace \`helperText\` with \`error\` to communicate validation failure — never show both.
-- Show errors only after the user has interacted (on blur or on submit), not while typing.
-- Keep labels short and in sentence case ("Full name", not "Full Name").
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -23,7 +23,7 @@ export interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElemen
  *
  * @see https://developer.gnome.org/hig/patterns/controls/text-fields.html
  */
-export function TextField({
+export const TextField = ({
   label,
   helperText,
   error,
@@ -31,7 +31,7 @@ export function TextField({
   className,
   disabled,
   ...props
-}: TextFieldProps) {
+}: TextFieldProps) => {
   const autoId = useId();
   const id = idProp ?? autoId;
   const helpId = `${id}-help`;
@@ -65,4 +65,4 @@ export function TextField({
       )}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Timeline/README.md
+++ b/packages/react/src/components/Timeline/README.md
@@ -1,0 +1,18 @@
+Ordered sequence of events connected by a visual timeline.
+
+Supports two orientations — **vertical** (activity feed, history log) and
+**horizontal** (stepper, progress indicator) — and three connector styles.
+
+```tsx
+import { Timeline } from "@gnome-ui/react";
+
+<Timeline
+  items={[
+    {
+      leading: <Text variant="caption" color="dim">10:32</Text>,
+      icon: <Icon icon={Check} />,
+      content: <Text variant="body">Document approved</Text>,
+    },
+  ]}
+/>
+```

--- a/packages/react/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react/src/components/Timeline/Timeline.stories.tsx
@@ -14,7 +14,7 @@ import { Badge } from '../Badge';
 import { Card } from '../Card';
 import { Icon } from '../Icon';
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import type { TimelineItem } from './Timeline';
 import { Timeline } from './Timeline';
 
@@ -26,26 +26,7 @@ const meta: Meta<typeof Timeline> = {
     layout: 'centered',
     docs: {
       description: {
-        component: `
-Ordered sequence of events connected by a visual timeline.
-
-Supports two orientations — **vertical** (activity feed, history log) and
-**horizontal** (stepper, progress indicator) — and three connector styles.
-
-\`\`\`tsx
-import { Timeline } from "@gnome-ui/react";
-
-<Timeline
-  items={[
-    {
-      leading: <Text variant="caption" color="dim">10:32</Text>,
-      icon: <Icon icon={Check} />,
-      content: <Text variant="body">Document approved</Text>,
-    },
-  ]}
-/>
-\`\`\`
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Timeline/Timeline.tsx
+++ b/packages/react/src/components/Timeline/Timeline.tsx
@@ -62,13 +62,13 @@ export interface TimelineProps extends HTMLAttributes<HTMLDivElement> {
  * <Timeline orientation="horizontal" variant="dotted" items={steps} />
  * ```
  */
-export function Timeline({
+export const Timeline = ({
   items,
   orientation = 'vertical',
   variant = 'default',
   className,
   ...props
-}: TimelineProps) {
+}: TimelineProps) => {
   const horizontal = orientation === 'horizontal';
   const showLine = variant !== 'none';
 
@@ -154,4 +154,4 @@ export function Timeline({
       })}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Toast/README.md
+++ b/packages/react/src/components/Toast/README.md
@@ -1,0 +1,12 @@
+Non-blocking temporary notification following the Adwaita `AdwToast` pattern.
+
+Two components:
+- **`Toast`** — the notification card. Manages its own auto-dismiss timer.
+- **`Toaster`** — fixed-position portal container at bottom (or top) center that stacks toasts.
+
+### Guidelines
+- Keep messages short — one sentence.
+- Use an action button for the single most relevant response (e.g. "Undo").
+- Auto-dismiss after 3 s by default; set `duration={0}` for persistent toasts.
+- The timer pauses while the user hovers or focuses the toast.
+- Do not use for errors that require user action — use **Dialog** or **Banner** instead.

--- a/packages/react/src/components/Toast/Toast.stories.tsx
+++ b/packages/react/src/components/Toast/Toast.stories.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 
 import { Button } from '../Button';
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { Toast } from './Toast';
 import { Toaster } from './Toaster';
 
@@ -14,20 +14,7 @@ const meta: Meta<typeof Toast> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Non-blocking temporary notification following the Adwaita \`AdwToast\` pattern.
-
-Two components:
-- **\`Toast\`** — the notification card. Manages its own auto-dismiss timer.
-- **\`Toaster\`** — fixed-position portal container at bottom (or top) center that stacks toasts.
-
-### Guidelines
-- Keep messages short — one sentence.
-- Use an action button for the single most relevant response (e.g. "Undo").
-- Auto-dismiss after 3 s by default; set \`duration={0}\` for persistent toasts.
-- The timer pauses while the user hovers or focuses the toast.
-- Do not use for errors that require user action — use **Dialog** or **Banner** instead.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Toast/Toast.tsx
+++ b/packages/react/src/components/Toast/Toast.tsx
@@ -33,7 +33,7 @@ export interface ToastProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Toast.html
  */
-export function Toast({
+export const Toast = ({
   title,
   duration = 3000,
   onDismiss,
@@ -42,7 +42,7 @@ export function Toast({
   dismissible = false,
   className,
   ...props
-}: ToastProps) {
+}: ToastProps) => {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const remainingRef = useRef(duration);
   const startedAtRef = useRef<number>(0);
@@ -135,4 +135,4 @@ export function Toast({
       )}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Toast/Toaster.tsx
+++ b/packages/react/src/components/Toast/Toaster.tsx
@@ -33,13 +33,13 @@ export interface ToasterProps extends HTMLAttributes<HTMLDivElement> {
  *   ))}
  * </Toaster>
  */
-export function Toaster({
+export const Toaster = ({
   position = 'bottom',
   children,
   container,
   className,
   ...props
-}: ToasterProps) {
+}: ToasterProps) => {
   const node = (
     <div
       aria-label="Notifications"
@@ -62,4 +62,4 @@ export function Toaster({
   }
 
   return createPortal(node, container ?? document.body);
-}
+};

--- a/packages/react/src/components/ToggleGroup/README.md
+++ b/packages/react/src/components/ToggleGroup/README.md
@@ -1,0 +1,10 @@
+Mutually-exclusive group of toggle buttons for in-place option selection.
+
+Mirrors `AdwToggleGroup` (libadwaita 1.7 / GNOME 48).
+
+Use for formatting controls, alignment selectors, and toolbar view modes —
+wherever a `ViewSwitcher` would be too heavy or doesn't belong in a HeaderBar.
+
+- Items can be **icon-only**, **label-only**, or **icon + label**.
+- For icon-only items, always provide an `aria-label` for screen readers.
+- Keyboard: ← / → cycle through items, Home / End jump to first / last.

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { ToggleGroup } from './ToggleGroup';
 import { ToggleGroupItem } from './ToggleGroupItem';
 
@@ -14,18 +14,7 @@ const meta: Meta<typeof ToggleGroup> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Mutually-exclusive group of toggle buttons for in-place option selection.
-
-Mirrors \`AdwToggleGroup\` (libadwaita 1.7 / GNOME 48).
-
-Use for formatting controls, alignment selectors, and toolbar view modes —
-wherever a \`ViewSwitcher\` would be too heavy or doesn't belong in a HeaderBar.
-
-- Items can be **icon-only**, **label-only**, or **icon + label**.
-- For icon-only items, always provide an \`aria-label\` for screen readers.
-- Keyboard: ← / → cycle through items, Home / End jump to first / last.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.test.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.test.tsx
@@ -5,13 +5,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { ToggleGroup } from './ToggleGroup';
 import { ToggleGroupItem } from './ToggleGroupItem';
 
-function Fixture({
+const Fixture = ({
   initial = 'list',
   onChange,
 }: {
   initial?: string;
   onChange?: (v: string) => void;
-}) {
+}) => {
   const [value, setValue] = useState(initial);
 
   return (
@@ -28,7 +28,7 @@ function Fixture({
       <ToggleGroupItem name="cards" label="Cards" />
     </ToggleGroup>
   );
-}
+};
 
 describe('ToggleGroup', () => {
   describe('rendering', () => {

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
@@ -53,14 +53,14 @@ export interface ToggleGroupProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ToggleGroup.html
  */
-export function ToggleGroup({
+export const ToggleGroup = ({
   value,
   onValueChange,
   'aria-label': ariaLabel = 'Options',
   children,
   className,
   ...props
-}: ToggleGroupProps) {
+}: ToggleGroupProps) => {
   const groupRef = useRef<HTMLDivElement>(null);
 
   function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
@@ -106,4 +106,4 @@ export function ToggleGroup({
       </div>
     </ToggleGroupContext.Provider>
   );
-}
+};

--- a/packages/react/src/components/ToggleGroup/ToggleGroupItem.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroupItem.tsx
@@ -21,14 +21,14 @@ export interface ToggleGroupItemProps extends ButtonHTMLAttributes<HTMLButtonEle
  * Can be icon-only, label-only, or icon + label. For icon-only items always
  * provide an `aria-label` so screen readers can identify the option.
  */
-export function ToggleGroupItem({
+export const ToggleGroupItem = ({
   name,
   label,
   icon,
   disabled,
   className,
   ...props
-}: ToggleGroupItemProps) {
+}: ToggleGroupItemProps) => {
   const { value, onValueChange } = useToggleGroup();
   const active = value === name;
   const iconOnly = icon && !label;
@@ -59,4 +59,4 @@ export function ToggleGroupItem({
       {label && <span className={styles.itemLabel}>{label}</span>}
     </button>
   );
-}
+};

--- a/packages/react/src/components/Toolbar/README.md
+++ b/packages/react/src/components/Toolbar/README.md
@@ -1,0 +1,10 @@
+Horizontal action bar following the libadwaita `.toolbar` pattern.
+
+Provides **6 px padding and gap** — the standard spacing for rows of flat buttons in
+header bars, action bars, and tool rows. Use `<Spacer />` to push trailing items to the end.
+
+### Guidelines
+- Use `<Button variant="flat">` for buttons that blend into the bar background.
+- Use `<Button variant="raised">` inside a Toolbar when a button needs explicit elevation.
+- Place `<Spacer />` between leading and trailing button groups.
+- Nest inside a surface (card, header bar, bottom bar) — Toolbar itself has no background.

--- a/packages/react/src/components/Toolbar/Spacer.stories.tsx
+++ b/packages/react/src/components/Toolbar/Spacer.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '../Button';
-
+import readme from './README.md?raw';
 import { Spacer } from './Spacer';
 import { Toolbar } from './Toolbar';
 
@@ -12,20 +12,7 @@ const meta: Meta<typeof Spacer> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Invisible \`flex: 1\` filler for \`Toolbar\` and \`HeaderBar\`.
-
-Place between leading and trailing button groups to push trailing items to the
-far end of the row. Multiple \`Spacer\` elements within the same flex container
-share the available space equally, which can be used to center a middle group.
-
-Mirrors \`GtkSeparator\` with the \`.spacer\` style class.
-
-### Guidelines
-- Has no visual appearance — it is purely a layout primitive.
-- Use inside any \`display: flex\` row container (\`Toolbar\`, \`HeaderBar\` slots, custom bars).
-- Avoid using outside a flex context; it has no effect.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Toolbar/Spacer.tsx
+++ b/packages/react/src/components/Toolbar/Spacer.tsx
@@ -19,7 +19,7 @@ export type SpacerProps = HTMLAttributes<HTMLDivElement>;
  *   <Button variant="flat">Done</Button>
  * </Toolbar>
  */
-export function Spacer({ className, ...props }: SpacerProps) {
+export const Spacer = ({ className, ...props }: SpacerProps) => {
   return (
     <div
       aria-hidden="true"
@@ -27,4 +27,4 @@ export function Spacer({ className, ...props }: SpacerProps) {
       {...props}
     />
   );
-}
+};

--- a/packages/react/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '../Button';
-
+import readme from './README.md?raw';
 import { Spacer } from './Spacer';
 import { Toolbar } from './Toolbar';
 
@@ -12,18 +12,7 @@ const meta: Meta<typeof Toolbar> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Horizontal action bar following the libadwaita \`.toolbar\` pattern.
-
-Provides **6 px padding and gap** — the standard spacing for rows of flat buttons in
-header bars, action bars, and tool rows. Use \`<Spacer />\` to push trailing items to the end.
-
-### Guidelines
-- Use \`<Button variant="flat">\` for buttons that blend into the bar background.
-- Use \`<Button variant="raised">\` inside a Toolbar when a button needs explicit elevation.
-- Place \`<Spacer />\` between leading and trailing button groups.
-- Nest inside a surface (card, header bar, bottom bar) — Toolbar itself has no background.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -19,10 +19,10 @@ export interface ToolbarProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1-latest/style-classes.html#toolbar-style-class
  */
-export function Toolbar({ children, className, ...props }: ToolbarProps) {
+export const Toolbar = ({ children, className, ...props }: ToolbarProps) => {
   return (
     <div className={[styles.toolbar, className].filter(Boolean).join(' ')} {...props}>
       {children}
     </div>
   );
-}
+};

--- a/packages/react/src/components/ToolbarView/README.md
+++ b/packages/react/src/components/ToolbarView/README.md
@@ -1,0 +1,12 @@
+Layout container that attaches bars at the top and/or bottom while
+scrolling only the middle content.
+
+The top/bottom bars remain fixed; the inner content area gets
+`overflow-y: auto` so it scrolls independently.
+
+Mirrors `AdwToolbarView`.
+
+### Usage
+- Pass a `HeaderBar` or `Toolbar` to `topBar`.
+- Pass a `Toolbar` or `ViewSwitcherBar` to `bottomBar`.
+- Put scrollable page content in `children`.

--- a/packages/react/src/components/ToolbarView/ToolbarView.stories.tsx
+++ b/packages/react/src/components/ToolbarView/ToolbarView.stories.tsx
@@ -7,7 +7,7 @@ import { HeaderBar } from '../HeaderBar';
 import { Text } from '../Text';
 import { Toolbar } from '../Toolbar';
 import { WindowTitle } from '../WindowTitle';
-
+import readme from './README.md?raw';
 import { ToolbarView } from './ToolbarView';
 
 const meta: Meta<typeof ToolbarView> = {
@@ -18,20 +18,7 @@ const meta: Meta<typeof ToolbarView> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Layout container that attaches bars at the top and/or bottom while
-scrolling only the middle content.
-
-The top/bottom bars remain fixed; the inner content area gets
-\`overflow-y: auto\` so it scrolls independently.
-
-Mirrors \`AdwToolbarView\`.
-
-### Usage
-- Pass a \`HeaderBar\` or \`Toolbar\` to \`topBar\`.
-- Pass a \`Toolbar\` or \`ViewSwitcherBar\` to \`bottomBar\`.
-- Put scrollable page content in \`children\`.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ToolbarView/ToolbarView.tsx
+++ b/packages/react/src/components/ToolbarView/ToolbarView.tsx
@@ -28,13 +28,13 @@ export interface ToolbarViewProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ToolbarView.html
  */
-export function ToolbarView({
+export const ToolbarView = ({
   topBar,
   bottomBar,
   children,
   className,
   ...props
-}: ToolbarViewProps) {
+}: ToolbarViewProps) => {
   return (
     <div className={[styles.toolbarView, className].filter(Boolean).join(' ')} {...props}>
       {topBar && <div className={styles.top}>{topBar}</div>}
@@ -42,4 +42,4 @@ export function ToolbarView({
       {bottomBar && <div className={styles.bottom}>{bottomBar}</div>}
     </div>
   );
-}
+};

--- a/packages/react/src/components/Tooltip/README.md
+++ b/packages/react/src/components/Tooltip/README.md
@@ -1,0 +1,11 @@
+Informational floating label following the GNOME HIG tooltip pattern.
+
+Wraps a single trigger element and shows a label on hover or keyboard focus.
+
+### Guidelines
+- Use to clarify icon-only controls that have no visible label.
+- Keep the text short — a noun phrase or brief description (< 10 words).
+- Do not repeat information already visible on screen.
+- Never put interactive content (links, buttons) inside a tooltip.
+- Tooltips are not shown on touch — do not rely on them for critical information.
+- The default delay is 500 ms to avoid flickering during normal mouse movement.

--- a/packages/react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { Tooltip } from './Tooltip';
 
 const meta: Meta<typeof Tooltip> = {
@@ -14,19 +14,7 @@ const meta: Meta<typeof Tooltip> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Informational floating label following the GNOME HIG tooltip pattern.
-
-Wraps a single trigger element and shows a label on hover or keyboard focus.
-
-### Guidelines
-- Use to clarify icon-only controls that have no visible label.
-- Keep the text short — a noun phrase or brief description (< 10 words).
-- Do not repeat information already visible on screen.
-- Never put interactive content (links, buttons) inside a tooltip.
-- Tooltips are not shown on touch — do not rely on them for critical information.
-- The default delay is 500 ms to avoid flickering during normal mouse movement.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -169,12 +169,12 @@ function computePosition(
  *
  * @see https://developer.gnome.org/hig/patterns/feedback/tooltips.html
  */
-export function Tooltip({
+export const Tooltip = ({
   label,
   placement: preferredPlacement = 'top',
   delay = 500,
   children,
-}: TooltipProps) {
+}: TooltipProps) => {
   const id = useId();
   const [visible, setVisible] = useState(false);
   const [pos, setPos] = useState<Position | null>(null);
@@ -309,4 +309,4 @@ export function Tooltip({
       {typeof document !== 'undefined' ? createPortal(tooltip, document.body) : tooltip}
     </>
   );
-}
+};

--- a/packages/react/src/components/ViewSwitcher/README.md
+++ b/packages/react/src/components/ViewSwitcher/README.md
@@ -1,0 +1,12 @@
+Segmented control for switching between major views, mirroring the Adwaita `AdwViewSwitcher`.
+
+Two components:
+- **`ViewSwitcher`** — the pill-shaped container with `role="radiogroup"` and roving-tabindex keyboard navigation.
+- **`ViewSwitcherItem`** — individual option with `role="radio"` and optional icon.
+
+### Guidelines
+- Use for 2–4 top-level views that are parallel (not sequential).
+- Prefer placing it as the `title` of a `HeaderBar` — the canonical GNOME pattern.
+- For more than 4 options, use **Tabs** or a **Sidebar** instead.
+- Do not use for settings that have side-effects; use **Switch** for that.
+- Keyboard: ← / → (or ↑ / ↓) cycle through items and activate them immediately.

--- a/packages/react/src/components/ViewSwitcher/ViewSwitcher.stories.tsx
+++ b/packages/react/src/components/ViewSwitcher/ViewSwitcher.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { Button } from '../Button';
 import { HeaderBar } from '../HeaderBar';
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { ViewSwitcher } from './ViewSwitcher';
 import { ViewSwitcherItem } from './ViewSwitcherItem';
 
@@ -16,20 +16,7 @@ const meta: Meta<typeof ViewSwitcher> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Segmented control for switching between major views, mirroring the Adwaita \`AdwViewSwitcher\`.
-
-Two components:
-- **\`ViewSwitcher\`** — the pill-shaped container with \`role="radiogroup"\` and roving-tabindex keyboard navigation.
-- **\`ViewSwitcherItem\`** — individual option with \`role="radio"\` and optional icon.
-
-### Guidelines
-- Use for 2–4 top-level views that are parallel (not sequential).
-- Prefer placing it as the \`title\` of a \`HeaderBar\` — the canonical GNOME pattern.
-- For more than 4 options, use **Tabs** or a **Sidebar** instead.
-- Do not use for settings that have side-effects; use **Switch** for that.
-- Keyboard: ← / → (or ↑ / ↓) cycle through items and activate them immediately.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ViewSwitcher/ViewSwitcher.tsx
+++ b/packages/react/src/components/ViewSwitcher/ViewSwitcher.tsx
@@ -20,12 +20,12 @@ export interface ViewSwitcherProps extends HTMLAttributes<HTMLDivElement> {
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ViewSwitcher.html
  * @see https://developer.gnome.org/hig/patterns/nav/view-switchers.html
  */
-export function ViewSwitcher({
+export const ViewSwitcher = ({
   children,
   className,
   'aria-label': ariaLabel = 'View switcher',
   ...props
-}: ViewSwitcherProps) {
+}: ViewSwitcherProps) => {
   const groupRef = useRef<HTMLDivElement>(null);
 
   function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
@@ -69,4 +69,4 @@ export function ViewSwitcher({
       {children}
     </div>
   );
-}
+};

--- a/packages/react/src/components/ViewSwitcher/ViewSwitcherItem.tsx
+++ b/packages/react/src/components/ViewSwitcher/ViewSwitcherItem.tsx
@@ -19,14 +19,14 @@ export interface ViewSwitcherItemProps extends ButtonHTMLAttributes<HTMLButtonEl
  *
  * Renders as `role="radio"` so the group has proper radiogroup semantics.
  */
-export function ViewSwitcherItem({
+export const ViewSwitcherItem = ({
   label,
   icon,
   active = false,
   className,
   disabled,
   ...props
-}: ViewSwitcherItemProps) {
+}: ViewSwitcherItemProps) => {
   return (
     <button
       type="button"
@@ -45,4 +45,4 @@ export function ViewSwitcherItem({
       <span className={styles.itemLabel}>{label}</span>
     </button>
   );
-}
+};

--- a/packages/react/src/components/ViewSwitcherBar/README.md
+++ b/packages/react/src/components/ViewSwitcherBar/README.md
@@ -1,0 +1,7 @@
+Bottom navigation bar for `ViewSwitcher` items on narrow screens (≤ 550 px), mirroring `AdwViewSwitcherBar`.
+
+Use in tandem with a header-bar `ViewSwitcher`:
+- **Wide (> 550 px):** show `ViewSwitcher` in the `HeaderBar`, hide the bar (`reveal={false}`).
+- **Narrow (≤ 550 px):** hide the header switcher, set `reveal={true}`.
+
+Pair with `useBreakpoint().isMedium` to automate the switch.

--- a/packages/react/src/components/ViewSwitcherBar/ViewSwitcherBar.stories.tsx
+++ b/packages/react/src/components/ViewSwitcherBar/ViewSwitcherBar.stories.tsx
@@ -7,7 +7,7 @@ import { HeaderBar } from '../HeaderBar';
 import { Text } from '../Text';
 import { ViewSwitcher } from '../ViewSwitcher';
 import { ViewSwitcherItem } from '../ViewSwitcher/ViewSwitcherItem';
-
+import readme from './README.md?raw';
 import { ViewSwitcherBar } from './ViewSwitcherBar';
 
 const meta: Meta<typeof ViewSwitcherBar> = {
@@ -18,15 +18,7 @@ const meta: Meta<typeof ViewSwitcherBar> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Bottom navigation bar for \`ViewSwitcher\` items on narrow screens (≤ 550 px), mirroring \`AdwViewSwitcherBar\`.
-
-Use in tandem with a header-bar \`ViewSwitcher\`:
-- **Wide (> 550 px):** show \`ViewSwitcher\` in the \`HeaderBar\`, hide the bar (\`reveal={false}\`).
-- **Narrow (≤ 550 px):** hide the header switcher, set \`reveal={true}\`.
-
-Pair with \`useBreakpoint().isMedium\` to automate the switch.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ViewSwitcherBar/ViewSwitcherBar.tsx
+++ b/packages/react/src/components/ViewSwitcherBar/ViewSwitcherBar.tsx
@@ -39,12 +39,12 @@ export interface ViewSwitcherBarProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ViewSwitcherBar.html
  */
-export function ViewSwitcherBar({
+export const ViewSwitcherBar = ({
   children,
   reveal = true,
   className,
   ...props
-}: ViewSwitcherBarProps) {
+}: ViewSwitcherBarProps) => {
   if (!reveal) {
     return null;
   }
@@ -59,4 +59,4 @@ export function ViewSwitcherBar({
       {children}
     </div>
   );
-}
+};

--- a/packages/react/src/components/ViewSwitcherSidebar/README.md
+++ b/packages/react/src/components/ViewSwitcherSidebar/README.md
@@ -1,0 +1,17 @@
+Sidebar-style view switcher for apps with many top-level views or when the
+sidebar layout fits better than a header-bar `ViewSwitcher`.
+
+Mirrors `AdwViewSwitcherSidebar` (libadwaita 1.9 / GNOME 50) — the modern
+replacement for `GtkStackSidebar`.
+
+### When to use
+- More than 4 top-level views (where `ViewSwitcher` in a HeaderBar becomes cramped).
+- Apps whose primary navigation is already sidebar-shaped (mail, files, contacts).
+- When views need additional metadata like unread counts (`count`) or custom widgets (`suffix`).
+
+### vs `Sidebar`
+| | `Sidebar` | `ViewSwitcherSidebar` |
+|---|---|---|
+| Semantics | `nav` + `aria-current` | `radiogroup` + `aria-checked` |
+| Keyboard | Tab between items | ↑ / ↓ within group |
+| Use for | App-level navigation | Switching between views/pages |

--- a/packages/react/src/components/ViewSwitcherSidebar/ViewSwitcherSidebar.stories.tsx
+++ b/packages/react/src/components/ViewSwitcherSidebar/ViewSwitcherSidebar.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { Badge } from '../Badge';
 import { HeaderBar } from '../HeaderBar';
 import { Text } from '../Text';
-
+import readme from './README.md?raw';
 import { ViewSwitcherSidebar } from './ViewSwitcherSidebar';
 import { ViewSwitcherSidebarItem } from './ViewSwitcherSidebarItem';
 
@@ -17,25 +17,7 @@ const meta: Meta<typeof ViewSwitcherSidebar> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Sidebar-style view switcher for apps with many top-level views or when the
-sidebar layout fits better than a header-bar \`ViewSwitcher\`.
-
-Mirrors \`AdwViewSwitcherSidebar\` (libadwaita 1.9 / GNOME 50) — the modern
-replacement for \`GtkStackSidebar\`.
-
-### When to use
-- More than 4 top-level views (where \`ViewSwitcher\` in a HeaderBar becomes cramped).
-- Apps whose primary navigation is already sidebar-shaped (mail, files, contacts).
-- When views need additional metadata like unread counts (\`count\`) or custom widgets (\`suffix\`).
-
-### vs \`Sidebar\`
-| | \`Sidebar\` | \`ViewSwitcherSidebar\` |
-|---|---|---|
-| Semantics | \`nav\` + \`aria-current\` | \`radiogroup\` + \`aria-checked\` |
-| Keyboard | Tab between items | ↑ / ↓ within group |
-| Use for | App-level navigation | Switching between views/pages |
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/ViewSwitcherSidebar/ViewSwitcherSidebar.tsx
+++ b/packages/react/src/components/ViewSwitcherSidebar/ViewSwitcherSidebar.tsx
@@ -75,7 +75,7 @@ export interface ViewSwitcherSidebarProps extends HTMLAttributes<HTMLElement> {
  * </ViewSwitcherSidebar>
  * ```
  */
-export function ViewSwitcherSidebar({
+export const ViewSwitcherSidebar = ({
   value,
   onValueChange,
   'aria-label': ariaLabel = 'Views',
@@ -87,7 +87,7 @@ export function ViewSwitcherSidebar({
   children,
   className,
   ...props
-}: ViewSwitcherSidebarProps) {
+}: ViewSwitcherSidebarProps) => {
   const groupRef = useRef<HTMLUListElement>(null);
 
   function handleKeyDown(e: KeyboardEvent<HTMLElement>) {
@@ -142,4 +142,4 @@ export function ViewSwitcherSidebar({
       </nav>
     </ViewSwitcherSidebarContext.Provider>
   );
-}
+};

--- a/packages/react/src/components/ViewSwitcherSidebar/ViewSwitcherSidebarItem.tsx
+++ b/packages/react/src/components/ViewSwitcherSidebar/ViewSwitcherSidebarItem.tsx
@@ -31,7 +31,7 @@ export interface ViewSwitcherSidebarItemProps extends ButtonHTMLAttributes<HTMLB
  * Renders as `role="radio"`. Only the active item is in the natural Tab order;
  * all others use `tabIndex={-1}` and are reached via arrow-key navigation.
  */
-export function ViewSwitcherSidebarItem({
+export const ViewSwitcherSidebarItem = ({
   name,
   label,
   icon,
@@ -40,7 +40,7 @@ export function ViewSwitcherSidebarItem({
   disabled,
   className,
   ...props
-}: ViewSwitcherSidebarItemProps) {
+}: ViewSwitcherSidebarItemProps) => {
   const { value, onValueChange, collapsed } = useViewSwitcherSidebar();
   const active = value === name;
   const trailing = suffix ?? (count !== null && count !== undefined ? count : null);
@@ -77,4 +77,4 @@ export function ViewSwitcherSidebarItem({
       </button>
     </li>
   );
-}
+};

--- a/packages/react/src/components/WindowTitle/README.md
+++ b/packages/react/src/components/WindowTitle/README.md
@@ -1,0 +1,11 @@
+Two-line title + subtitle widget for use inside a `HeaderBar`.
+
+Pass as the `title` prop of `HeaderBar` to display a centred two-line header
+with an app name and current document/view name.
+
+Mirrors `AdwWindowTitle`.
+
+### Usage
+- `title` is the primary bold line (e.g. app name or current view).
+- `subtitle` is the secondary dimmed line below (e.g. file path or context).
+- Omit `subtitle` for a single-line header.

--- a/packages/react/src/components/WindowTitle/WindowTitle.stories.tsx
+++ b/packages/react/src/components/WindowTitle/WindowTitle.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Button } from '../Button';
 import { HeaderBar } from '../HeaderBar';
 import { Icon } from '../Icon';
-
+import readme from './README.md?raw';
 import { WindowTitle } from './WindowTitle';
 
 const meta: Meta<typeof WindowTitle> = {
@@ -14,19 +14,7 @@ const meta: Meta<typeof WindowTitle> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Two-line title + subtitle widget for use inside a \`HeaderBar\`.
-
-Pass as the \`title\` prop of \`HeaderBar\` to display a centred two-line header
-with an app name and current document/view name.
-
-Mirrors \`AdwWindowTitle\`.
-
-### Usage
-- \`title\` is the primary bold line (e.g. app name or current view).
-- \`subtitle\` is the secondary dimmed line below (e.g. file path or context).
-- Omit \`subtitle\` for a single-line header.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/WindowTitle/WindowTitle.tsx
+++ b/packages/react/src/components/WindowTitle/WindowTitle.tsx
@@ -24,11 +24,11 @@ export interface WindowTitleProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.WindowTitle.html
  */
-export function WindowTitle({ title, subtitle, className, ...props }: WindowTitleProps) {
+export const WindowTitle = ({ title, subtitle, className, ...props }: WindowTitleProps) => {
   return (
     <div className={[styles.windowTitle, className].filter(Boolean).join(' ')} {...props}>
       <span className={styles.title}>{title}</span>
       {subtitle && <span className={styles.subtitle}>{subtitle}</span>}
     </div>
   );
-}
+};

--- a/packages/react/src/components/WrapBox/README.md
+++ b/packages/react/src/components/WrapBox/README.md
@@ -1,0 +1,9 @@
+Flexible wrapping layout container.
+
+Children flow horizontally and wrap to new lines when they don't fit,
+like words in a paragraph — without locking them into a grid.
+
+Mirrors `AdwWrapBox` (libadwaita 1.7 / GNOME 48).
+
+Pair with `Chip` for tag lists and filter rows, or use standalone for
+any collection of variable-width items.

--- a/packages/react/src/components/WrapBox/WrapBox.stories.tsx
+++ b/packages/react/src/components/WrapBox/WrapBox.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { Chip } from '../Chip';
-
+import readme from './README.md?raw';
 import { WrapBox } from './WrapBox';
 
 const meta: Meta<typeof WrapBox> = {
@@ -13,17 +13,7 @@ const meta: Meta<typeof WrapBox> = {
   parameters: {
     docs: {
       description: {
-        component: `
-Flexible wrapping layout container.
-
-Children flow horizontally and wrap to new lines when they don't fit,
-like words in a paragraph — without locking them into a grid.
-
-Mirrors \`AdwWrapBox\` (libadwaita 1.7 / GNOME 48).
-
-Pair with \`Chip\` for tag lists and filter rows, or use standalone for
-any collection of variable-width items.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/components/WrapBox/WrapBox.tsx
+++ b/packages/react/src/components/WrapBox/WrapBox.tsx
@@ -37,7 +37,7 @@ export interface WrapBoxProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.WrapBox.html
  */
-export function WrapBox({
+export const WrapBox = ({
   childSpacing = 6,
   lineSpacing,
   justify = 'start',
@@ -47,7 +47,7 @@ export function WrapBox({
   className,
   style,
   ...props
-}: WrapBoxProps) {
+}: WrapBoxProps) => {
   const gap = typeof childSpacing === 'number' ? `${childSpacing}px` : childSpacing;
   const rowGap =
     lineSpacing !== null && lineSpacing !== undefined
@@ -75,4 +75,4 @@ export function WrapBox({
       {children}
     </div>
   );
-}
+};

--- a/packages/react/src/stories/layout/Dashboard.stories.tsx
+++ b/packages/react/src/stories/layout/Dashboard.stories.tsx
@@ -27,7 +27,7 @@ import {
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
 /** Menu item inside the avatar popover dropdown. */
-function AvatarMenuItem({
+const AvatarMenuItem = ({
   label,
   destructive = false,
   onClick,
@@ -35,7 +35,7 @@ function AvatarMenuItem({
   label: string;
   destructive?: boolean;
   onClick?: () => void;
-}) {
+}) => {
   return (
     <button
       type="button"
@@ -67,11 +67,11 @@ function AvatarMenuItem({
       {label}
     </button>
   );
-}
+};
 
 // ─── Dashboard component ───────────────────────────────────────────────────────
 
-function Dashboard() {
+const Dashboard = () => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeNav, setActiveNav] = useState('home');
   const [searchQuery, setSearchQuery] = useState('');
@@ -449,7 +449,7 @@ function Dashboard() {
       </footer>
     </div>
   );
-}
+};
 
 // ─── Meta ──────────────────────────────────────────────────────────────────────
 

--- a/packages/react/src/stories/layout/Dashboard.stories.tsx
+++ b/packages/react/src/stories/layout/Dashboard.stories.tsx
@@ -1,7 +1,6 @@
 import { GoHome, Settings, Share, Star } from '@gnome-ui/icons';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-
 import {
   ActionRow,
   Avatar,
@@ -23,6 +22,7 @@ import {
   Text,
   Toolbar,
 } from '../../index';
+import readme from './README.md?raw';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -459,19 +459,7 @@ const meta: Meta = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: `
-Full-page dashboard layout demonstrating the composition of components following
-the GNOME Human Interface Guidelines.
-
-**Includes:**
-- \`Toolbar\` with logo, inline \`SearchBar\`, action buttons, and avatar \`Popover\`
-- Collapsible \`Sidebar\` with \`SidebarItem\`, \`Badge\`, and auto-tooltip on collapse
-- Content area with \`Card\`, \`BoxedList\`, \`ActionRow\`, \`ExpanderRow\`, \`InlineViewSwitcher\`, and \`StatusPage\`
-- Footer \`Toolbar\` with status text
-
-**Toggle the sidebar** with the hamburger button at the top-left.
-**Switch navigation sections** with the sidebar items.
-        `,
+        component: readme,
       },
     },
   },

--- a/packages/react/src/stories/layout/README.md
+++ b/packages/react/src/stories/layout/README.md
@@ -1,0 +1,11 @@
+Full-page dashboard layout demonstrating the composition of components following
+the GNOME Human Interface Guidelines.
+
+**Includes:**
+- `Toolbar` with logo, inline `SearchBar`, action buttons, and avatar `Popover`
+- Collapsible `Sidebar` with `SidebarItem`, `Badge`, and auto-tooltip on collapse
+- Content area with `Card`, `BoxedList`, `ActionRow`, `ExpanderRow`, `InlineViewSwitcher`, and `StatusPage`
+- Footer `Toolbar` with status text
+
+**Toggle the sidebar** with the hamburger button at the top-left.
+**Switch navigation sections** with the sidebar items.


### PR DESCRIPTION
## What

Docs to README.md — extracted docs.description.component template literals from all *.stories.tsx files into sibling README.md files per component, loaded via Vite's native ?raw import. Docs render identically in Storybook; markdown content is now editable without touching TypeScript (~103 components across @gnome-ui/react and @gnome-ui/layout).
Arrow function components — converted all function component declarations to arrow function syntax across react, layout, charts, and icons packages to satisfy the react/function-component-definition ESLint rule.
Hooks barrel exports — replaced export * wildcard re-exports in @gnome-ui/hooks with explicit named exports for better static analysis.
Security fixes — upgraded vite from 8.0.3 → 8.0.16 (path traversal, server.fs.deny bypass, arbitrary file read via WebSocket) and lodash to 4.18.1 (code injection, prototype pollution). Added overrides entry to resolve the @joshwooding/vite-plugin-react-docgen-typescript peer dep conflict.
Bug fix — SidebarItem.tsx: menuItems?.length && createPortal(...) rendered 0 on empty array; fixed with !!menuItems?.length.

## Changes

- [ ] New component
- [ ] Bug fix
- [ ] Enhancement
- [x] Docs
- [x] Chore (deps, config, CI)

## Checklist

- [ ] Follows [GNOME HIG](https://developer.gnome.org/hig/) guidelines
- [ ] All styles use CSS custom properties from `@gnome-ui/core`
- [ ] Dark mode works via `@media (prefers-color-scheme: dark)`
- [ ] Keyboard accessible
- [ ] Storybook story added or updated
- [ ] TypeScript types exported
- [ ] `ROADMAP.md` updated if applicable
